### PR TITLE
Allow `Categorical` to take any `ListLike` to support using `Series`.

### DIFF
--- a/pandas-stubs/core/arrays/categorical.pyi
+++ b/pandas-stubs/core/arrays/categorical.pyi
@@ -19,6 +19,7 @@ from pandas.core.indexes.base import Index
 from pandas._typing import (
     ArrayLike as ArrayLike,
     Dtype as Dtype,
+    ListLike as ListLike,
     Ordered as Ordered,
     Scalar as Scalar,
     Series as Series,
@@ -33,7 +34,7 @@ class Categorical(ExtensionArray, PandasObject):
     __array_priority__: int = ...
     def __init__(
         self,
-        values: Sequence,
+        values: ListLike,
         categories=...,
         ordered: Optional[bool] = ...,
         dtype: Optional[CategoricalDtype] = ...,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3,7 +3,9 @@ import tempfile
 from typing import (
     TYPE_CHECKING,
     List,
+    Sequence,
     Union,
+    cast,
 )
 
 import numpy as np
@@ -691,6 +693,14 @@ def test_cat_accessor() -> None:
     # GH 43
     s = pd.Series(pd.Categorical(["a", "b", "a"], categories=["a", "b"]))
     assert_type(s.cat.codes, "pd.Series[int]")
+
+
+def test_cat_ctor_values() -> None:
+    # GH 95
+    c1 = pd.Categorical(["a", "b", "a"])
+    c2 = pd.Categorical(pd.Series(["a", "b", "a"]))
+    s: Sequence = cast(Sequence, ["a", "b", "a"])
+    c3 = pd.Categorical(s)
 
 
 def test_iloc_getitem_ndarray() -> None:


### PR DESCRIPTION
Closes #95

- [ ] Closes #95(Replace xxxx with the Github issue number)
- [ ] Tests added: `test_cat_ctor_values` - attempts to create a `Categorical` with a few `ListLike` values.
