### PR TITLE
Rename poe tasks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,29 +39,29 @@ jobs:
     - name: Install project dependencies
       run: poetry install -vvv --no-root
 
-    - name: Run MyPy Against Source Code
+    - name: Run mypy on 'tests' (using the local stubs) and on the local stubs
       run: poetry run poe mypy_src
 
-    - name: Run Pyright Against Source Code
+    - name: Run pyright on 'tests' (using the local stubs) and on the local stubs
       run: poetry run poe pyright_src
 
-    - name: Run Pytest Against Source Code
+    - name: Run pytest
       run: poetry run poe pytest_src
 
     - if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
       uses: pre-commit/action@v3.0.0
 
-    - name: Build Distribution
+    - name: Build pandas-stubs
       run: poetry run poe build_dist
 
-    - name: Install Distribution
+    - name: Install pandas-stubs
       run: poetry run poe install_dist
 
-    - name: Rename Source Code
+    - name: Rename local stubs
       run: poetry run poe rename_src
 
-    - name: Run Pyright Against Distribution
+    - name: Run pyright on 'tests' using the installed stubs
       run: poetry run poe pyright_dist
 
-    - name: Run MyPy Against Distribution
+    - name: Run mypy on 'tests' using the installed stubs
       run: poetry run poe mypy_dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,16 +46,16 @@ jobs:
       run: poetry run poe pyright_src
 
     - name: Run Pytest Against Source Code
-      run: poetry run poe pytest_src
+      run: poetry run poe test_src pytest
+
+    - if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
+      uses: pre-commit/action@v3.0.0
 
     - name: Build Distribution
       run: poetry run poe build_dist
 
     - name: Install Distribution
       run: poetry run poe install_dist
-
-    - if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
-      uses: pre-commit/action@v3.0.0
 
     - name: Rename Source Code
       run: poetry run poe rename_src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,5 @@ jobs:
     - if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
       uses: pre-commit/action@v3.0.0
 
-    - name: Build pandas-stubs
+    - name: Install pandas-stubs and run tests on the installed stubs
       run: poetry run poe test_dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,16 +52,4 @@ jobs:
       uses: pre-commit/action@v3.0.0
 
     - name: Build pandas-stubs
-      run: poetry run poe build_dist
-
-    - name: Install pandas-stubs
-      run: poetry run poe install_dist
-
-    - name: Rename local stubs
-      run: poetry run poe rename_src
-
-    - name: Run pyright on 'tests' using the installed stubs
-      run: poetry run poe pyright_dist
-
-    - name: Run mypy on 'tests' using the installed stubs
-      run: poetry run poe mypy_dist
+      run: poetry run poe test_dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       run: poetry run poe pyright_src
 
     - name: Run pytest
-      run: poetry run poe pytest_src
+      run: poetry run poe pytest
 
     - if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
       uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       run: poetry run poe pyright_src
 
     - name: Run Pytest Against Source Code
-      run: poetry run poe test_src --profile=pytest
+      run: poetry run poe pytest_src
 
     - if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
       uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       run: poetry run poe pyright_src
 
     - name: Run Pytest Against Source Code
-      run: poetry run poe test_src pytest
+      run: poetry run poe test_src --profile=pytest
 
     - if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
       uses: pre-commit/action@v3.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,13 @@ script = "scripts.test:test(clean_cache, src=True, dist=True)"
     options = ["-c", "--clean_cache"]
     default = false
 
-[tool.poe.tasks.pytest_src]
+[tool.poe.tasks.pytest]
 help = "Run pytest"
-script = "scripts.test.run:pytest_src"
+script = "scripts.test.run:pytest"
+
+[tool.poe.tasks.style]
+help = "Run pre-commit"
+script = "scripts.test.run:style"
 
 [tool.poe.tasks.mypy_src]
 help = "Run mypy on 'tests' (using the local stubs) and on the local stubs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,16 @@ isort = ">=5.10.1"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.poe.tasks.test_all]
