### PR TITLE
Fixes for GH 29, 30, 31, 32

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -955,7 +955,7 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> DataFrame: ...
     def join(
         self,
-        other: Union[DataFrame, Series, List[DataFrame]],
+        other: Union[DataFrame, Series, List[Union[DataFrame, Series]]],
         on: Optional[Union[_str, List[_str]]] = ...,
         how: Union[_str, Literal["left", "right", "outer", "inner"]] = ...,
         lsuffix: _str = ...,

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -124,7 +124,7 @@ class _LocIndexerFrame(_LocIndexer):
     @overload
     def __getitem__(
         self,
-        idx: Tuple[Union[StrLike, Tuple[StrLike, ...]], StrLike],
+        idx: Tuple[Union[Union[int, StrLike], Tuple[StrLike, ...]], StrLike],
     ) -> Scalar: ...
     @overload
     def __getitem__(
@@ -1104,7 +1104,7 @@ class DataFrame(NDFrame, OpsMixin):
         level: Level = ...,
         fill_value: Union[None, float] = ...,
     ) -> DataFrame: ...
-    def __iter__(self) -> Iterator: ...
+    def __iter__(self) -> Iterator[Hashable]: ...
     # properties
     @property
     def at(self): ...  # Not sure what to do with this yet; look at source

--- a/pandas-stubs/core/indexes/datetimes.pyi
+++ b/pandas-stubs/core/indexes/datetimes.pyi
@@ -1,12 +1,20 @@
 import numpy as np
 from datetime import tzinfo as tzinfo
+from pandas.core.indexes.api import (
+    PeriodIndex as PeriodIndex,
+    Float64Index as Float64Index,
+)
 from pandas.core.indexes.datetimelike import (
     DatetimeTimedeltaMixin as DatetimeTimedeltaMixin,
     DatetimelikeDelegateMixin as DatetimelikeDelegateMixin,
 )
 from pandas.core.indexes.timedeltas import TimedeltaIndex as TimedeltaIndex
 from pandas.core.series import Series as Series, TimedeltaSeries, TimestampSeries
-from pandas._typing import Timestamp as Timestamp, Timedelta as Timedelta
+from pandas._typing import (
+    Timestamp as Timestamp,
+    Timedelta as Timedelta,
+    DataFrame as DataFrame,
+)
 from typing import Optional, Union, overload
 
 class DatetimeDelegateMixin(DatetimelikeDelegateMixin): ...
@@ -50,6 +58,12 @@ class DatetimeIndex(DatetimeTimedeltaMixin, DatetimeDelegateMixin):
         self, start_time, end_time, include_start: bool = ..., include_end: bool = ...
     ): ...
     def strftime(self, date_format: str = ...) -> np.ndarray: ...
+    def tz_convert(self, tz) -> DatetimeIndex: ...
+    def tz_localize(self, tz, ambiguous=..., nonexistent=...) -> DatetimeIndex: ...
+    def to_period(self, freq) -> PeriodIndex: ...
+    def to_perioddelta(self, freq) -> TimedeltaIndex: ...
+    def to_julian_date(self) -> Float64Index: ...
+    def isocalendar(self) -> DataFrame: ...
 
 def date_range(
     start=...,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandas-stubs"
-version = "1.4.2.220608"
+version = "1.4.2.220622"
 description = "Type annotations for pandas"
 authors = ["The Pandas Development Team <pandas-dev@python.org>"]
 license = "BSD-3-Clause"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -134,6 +134,7 @@ def test_types_loc_at() -> None:
     df = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
     df.loc[[0], "col1"]
     df.at[0, "col1"]
+    df.loc[0, "col1"]
 
 
 def test_types_boolean_indexing() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3,10 +3,11 @@ from datetime import date, datetime
 import io
 import tempfile
 from pathlib import Path
-from typing import List, Tuple, Iterable, Any, Dict, Hashable
+from typing import List, Tuple, Iterable, Any, Union
 from typing_extensions import assert_type
 
 import pandas as pd
+from pandas._testing import getSeriesData
 from pandas.io.parsers import TextFileReader
 import numpy as np
 
@@ -997,3 +998,13 @@ def test_getmultiindex_columns() -> None:
 def test_frame_getitem_isin() -> None:
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5]}, index=[1, 2, 3, 4, 5])
     assert_type(df[df.index.isin([1, 3, 5])], "pd.DataFrame")
+
+
+def test_join() -> None:
+    float_frame = pd.DataFrame(getSeriesData())
+    # GH 29
+    left = float_frame["A"].to_frame()
+    seriesB = float_frame["B"]
+    frameCD = float_frame[["C", "D"]]
+    right: List[Union[pd.Series, pd.DataFrame]] = [seriesB, frameCD]
+    result = left.join(right)

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -148,3 +148,9 @@ def test_timedelta_series_sum() -> None:
 
     sf = pd.Series([1.0, 2.2, 3.3])
     sfsum: float = sf.sum()
+
+
+def test_iso_calendar() -> None:
+    # GH 31
+    dates = pd.date_range(start="2012-01-01", end="2019-12-31", freq="W-MON")
+    dates.isocalendar()


### PR DESCRIPTION
- For `DataFrame.__iter__()` return `Iterable[Hashable]` #30 
- For `DataFrame.loc[1, "abc"]`, allow `int` as first argument #32 
- For `DatetimeIndex`, add methods such as `isocalendar()` #31 
- For `DataFrame.join()` allow a mix of `Series` and `DataFrame` as `other` argument #29 

Bump version to 1.4.2.220622
