### PR TITLE
MAINT: Catch expected warnings

### DIFF
--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -268,7 +268,8 @@ def test_types_max() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     s.max()
     s.max(axis=0)
-    s.max(level=0)
+    with pytest.warns(FutureWarning, match="Using the level keyword"):
+        s.max(level=0)
     s.max(skipna=False)
 
 
@@ -411,7 +412,8 @@ def test_types_plot() -> None:
 def test_types_window() -> None:
     s = pd.Series([0, 1, 1, 0, 5, 1, -10])
     s.expanding()
-    s.expanding(axis=0, center=True)
+    with pytest.warns(FutureWarning, match="The `center` argument"):
+        s.expanding(axis=0, center=True)
 
     s.rolling(2)
     s.rolling(2, axis=0, center=True)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -3,6 +3,7 @@ from pandas.testing import (
     assert_frame_equal,
     assert_series_equal,
 )
+import pytest
 
 
 def test_types_assert_series_equal() -> None:
@@ -17,9 +18,10 @@ def test_types_assert_series_equal() -> None:
         check_flags=True,
         check_datetimelike_compat=True,
     )
-    assert_series_equal(
-        s1, s2, check_dtype=True, check_less_precise=True, check_names=True
-    )
+    with pytest.warns(FutureWarning, match="The 'check_less_precise'"):
+        assert_series_equal(
+            s1, s2, check_dtype=True, check_less_precise=True, check_names=True
+        )
 
 
 def test_assert_frame_equal():


### PR DESCRIPTION
Catch expected warnings to reduce noise in testing