+help = "Run all tests"
+script = "scripts.test:test(clean_cache, src=True, dist=True)"
+
+    [[tool.poe.tasks.test_all.args]]
+    help = "remove cache folders (mypy and pytest)"
+    name = "clean-cache"
+    options = ["-c", "--clean_cache"]
+    default = false
+
 [tool.poe.tasks.test_src]
 help = "Run local tests (includes 'mypy_src', 'pyright_src', 'pytest', and 'style')"
 script = "scripts.test:test(clean_cache, src=True)"
@@ -65,16 +75,6 @@ help = "Run tests on the installed stubs (includes 'mypy_dist' and 'pyright_dist
 script = "scripts.test:test(clean_cache, dist=True)"
 
     [[tool.poe.tasks.test_dist.args]]
-    help = "remove cache folders (mypy and pytest)"
-    name = "clean-cache"
-    options = ["-c", "--clean_cache"]
-    default = false
-
-[tool.poe.tasks.test_all]
-help = "Run all tests"
-script = "scripts.test:test(clean_cache, src=True, dist=True)"
-
-    [[tool.poe.tasks.test_all.args]]
     help = "remove cache folders (mypy and pytest)"
     name = "clean-cache"
     options = ["-c", "--clean_cache"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,75 +51,72 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poe.tasks.test_src]
-help = "LOCAL Test | Run tests against source code version: \"poe test_src -p=<profile>\""
+help = "Run local tests"
 script = "scripts.test:test_src(profile, clean_cache)"
 
     [[tool.poe.tasks.test_src.args]]
-    help = "\"default\" (mypy + pyright) or \"pytest\" (pytest only) or \"full\" (mypy + pyright + pytest)"
+    help = "'typing' (mypy and pyright), 'pytest' (pytest only), 'style' (pre-commit only), or 'all'"
     name = "profile"
     options = ["-p", "--profile"]
-    default = "default"
+    default = "typing"
 
     [[tool.poe.tasks.test_src.args]]
-    help = "remove mypy and pytest cache folders"
+    help = "remove cache folders (mypy and pytest)"
     name = "clean-cache"
     options = ["-c", "--clean_cache"]
     default = false
 
 [tool.poe.tasks.test_dist]
-help = "Local Test | Run tests against distribuition version: \"poe test_dist\""
+help = "Run all typing tests using the installed stubs"
 script = "scripts.test:test_dist(clean_cache)"
 
     [[tool.poe.tasks.test_dist.args]]
-    help = "remove mypy and pytest cache folders"
+    help = "remove cache folder (mypy)"
     name = "clean-cache"
     options = ["-c", "--clean_cache"]
     default = false
 
 [tool.poe.tasks.test_all]
-help = "Local Test | Run tests against source code and distribuition version: \"poe test_all\""
+help = "Run all tests (includes installing the stubs)"
 script = "scripts.test:test_all(clean_cache)"
 
     [[tool.poe.tasks.test_all.args]]
-    help = "remove mypy and pytest cache folders"
+    help = "remove cache folders (mypy and pytest)"
     name = "clean-cache"
     options = ["-c", "--clean_cache"]
     default = false
 
 [tool.poe.tasks.mypy_src]
-help = "CI Test | Run mypy against source code"
+help = "Run mypy on 'tests' (using the local stubs) and on the local stubs"
 script = "scripts.test.run:mypy_src"
 
+[tool.poe.tasks.mypy_dist]
+help = "Run mypy on 'tests' using the installed stubs"
+script = "scripts.test.run:mypy_dist"
+
 [tool.poe.tasks.pyright_src]
-help = "CI Test | Run pyright against source code"
+help = "Run pyright on 'tests' (using the local stubs) and on the local stubs"
 script = "scripts.test.run:pyright_src"
 
-[tool.poe.tasks.pytest_src]
-help = "CI Test | Run pytest against source code"
-script = "scripts.test.run:pytest_src"
+[tool.poe.tasks.pyright_dist]
+help = "Run pyright on 'tests' using the installed stubs"
+script = "scripts.test.run:pyright_dist"
 
 [tool.poe.tasks.build_dist]
-help = "CI Test | Build distribuition"
+help = "Build pandas-stubs"
 script = "scripts.test.run:build_dist"
 
 [tool.poe.tasks.install_dist]
