### PR TITLE
ENH: Overload to_datetime when errors="coerce"

### DIFF
--- a/pandas-stubs/core/tools/datetimes.pyi
+++ b/pandas-stubs/core/tools/datetimes.pyi
@@ -1,6 +1,7 @@
 from datetime import datetime as datetime
 from typing import (
     List,
+    Literal,
     Optional,
     Tuple,
     TypedDict,
@@ -18,6 +19,7 @@ from pandas.core.series import (
     TimestampSeries,
 )
 
+from pandas._libs.tslibs import NaTType
 from pandas._typing import (
     AnyArrayLike as AnyArrayLike,
     ArrayLike as ArrayLike,
@@ -61,7 +63,7 @@ def should_cache(
 @overload
 def to_datetime(
     arg: DatetimeScalar,
-    errors: DateTimeErrorChoices = ...,
+    errors: Literal["ignore", "raise"] = ...,
     dayfirst: bool = ...,
     yearfirst: bool = ...,
     utc: bool | None = ...,
@@ -72,6 +74,20 @@ def to_datetime(
     origin=...,
     cache: bool = ...,
 ) -> Timestamp: ...
+@overload
+def to_datetime(
+    arg: DatetimeScalar,
+    errors: Literal["coerce"],
+    dayfirst: bool = ...,
+    yearfirst: bool = ...,
+    utc: bool | None = ...,
+    format: str | None = ...,
+    exact: bool = ...,
+    unit: str | None = ...,
+    infer_datetime_format: bool = ...,
+    origin=...,
+    cache: bool = ...,
+) -> Timestamp | NaTType: ...
 @overload
 def to_datetime(
     arg: Series | DictConvertible,

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -215,8 +215,26 @@ def test_comparisons_datetimeindex() -> None:
 
 
 def test_to_datetime_nat() -> None:
-    assert_type(pd.to_datetime("2021-03-01", errors="ignore"), "pd.Timestamp")
-    assert_type(pd.to_datetime("2021-03-01", errors="raise"), "pd.Timestamp")
-    assert_type(
-        pd.to_datetime("2021-03-01", errors="coerce"), "Union[pd.Timestamp, NaTType]"
+    # GH 88
+    assert isinstance(
+        assert_type(pd.to_datetime("2021-03-01", errors="ignore"), "pd.Timestamp"),
+        pd.Timestamp,
+    )
+    assert isinstance(
+        assert_type(pd.to_datetime("2021-03-01", errors="raise"), "pd.Timestamp"),
+        pd.Timestamp,
+    )
+    assert isinstance(
+        assert_type(
+            pd.to_datetime("2021-03-01", errors="coerce"),
+            "Union[pd.Timestamp, NaTType]",
+        ),
+        pd.Timestamp,
+    )
+    assert isinstance(
+        assert_type(
+            pd.to_datetime("not a date", errors="coerce"),
+            "Union[pd.Timestamp, NaTType]",
+        ),
+        NaTType,
     )

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -4,12 +4,15 @@ import datetime as dt
 from typing import (
     TYPE_CHECKING,
     Optional,
+    Union,
 )
 
 import numpy as np
 from numpy import typing as npt
 import pandas as pd
 from typing_extensions import assert_type
+
+from pandas._libs import NaTType
 
 if TYPE_CHECKING:
     from pandas.core.series import (
@@ -209,3 +212,11 @@ def test_comparisons_datetimeindex() -> None:
     assert_type((dti <= ts), np_ndarray_bool)
     assert_type((dti == ts), np_ndarray_bool)
     assert_type((dti != ts), np_ndarray_bool)
+
+
+def test_to_datetime_nat() -> None:
+    assert_type(pd.to_datetime("2021-03-01", errors="ignore"), "pd.Timestamp")
+    assert_type(pd.to_datetime("2021-03-01", errors="raise"), "pd.Timestamp")
+    assert_type(
+        pd.to_datetime("2021-03-01", errors="coerce"), "Union[pd.Timestamp, NaTType]"
+    )


### PR DESCRIPTION
Have to_datetime returning NaTType when errors are coerced and scalar input

- [X] Closes #88 (Replace xxxx with the Github issue number)
- [X] Tests added: Please use `assert_type()` to assert the type of any return value
