### PR TITLE
stubtest: option to not set ignore-missing-stub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,9 @@ help = "Run pyright on 'tests' using the installed stubs"
 script = "scripts.test:test(dist=True, type_checker='pyright')"
 
 [tool.poe.tasks.stubtest]
-script = "scripts.test:stubtest(allowlist)"
+script = "scripts.test:stubtest(allowlist, check_missing)"
 help = "Run stubtest to compare the installed stubs against pandas"
-args = [{ name = "allowlist", positional = true, default = "", required = false, help= "Path to an allowlist (optional)" }]
+args = [{ name = "allowlist", positional = true, default = "", required = false, help= "Path to an allowlist (optional)" }, {name = "check_missing", positional = false, default = false, type = "boolean", required = false, help= "Report errors when the stubs are incomplete (off by default)"}]
 
 
 [tool.black]

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -42,5 +42,4 @@ def stubtest(allowlist: str, check_missing: bool):
             _step.stubtest.run, allowlist=allowlist, check_missing=check_missing
         ),
     )
-    print(_DIST_STEPS[:2])
     run_job(_DIST_STEPS[:2] + [stubtest])

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -35,8 +35,12 @@ def test(
     run_job(steps)
 
 
-def stubtest(allowlist: str):
+def stubtest(allowlist: str, check_missing: bool):
     stubtest = dataclasses.replace(
-        _step.stubtest, run=partial(_step.stubtest.run, allowlist=allowlist)
+        _step.stubtest,
+        run=partial(
+            _step.stubtest.run, allowlist=allowlist, check_missing=check_missing
+        ),
     )
-    run_job(_DIST_STEPS[:-2] + [stubtest])
+    print(_DIST_STEPS[:2])
+    run_job(_DIST_STEPS[:2] + [stubtest])

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -23,17 +23,18 @@ def style():
     subprocess.run(cmd, check=True)
 
 
-def stubtest(allowlist: str = ""):
+def stubtest(allowlist: str = "", check_missing: bool = False):
     cmd = [
         sys.executable,
         "-m",
         "mypy.stubtest",
         "pandas",
         "--concise",
-        "--ignore-missing-stub",
         "--mypy-config-file",
         "pyproject.toml",
     ]
+    if not check_missing:
+        cmd += ["--ignore-missing-stub"]
     if allowlist:
         cmd += ["--allowlist", allowlist]
     subprocess.run(cmd, check=True)


### PR DESCRIPTION
will make it easier for #128 `poe stubtest --check_missing | grep "pandas\._typing"` @Dr-Irv 