### PR TITLE
run pyright_dist instead of pyright_src when testing dist

### DIFF
--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -55,7 +55,7 @@ def test_dist(clean_cache: bool = False):
             _step.install_dist,
             _step.rename_src,
             _step.mypy_dist,
-            _step.pyright_src,
+            _step.pyright_dist,
             _step.uninstall_dist,
             _step.restore_src,
         ]
@@ -85,7 +85,7 @@ def test_all(clean_cache: bool = False):
             _step.install_dist,
             _step.rename_src,
             _step.mypy_dist,
-            _step.pyright_src,
+            _step.pyright_dist,
             _step.uninstall_dist,
             _step.restore_src,
         ]

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -26,6 +26,6 @@ rename_src = Step(
     rollback=run.restore_src,
 )
 mypy_dist = Step(name="Run MyPy Against Dist", run=run.mypy_dist)
-pyright = Step(name="Run Pyright Against Dist", run=run.pyright_dist)
+pyright_dist = Step(name="Run Pyright Against Dist", run=run.pyright_dist)
 uninstall_dist = Step(name="Uninstall Dist", run=run.uninstall_dist)
 restore_src = Step(name="Restore Source Code", run=run.restore_src)


### PR DESCRIPTION
Errors in script were calling `pyright_src` instead of `pyright_dist` when testing the distribution.