-help = "CI Test | Install distribuition"
+help = "Install pandas-stubs"
 script = "scripts.test.run:install_dist"
 
 [tool.poe.tasks.rename_src]
-help = "CI Test | Rename source code"
+help = "Rename local stubs"
 script = "scripts.test.run:rename_src"
 
-[tool.poe.tasks.mypy_dist]
-help = "CI Test | Run mypy against distribuition"
-script = "scripts.test.run:mypy_dist"
-
-[tool.poe.tasks.pyright_dist]
-help = "CI Test | Run pyright against distribuition"
-script = "scripts.test.run:pyright_dist"
 
 [tool.black]
-target-version = ['py38', 'py39']
+target-version = ['py38']
 
 [tool.isort]
 known_pre_libs = "pandas._config"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poe.tasks.test_src]
-help = "Run all local tests"
+help = "Run local tests (includes 'mypy_src', 'pyright_src', 'pytest', and 'style')"
 script = "scripts.test:test(clean_cache, src=True)"
 
     [[tool.poe.tasks.test_src.args]]
@@ -61,7 +61,7 @@ script = "scripts.test:test(clean_cache, src=True)"
     default = false
 
 [tool.poe.tasks.test_dist]
-help = "Run typing tests on 'tests' using the installed stubs"
+help = "Run tests on the installed stubs (includes 'mypy_dist' and 'pyright_dist')"
 script = "scripts.test:test(clean_cache, dist=True)"
 
     [[tool.poe.tasks.test_dist.args]]
@@ -71,7 +71,7 @@ script = "scripts.test:test(clean_cache, dist=True)"
     default = false
 
 [tool.poe.tasks.test_all]
