### PR TITLE
Allow `num` to be a `complex` type to support `Series` operations.

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -101,7 +101,7 @@ AggFuncType = Union[
     AggFuncTypeDict,
 ]
 
-num = Union[int, float]
+num = Union[int, float, complex]
 SeriesAxisType = Literal["index", 0]  # Restricted subset of _AxisType for series
 AxisType = Literal["columns", "index", 0, 1]
 DtypeNp = TypeVar("DtypeNp", bound=np.dtype[np.generic])

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -408,6 +408,14 @@ def test_types_scalar_arithmetic() -> None:
     res_pow3: pd.Series = s.pow(0.5)
 
 
+# GH 103
+def test_types_complex_arithmetic() -> None:
+    c = 1 + 1j
+    s = pd.Series([1.0, 2.0, 3.0])
+    x = s + c
+    y = s - c
+
+
 def test_types_groupby() -> None:
     s = pd.Series([4, 2, 1, 8], index=["a", "b", "a", "b"])
     s.groupby(["a", "b", "a", "b"])


### PR DESCRIPTION
Closes #103

- [ ] Closes #103
- [ ] Tests added: `test_types_complex_arithmetic`
