### PR TITLE
CI: use matplotlib stubs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "microsoft-python-type-stubs"]
+	path = microsoft-python-type-stubs
+	url = git@github.com:microsoft/python-type-stubs.git

--- a/matplotlib
+++ b/matplotlib
@@ -1,0 +1,1 @@
+microsoft-python-type-stubs/matplotlib/


### PR DESCRIPTION
I hope there is a nicer solution: this makes the MS stubs a submodule and then symlinks the matplotlib folder. Pyright and mypy seem to pick up on it as "." is the stub folder.

xref #45