-help = "Run all tests (includes installing the stubs)"
+help = "Run all tests"
 script = "scripts.test:test(clean_cache, src=True, dist=True)"
 
     [[tool.poe.tasks.test_all.args]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ script = "scripts.test:test_src(profile, clean_cache)"
     default = false
 
 [tool.poe.tasks.test_dist]
-help = "Run all typing tests using the installed stubs"
+help = "Run typing tests on 'tests' using the installed stubs"
 script = "scripts.test:test_dist(clean_cache)"
 
     [[tool.poe.tasks.test_dist.args]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,14 +51,8 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poe.tasks.test_src]
-help = "Run local tests"
-script = "scripts.test:test_src(profile, clean_cache)"
-
-    [[tool.poe.tasks.test_src.args]]
-    help = "'typing' (mypy and pyright), 'pytest' (pytest only), 'style' (pre-commit only), or 'all'"
-    name = "profile"
-    options = ["-p", "--profile"]
-    default = "typing"
+help = "Run all local tests"
+script = "scripts.test:test(clean_cache, src=True)"
 
     [[tool.poe.tasks.test_src.args]]
     help = "remove cache folders (mypy and pytest)"
@@ -68,23 +62,27 @@ script = "scripts.test:test_src(profile, clean_cache)"
 
 [tool.poe.tasks.test_dist]
 help = "Run typing tests on 'tests' using the installed stubs"
-script = "scripts.test:test_dist(clean_cache)"
+script = "scripts.test:test(clean_cache, dist=True)"
 
     [[tool.poe.tasks.test_dist.args]]
-    help = "remove cache folder (mypy)"
+    help = "remove cache folders (mypy and pytest)"
     name = "clean-cache"
     options = ["-c", "--clean_cache"]
     default = false
 
 [tool.poe.tasks.test_all]
 help = "Run all tests (includes installing the stubs)"
-script = "scripts.test:test_all(clean_cache)"
+script = "scripts.test:test(clean_cache, src=True, dist=True)"
 
     [[tool.poe.tasks.test_all.args]]
     help = "remove cache folders (mypy and pytest)"
     name = "clean-cache"
     options = ["-c", "--clean_cache"]
     default = false
+
+[tool.poe.tasks.pytest_src]
+help = "Run pytest"
+script = "scripts.test.run:pytest_src"
 
 [tool.poe.tasks.mypy_src]
 help = "Run mypy on 'tests' (using the local stubs) and on the local stubs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ script = "scripts.test.run:mypy_src"
 
 [tool.poe.tasks.mypy_dist]
 help = "Run mypy on 'tests' using the installed stubs"
-script = "scripts.test.run:mypy_dist"
+script = "scripts.test:test(clean_cache=False, dist=True, type_checker='mypy')"
 
 [tool.poe.tasks.pyright_src]
 help = "Run pyright on 'tests' (using the local stubs) and on the local stubs"
@@ -102,19 +102,8 @@ script = "scripts.test.run:pyright_src"
 
 [tool.poe.tasks.pyright_dist]
 help = "Run pyright on 'tests' using the installed stubs"
-script = "scripts.test.run:pyright_dist"
+script = "scripts.test:test(clean_cache=False, dist=True, type_checker='pyright')"
 
-[tool.poe.tasks.build_dist]
-help = "Build pandas-stubs"
-script = "scripts.test.run:build_dist"
-
-[tool.poe.tasks.install_dist]
-help = "Install pandas-stubs"
-script = "scripts.test.run:install_dist"
-
-[tool.poe.tasks.rename_src]
-help = "Rename local stubs"
-script = "scripts.test.run:rename_src"
 
 
 [tool.black]

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -1,77 +1,28 @@
 from scripts._job import run_job
 from scripts.test import _step
 
+_CACHE_STEPS = [_step.clean_mypy_cache, _step.clean_pytest_cache]
+_SRC_STEPS = [_step.mypy_src, _step.pyright_src, _step.pytest_src, _step.style_src]
+_DIST_STEPS = [
+    _step.build_dist,
+    _step.install_dist,
+    _step.rename_src,
+    _step.mypy_dist,
+    _step.pyright_dist,
+    _step.uninstall_dist,
+    _step.restore_src,
+]
 
-def test_src(profile: str, clean_cache: bool = False):
+
+def test(clean_cache: bool = False, src: bool = False, dist: bool = False):
     steps = []
     if clean_cache:
-        steps.extend(
-            [
-                _step.clean_mypy_cache,
-                _step.clean_pytest_cache,
-            ]
-        )
+        steps.extend(_CACHE_STEPS)
 
-    if profile in (None, "", "typing"):
-        steps.extend([_step.mypy_src, _step.pyright_src])
-    elif profile == "pytest":
-        steps.extend([_step.pytest_src])
-    elif profile == "style":
-        steps.extend([_step.style_src])
-    elif profile == "all":
-        steps.extend(
-            [_step.mypy_src, _step.pyright_src, _step.pytest_src, _step.style_src]
-        )
-    else:
-        raise ModuleNotFoundError("Profile not found!")
+    if src:
+        steps.extend(_SRC_STEPS)
 
-    run_job(steps)
-
-
-def test_dist(clean_cache: bool = False):
-    steps = []
-    if clean_cache:
-        steps.extend([_step.clean_mypy_cache])
-
-    steps.extend(
-        [
-            _step.build_dist,
-            _step.install_dist,
-            _step.rename_src,
-            _step.mypy_dist,
-            _step.pyright_dist,
-            _step.uninstall_dist,
-            _step.restore_src,
-        ]
-    )
-
-    run_job(steps)
-
-
-def test_all(clean_cache: bool = False):
-    steps = []
-    if clean_cache:
-        steps.extend(
-            [
-                _step.clean_mypy_cache,
-                _step.clean_pytest_cache,
-            ]
-        )
-
-    steps.extend(
-        [
-            _step.mypy_src,
-            _step.pyright_src,
-            _step.pytest_src,
-            _step.style_src,
-            _step.build_dist,
-            _step.install_dist,
-            _step.rename_src,
-            _step.mypy_dist,
-            _step.pyright_dist,
-            _step.uninstall_dist,
-            _step.restore_src,
-        ]
-    )
+    if src:
+        steps.extend(_DIST_STEPS)
 
     run_job(steps)

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from scripts._job import run_job
 from scripts.test import _step
 
@@ -14,7 +16,12 @@ _DIST_STEPS = [
 ]
 
 
-def test(clean_cache: bool = False, src: bool = False, dist: bool = False):
+def test(
+    clean_cache: bool = False,
+    src: bool = False,
+    dist: bool = False,
+    type_checker: Literal["", "mypy", "pyright"] = "",
+):
     steps = []
     if clean_cache:
         steps.extend(_CACHE_STEPS)
@@ -24,5 +31,10 @@ def test(clean_cache: bool = False, src: bool = False, dist: bool = False):
 
     if dist:
         steps.extend(_DIST_STEPS)
+
+    if type_checker:
+        # either pyright or mypy
+        remove = "mypy" if type_checker == "pyright" else "pyright"
+        steps = [step for step in steps if remove not in step.name]
 
     run_job(steps)

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -12,13 +12,13 @@ def test_src(profile: str, clean_cache: bool = False):
             ]
         )
 
