### PR TITLE
Use Sequence instead of List for drop

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -398,15 +398,15 @@ class DataFrame(NDFrame, OpsMixin):
         fill_axis: AxisType = ...,
         broadcast_axis: Optional[AxisType] = ...,
     ) -> DataFrame: ...
-    def reindex(**kwargs) -> DataFrame: ...
+    def reindex(self, **kwargs) -> DataFrame: ...
     @overload
     def drop(
         self,
-        labels: Hashable | list[Hashable] = ...,
+        labels: Hashable | Sequence[Hashable] = ...,
         *,
         axis: Axis = ...,
-        index: Hashable | list[Hashable] = ...,
-        columns: Hashable | list[Hashable] = ...,
+        index: Hashable | Sequence[Hashable] = ...,
+        columns: Hashable | Sequence[Hashable] = ...,
         level: Optional[Level] = ...,
         inplace: Literal[True],
         errors: IgnoreRaise = ...,
@@ -414,11 +414,11 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def drop(
         self,
-        labels: Hashable | list[Hashable] = ...,
+        labels: Hashable | Sequence[Hashable] = ...,
         *,
         axis: Axis = ...,
-        index: Hashable | list[Hashable] = ...,
-        columns: Hashable | list[Hashable] = ...,
+        index: Hashable | Sequence[Hashable] = ...,
+        columns: Hashable | Sequence[Hashable] = ...,
         level: Optional[Level] = ...,
         inplace: Literal[False] = ...,
         errors: IgnoreRaise = ...,
@@ -426,11 +426,11 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def drop(
         self,
-        labels: Hashable | list[Hashable] = ...,
+        labels: Hashable | Sequence[Hashable] = ...,
         *,
         axis: Axis = ...,
-        index: Hashable | list[Hashable] = ...,
-        columns: Hashable | list[Hashable] = ...,
+        index: Hashable | Sequence[Hashable] = ...,
+        columns: Hashable | Sequence[Hashable] = ...,
         level: Optional[Level] = ...,
         inplace: bool = ...,
         errors: IgnoreRaise = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -200,6 +200,8 @@ def test_types_drop() -> None:
     res6: pd.DataFrame = df.drop(index=1)
     res7: pd.DataFrame = df.drop(labels=0)
     res8: None = df.drop([0, 0], inplace=True)
+    to_drop: List[str] = ["col1"]
+    res9: pd.DataFrame = df.drop(columns=to_drop)
 
 
 def test_types_dropna() -> None:


### PR DESCRIPTION
The advantage is that `Sequence` is covariant which allows passing in `List[str]`, for example.

I also added `self` to `reindex` because mypy was complaining about that.