### PR TITLE
Make `index` in the `Series` ctor optional to match Pandas docs.

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -142,7 +142,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     def __new__(
         cls,
         data: DatetimeIndex,
-        index: Union[_str, int, Series, List, Index] = ...,
+        index: Optional[Union[_str, int, Series, List, Index]] = ...,
         dtype=...,
         name: Optional[Hashable] = ...,
         copy: bool = ...,
@@ -155,7 +155,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
             Union[object, _ListLike, Series[S1], Dict[int, S1], Dict[_str, S1]]
         ],
         dtype: Type[S1],
-        index: Union[_str, int, Series, List, Index] = ...,
+        index: Optional[Union[_str, int, Series, List, Index]] = ...,
         name: Optional[Hashable] = ...,
         copy: bool = ...,
         fastpath: bool = ...,
@@ -166,7 +166,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         data: Optional[
             Union[object, _ListLike, Series[S1], Dict[int, S1], Dict[_str, S1]]
         ] = ...,
-        index: Union[_str, int, Series, List, Index] = ...,
+        index: Optional[Union[_str, int, Series, List, Index]] = ...,
         dtype=...,
         name: Optional[Hashable] = ...,
         copy: bool = ...,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -24,6 +24,15 @@ def test_types_init() -> None:
     pd.Series(data=[1, 2, 3, 4], dtype=np.int8)
     pd.Series(data={"row1": [1, 2], "row2": [3, 4]})
     pd.Series(data=[1, 2, 3, 4], index=[4, 3, 2, 1], copy=True)
+    # GH 90
+    dt: pd.DatetimeIndex = pd.to_datetime(
+        [1, 2], unit="D", origin=pd.Timestamp("01/01/2000")
+    )
+    pd.Series(data=dt, index=None)
+    pd.Series(data=[1, 2, 3, 4], dtype=int, index=None)
+    pd.Series(data={"row1": [1, 2], "row2": [3, 4]}, dtype=int, index=None)
+    pd.Series(data=[1, 2, 3, 4], index=None)
+    pd.Series(data={"row1": [1, 2], "row2": [3, 4]}, index=None)
 
 
 def test_types_any() -> None:


### PR DESCRIPTION
https://pandas.pydata.org/docs/reference/api/pandas.Series.html#pandas-series

Closes #90

- [ ] Closes #90
- [ ] Tests added: In `test_types_init`, added usages of `Series` to cover the three ctor overloads for datetime, array and dict w/ dtype, and array and dict w/out dtype.
