### PR TITLE
CLEAN: Align Groupby types

### DIFF
--- a/pandas-stubs/core/base.pyi
+++ b/pandas-stubs/core/base.pyi
@@ -1,24 +1,18 @@
 from __future__ import annotations
 
 from typing import (
-    Callable,
     Generic,
     Literal,
 )
 
 import numpy as np
-from pandas import (
-    DataFrame,
-    Index,
-    Series,
-)
+from pandas import Index
 from pandas.core.accessor import DirNamesMixin
 from pandas.core.arrays import ExtensionArray
 from pandas.core.arrays.categorical import Categorical
 
 from pandas._typing import (
     NDFrameT,
-    Scalar,
     SeriesAxisType,
 )
 
@@ -35,10 +29,6 @@ class SpecificationError(GroupByError): ...
 class SelectionMixin(Generic[NDFrameT]):
     def ndim(self) -> int: ...
     def __getitem__(self, key): ...
-    def aggregate(
-        self, func: Callable | None = ..., *args, **kwargs
-    ) -> Scalar | Series | DataFrame: ...
-    agg = aggregate
 
 class ShallowMixin: ...
 

--- a/pandas-stubs/core/groupby/groupby.pyi
+++ b/pandas-stubs/core/groupby/groupby.pyi
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Callable
 
-from pandas.core.base import PandasObject
+from pandas.core.base import (
+    PandasObject,
+    SelectionMixin,
+)
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame
 from pandas.core.groupby import ops
@@ -14,6 +17,7 @@ from pandas._typing import (
     AxisType,
     FrameOrSeriesUnion,
     KeysArgType,
+    NDFrameT,
 )
 
 class GroupByPlot(PandasObject):
@@ -21,7 +25,7 @@ class GroupByPlot(PandasObject):
     def __call__(self, *args, **kwargs): ...
     def __getattr__(self, name: str): ...
 
-class _GroupBy(PandasObject, GroupByIndexingMixin):
+class BaseGroupBy(PandasObject, SelectionMixin[NDFrameT], GroupByIndexingMixin):
     level = ...
     as_index = ...
     keys = ...
@@ -63,7 +67,7 @@ class _GroupBy(PandasObject, GroupByIndexingMixin):
     def get_group(self, name, obj: DataFrame | None = ...) -> DataFrame: ...
     def apply(self, func: Callable, *args, **kwargs) -> FrameOrSeriesUnion: ...
 
-class GroupBy(_GroupBy):
+class GroupBy(BaseGroupBy[NDFrameT]):
     def count(self) -> FrameOrSeriesUnion: ...
     def mean(self, **kwargs) -> FrameOrSeriesUnion: ...
     def median(self, **kwargs) -> FrameOrSeriesUnion: ...

--- a/pandas-stubs/core/resample.pyi
+++ b/pandas-stubs/core/resample.pyi
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from pandas.core.base import ShallowMixin as ShallowMixin
 from pandas.core.groupby.base import GroupByMixin as GroupByMixin
-from pandas.core.groupby.groupby import _GroupBy
+from pandas.core.groupby.groupby import BaseGroupBy
 from pandas.core.groupby.grouper import Grouper as Grouper
 
 from pandas._typing import FrameOrSeriesUnion
 
-class Resampler(_GroupBy, ShallowMixin):
+class Resampler(BaseGroupBy, ShallowMixin):
     def __init__(
         self, obj, groupby=..., axis: int = ..., kind=..., **kwargs
     ) -> None: ...


### PR DESCRIPTION
- [X] Closes #149 
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
  - None

pandas has `BaseGroupBy` (which should be private), whereas the stubs had `_GroupBy`, but I wanted to get things aligned.  Probably `BaseGroupBy` should be private in pandas.

In addition, `SelectionMixin` is really an abstract class, so removing `aggregate` makes sense, as the pandas implementation raises an exception anyway.

