### PR TITLE
BUG: Allow integer ndarray for Series iloc

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -121,10 +121,25 @@ Scalar = Union[
     Timestamp,
     Timedelta,
 ]
-# Refine the next 3 in 3.9 to use the specialized type.
+# Refine the definitions below in 3.9 to use the specialized type.
+np_ndarray_int8 = npt.NDArray[np.int8]
+np_ndarray_int16 = npt.NDArray[np.int16]
+np_ndarray_int32 = npt.NDArray[np.int32]
 np_ndarray_int64 = npt.NDArray[np.int64]
+np_ndarray_uint8 = npt.NDArray[np.uint8]
+np_ndarray_uint16 = npt.NDArray[np.uint16]
+np_ndarray_uint32 = npt.NDArray[np.uint32]
+np_ndarray_uint64 = npt.NDArray[np.uint64]
+np_ndarray_int = Union[
+    np_ndarray_int8, np_ndarray_int16, np_ndarray_int32, np_ndarray_int64
+]
+np_ndarray_uint = Union[
+    np_ndarray_uint8, np_ndarray_uint16, np_ndarray_uint32, np_ndarray_uint64
+]
+np_ndarray_anyint = Union[np_ndarray_int, np_ndarray_uint]
 np_ndarray_bool = npt.NDArray[np.bool_]
 np_ndarray_str = npt.NDArray[np.str_]
+
 IndexType = Union[slice, np_ndarray_int64, Index, List[int], Series[int]]
 MaskType = Union[Series[bool], np_ndarray_bool, List[bool]]
 # Scratch types for generics

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -64,7 +64,7 @@ from pandas._typing import (
     SeriesAxisType as SeriesAxisType,
     Timedelta as Timedelta,
     Timestamp as Timestamp,
-    np_ndarray_int64 as np_ndarray_int64,
+    np_ndarray_anyint as np_ndarray_anyint,
     num as num,
 )
 
@@ -87,12 +87,16 @@ class _iLocIndexerSeries(_iLocIndexer, Generic[S1]):
     @overload
     def __getitem__(self, idx: IndexingInt) -> S1: ...
     @overload
-    def __getitem__(self, idx: Union[Index, slice, np_ndarray_int64]) -> Series[S1]: ...
+    def __getitem__(
+        self, idx: Union[Index, slice, np_ndarray_anyint]
+    ) -> Series[S1]: ...
     # set item
     @overload
     def __setitem__(self, idx: int, value: S1) -> None: ...
     @overload
-    def __setitem__(self, idx: Index, value: Union[S1, Series[S1]]) -> None: ...
+    def __setitem__(
+        self, idx: Union[Index, slice, np_ndarray_anyint], value: Union[S1, Series[S1]]
+    ) -> None: ...
 
 class _LocIndexerSeries(_LocIndexer, Generic[S1]):
     @overload

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -691,9 +691,53 @@ def test_cat_accessor() -> None:
     assert_type(s.cat.codes, "pd.Series[int]")
 
 
-def test_iloc_ndarray() -> None:
+def test_iloc_getitem_ndarray() -> None:
     # GH 85
     # GH 86
-    indices = np.array([0, 1, 2, 3], dtype=np.int64)
+    indices_i8 = np.array([0, 1, 2, 3], dtype=np.int8)
+    indices_i16 = np.array([0, 1, 2, 3], dtype=np.int16)
+    indices_i32 = np.array([0, 1, 2, 3], dtype=np.int32)
+    indices_i64 = np.array([0, 1, 2, 3], dtype=np.int64)
+
+    indices_u8 = np.array([0, 1, 2, 3], dtype=np.uint8)
+    indices_u16 = np.array([0, 1, 2, 3], dtype=np.uint16)
+    indices_u32 = np.array([0, 1, 2, 3], dtype=np.uint32)
+    indices_u64 = np.array([0, 1, 2, 3], dtype=np.uint64)
+
     values_s = pd.Series(np.arange(10), name="a")
-    assert_type(values_s.iloc[indices], "pd.Series")
+
+    assert_type(values_s.iloc[indices_i8], "pd.Series")
+    assert_type(values_s.iloc[indices_i16], "pd.Series")
+    assert_type(values_s.iloc[indices_i32], "pd.Series")
+    assert_type(values_s.iloc[indices_i64], "pd.Series")
+
+    assert_type(values_s.iloc[indices_u8], "pd.Series")
+    assert_type(values_s.iloc[indices_u16], "pd.Series")
+    assert_type(values_s.iloc[indices_u32], "pd.Series")
+    assert_type(values_s.iloc[indices_u64], "pd.Series")
+
+
+def test_iloc_setitem_ndarray() -> None:
+    # GH 85
+    # GH 86
+    indices_i8 = np.array([0, 1, 2, 3], dtype=np.int8)
+    indices_i16 = np.array([0, 1, 2, 3], dtype=np.int16)
+    indices_i32 = np.array([0, 1, 2, 3], dtype=np.int32)
+    indices_i64 = np.array([0, 1, 2, 3], dtype=np.int64)
+
+    indices_u8 = np.array([0, 1, 2, 3], dtype=np.uint8)
+    indices_u16 = np.array([0, 1, 2, 3], dtype=np.uint16)
+    indices_u32 = np.array([0, 1, 2, 3], dtype=np.uint32)
+    indices_u64 = np.array([0, 1, 2, 3], dtype=np.uint64)
+
+    values_s = pd.Series(np.arange(10), name="a")
+
+    values_s.iloc[indices_i8] = -1
+    values_s.iloc[indices_i16] = -1
+    values_s.iloc[indices_i32] = -1
+    values_s.iloc[indices_i64] = -1
+
+    values_s.iloc[indices_u8] = -1
+    values_s.iloc[indices_u16] = -1
+    values_s.iloc[indices_u32] = -1
+    values_s.iloc[indices_u64] = -1


### PR DESCRIPTION
Allow set and get for any signed or unsigned int arrays

closes #96

- [X] Closes #96
- [X] Tests added: Please use `assert_type()` to assert the type of any return value
