### PR TITLE
remove installation dependencies on pandas and matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandas-stubs"
-version = "1.4.2.220626"
+version = "1.4.3.220702"
 description = "Type annotations for pandas"
 authors = ["The Pandas Development Team <pandas-dev@python.org>"]
 license = "BSD-3-Clause"
@@ -32,9 +32,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-pandas = "1.4.2"
-typing-extensions = ">=4.2.0"
-matplotlib = ">=3.3.2"
 
 [tool.poetry.dev-dependencies]
 mypy = ">=0.960"
@@ -45,6 +42,9 @@ isort = ">=5.10.1"
 poethepoet = ">=0.13.1"
 loguru = ">=0.6.0"
 pyupgrade = "^2.34.0"
+pandas = "1.4.3"
+typing-extensions = ">=4.2.0"
+matplotlib = ">=3.3.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- [x] Closes #62 and #45
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

Moved the dependencies for `pandas`, `matplotlib` and `typing_extensions` to be dev only.

No tests added.  Tested locally to see that you can install the stubs without pandas and matplotlib being installed, and `pyright` and both `mypy` still will check source.
