### PR TITLE
try setup-python's cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,15 @@ jobs:
 
     - uses: actions/checkout@v3
 
+    - name: Install Poetry
+      run: pipx install poetry
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Upgrade pip
-      run: python -m pip install --upgrade pip
-
-    - name: Install Poetry
-      run: pip install poetry
+        cache: 'poetry'
+        cache-dependency-path: 'pyproject.toml'
 
     - name: Determine poetry version
       run: echo "::set-output name=VERSION::$(poetry --version)"


### PR DESCRIPTION
setup-python has a built-in cache option that even supports poetry! It doesn't help us to cache poetry.lock, but it will cache the virtual environment that poetry creates.

I changed the CI based on the example provided by setup-python: https://github.com/actions/setup-python#caching-packages-dependencies