-    if profile in (None, "", "default"):
+    if profile in (None, "", "typing"):
         steps.extend([_step.mypy_src, _step.pyright_src])
     elif profile == "pytest":
         steps.extend([_step.pytest_src])
     elif profile == "style":
         steps.extend([_step.style_src])
-    elif profile == "full":
+    elif profile == "all":
         steps.extend(
             [_step.mypy_src, _step.pyright_src, _step.pytest_src, _step.style_src]
         )
@@ -31,12 +31,7 @@ def test_src(profile: str, clean_cache: bool = False):
 def test_dist(clean_cache: bool = False):
     steps = []
     if clean_cache:
-        steps.extend(
-            [
-                _step.clean_mypy_cache,
-                _step.clean_pytest_cache,
-            ]
-        )
+        steps.extend([_step.clean_mypy_cache])
 
     steps.extend(
         [

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -22,7 +22,7 @@ def test(clean_cache: bool = False, src: bool = False, dist: bool = False):
     if src:
         steps.extend(_SRC_STEPS)
 
-    if src:
+    if dist:
         steps.extend(_DIST_STEPS)
 
     run_job(steps)

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -2,7 +2,7 @@ from scripts._job import run_job
 from scripts.test import _step
 
 _CACHE_STEPS = [_step.clean_mypy_cache, _step.clean_pytest_cache]
-_SRC_STEPS = [_step.mypy_src, _step.pyright_src, _step.pytest_src, _step.style_src]
+_SRC_STEPS = [_step.mypy_src, _step.pyright_src, _step.pytest, _step.style]
 _DIST_STEPS = [
     _step.build_dist,
     _step.install_dist,

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -11,8 +11,8 @@ pyright_src = Step(
     name="Run pyright on 'tests' (using the local stubs) and on the local stubs",
     run=run.pyright_src,
 )
-pytest_src = Step(name="Run pytest", run=run.pytest_src)
-style_src = Step(name="Run pre-commit Against Source Code", run=run.style_src)
+pytest = Step(name="Run pytest", run=run.pytest)
+style = Step(name="Run pre-commit", run=run.style)
 build_dist = Step(name="Build pandas-stubs", run=run.build_dist)
 install_dist = Step(
     name="Install pandas-stubs", run=run.install_dist, rollback=run.uninstall_dist

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -5,6 +5,7 @@ clean_mypy_cache = Step(name="Clean mypy cache", run=run.clean_mypy_cache)
 clean_pytest_cache = Step(name="Clean pytest cache", run=run.clean_pytest_cache)
 mypy_src = Step(name="Run Mypy Against Source Code", run=run.mypy_src)
 pyright_src = Step(name="Run Pyright Against Source Code", run=run.pyright_src)
+pytest_src = Step(name="Run Pytest Against Source Code", run=run.pytest_src)
 style_src = Step(name="Run pre-commit Against Source Code", run=run.style_src)
 build_dist = Step(name="Build Dist", run=run.build_dist)
 install_dist = Step(

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -3,20 +3,30 @@ from scripts.test import run
 
 clean_mypy_cache = Step(name="Clean mypy cache", run=run.clean_mypy_cache)
 clean_pytest_cache = Step(name="Clean pytest cache", run=run.clean_pytest_cache)
-mypy_src = Step(name="Run Mypy Against Source Code", run=run.mypy_src)
-pyright_src = Step(name="Run Pyright Against Source Code", run=run.pyright_src)
-pytest_src = Step(name="Run Pytest Against Source Code", run=run.pytest_src)
+mypy_src = Step(
+    name="Run mypy on 'tests' (using the local stubs) and on the local stubs",
+    run=run.mypy_src,
+)
+pyright_src = Step(
+    name="Run pyright on 'tests' (using the local stubs) and on the local stubs",
+    run=run.pyright_src,
+)
+pytest_src = Step(name="Run pytest", run=run.pytest_src)
 style_src = Step(name="Run pre-commit Against Source Code", run=run.style_src)
-build_dist = Step(name="Build Dist", run=run.build_dist)
+build_dist = Step(name="Build pandas-stubs", run=run.build_dist)
 install_dist = Step(
-    name="Install Dist", run=run.install_dist, rollback=run.uninstall_dist
+    name="Install pandas-stubs", run=run.install_dist, rollback=run.uninstall_dist
 )
 rename_src = Step(
-    name="Rename Source Code Folder",
+    name="Rename local stubs",
     run=run.rename_src,
     rollback=run.restore_src,
 )
-mypy_dist = Step(name="Run MyPy Against Dist", run=run.mypy_dist)
-pyright_dist = Step(name="Run Pyright Against Dist", run=run.pyright_dist)
-uninstall_dist = Step(name="Uninstall Dist", run=run.uninstall_dist)
-restore_src = Step(name="Restore Source Code", run=run.restore_src)
+mypy_dist = Step(
+    name="Run mypy on 'tests' using the installed stubs", run=run.mypy_dist
+)
+pyright_dist = Step(
+    name="Run pyright on 'tests' using the installed stubs", run=run.pyright_dist
+)
+uninstall_dist = Step(name="Uninstall pandas-stubs", run=run.uninstall_dist)
+restore_src = Step(name="Restore local stubs", run=run.restore_src)

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -5,7 +5,6 @@ clean_mypy_cache = Step(name="Clean mypy cache", run=run.clean_mypy_cache)
 clean_pytest_cache = Step(name="Clean pytest cache", run=run.clean_pytest_cache)
 mypy_src = Step(name="Run Mypy Against Source Code", run=run.mypy_src)
 pyright_src = Step(name="Run Pyright Against Source Code", run=run.pyright_src)
-pytest_src = Step(name="Run Pytest Against Source Code", run=run.pytest_src)
 style_src = Step(name="Run pre-commit Against Source Code", run=run.style_src)
 build_dist = Step(name="Build Dist", run=run.build_dist)
 install_dist = Step(

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -29,7 +29,7 @@ def build_dist():
 
 
 def install_dist():
-    path = sorted(Path("dist/").glob("pandas_stubs-1*.whl"))[-1]
+    path = sorted(Path("dist/").glob("pandas_stubs-*.whl"))[-1]
     cmd = ["pip", "install", "--force-reinstall", str(path)]
     subprocess.run(cmd, check=True)
 

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -29,7 +29,7 @@ def build_dist():
 
 
 def install_dist():
-    path = next(Path("dist/").glob("*.whl"))
+    path = sorted(Path("dist/").glob("pandas_stubs-1*.whl"))[-1]
     cmd = ["pip", "install", "--force-reinstall", str(path)]
     subprocess.run(cmd, check=True)
 

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -30,7 +30,7 @@ def build_dist():
 
 def install_dist():
     path = next(Path("dist/").glob("*.whl"))
-    cmd = ["pip", "install", str(path)]
+    cmd = ["pip", "install", "--force-reinstall", str(path)]
     subprocess.run(cmd, check=True)
 
 

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -13,12 +13,12 @@ def pyright_src():
     subprocess.run(cmd, check=True)
 
 
-def pytest_src():
+def pytest():
     cmd = ["pytest"]
     subprocess.run(cmd, check=True)
 
 
-def style_src():
+def style():
     cmd = ["pre-commit", "run", "--all-files", "--verbose"]
     subprocess.run(cmd, check=True)
 


### PR DESCRIPTION
This should make `poe --help` easier to skim and clearer.

![image](https://user-images.githubusercontent.com/6618166/178802754-2066af26-2f55-4537-af4c-b2f058833417.png)


Happy to also rename `Steps` (in `scripts/test/_step.`py) and the github workflow steps, if the changes in pyproject.toml are okay.
