### PR TITLE
Fix error when `sheet_name` is `None` for `read_excel`.

### DIFF
--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -21,7 +21,7 @@ from pandas._typing import (
 @overload
 def read_excel(
     filepath: str,
-    sheet_name: List[Union[int, str]],
+    sheet_name: Union[List[Union[int, str]], None],
     header: Optional[Union[int, Sequence[int]]] = ...,
     names: Optional[List[str]] = ...,
     index_col: Optional[Union[int, Sequence[int]]] = ...,

--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -21,7 +21,7 @@ from pandas._typing import (
 @overload
 def read_excel(
     filepath: str,
-    sheet_name: Union[List[Union[int, str]], None],
+    sheet_name: Optional[List[Union[int, str]]],
     header: Optional[Union[int, Sequence[int]]] = ...,
     names: Optional[List[str]] = ...,
     index_col: Optional[Union[int, Sequence[int]]] = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1024,13 +1024,13 @@ def test_read_excel() -> None:
         df14: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
             "foo", sheet_name=["sheet"]
         )
-        df15: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
-            "foo", sheet_name=[0]
-        )
+        df15: Dict[Union[int, str], pd.DataFrame] = pd.read_excel("foo", sheet_name=[0])
         df16: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
             "foo", sheet_name=[0, "sheet"]
         )
-        df17: Dict[Union[int, str], pd.DataFrame] = pd.read_excel("foo", sheet_name=None)
+        df17: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
+            "foo", sheet_name=None
+        )
 
 
 def test_join() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1020,9 +1020,17 @@ def test_read_excel() -> None:
         # https://github.com/pandas-dev/pandas-stubs/pull/33
         df11: pd.DataFrame = pd.read_excel("foo")
         df12: pd.DataFrame = pd.read_excel("foo", sheet_name="sheet")
-        df13: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
+        df13: pd.DataFrame = pd.read_excel("foo", sheet_name=0)
+        df14: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
             "foo", sheet_name=["sheet"]
         )
+        df15: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
+            "foo", sheet_name=[0]
+        )
+        df16: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
+            "foo", sheet_name=[0, "sheet"]
+        )
+        df17: Dict[Union[int, str], pd.DataFrame] = pd.read_excel("foo", sheet_name=None)
 
 
 def test_join() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1020,10 +1020,11 @@ def test_read_excel() -> None:
         # https://github.com/pandas-dev/pandas-stubs/pull/33
         df11: pd.DataFrame = pd.read_excel("foo")
         df12: pd.DataFrame = pd.read_excel("foo", sheet_name="sheet")
-        df13: pd.DataFrame = pd.read_excel("foo", sheet_name=0)
-        df14: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
+        df13: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
             "foo", sheet_name=["sheet"]
         )
+        # GH 98
+        df14: pd.DataFrame = pd.read_excel("foo", sheet_name=0)
         df15: Dict[Union[int, str], pd.DataFrame] = pd.read_excel("foo", sheet_name=[0])
         df16: Dict[Union[int, str], pd.DataFrame] = pd.read_excel(
             "foo", sheet_name=[0, "sheet"]


### PR DESCRIPTION
`pandas.read_excel` supports specifying `None` for `sheet_name`.
When using `None`, all worksheets are returned.

https://pandas.pydata.org/docs/reference/api/pandas.read_excel.html#pandas.read_excel

- [ ] Closes #98
- [ ] Tests added: Added checks for overloads when `sheet_name` is `None`, an int, a list[int], or a list[int|str]
