### PR TITLE
BUG: Fix typo on check_frame_type

### DIFF
--- a/pandas-stubs/_testing/__init__.pyi
+++ b/pandas-stubs/_testing/__init__.pyi
@@ -107,7 +107,7 @@ def assert_frame_equal(
     check_dtype: bool | Literal["equiv"] = ...,
     check_index_type: bool | Literal["equiv"] = ...,
     check_column_type: bool | Literal["equiv"] = ...,
-    check_frame_typ: bool = ...,
+    check_frame_type: bool = ...,
     check_less_precise: int | bool = ...,
     check_names: bool = ...,
     by_blocks: bool = ...,


### PR DESCRIPTION
`check_frame_typ` → `check_frame_type`

`check_frame_typ` does not appear in the parameters, I think this is most likely to be a typo.
https://pandas.pydata.org/docs/reference/api/pandas.testing.assert_frame_equal.html

Currently the type hint incorrectly produces this error in mypy:
```
error: Unexpected keyword argument "check_frame_type" for "assert_frame_equal"; did you mean "check_frame_typ"?
```