### PR TITLE
stbutest: option to use it with pandas nightly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,9 @@ help = "Run pyright on 'tests' using the installed stubs"
 script = "scripts.test:test(dist=True, type_checker='pyright')"
 
 [tool.poe.tasks.stubtest]
-script = "scripts.test:stubtest(allowlist, check_missing)"
+script = "scripts.test:stubtest(allowlist, check_missing, nightly)"
 help = "Run stubtest to compare the installed stubs against pandas"
-args = [{ name = "allowlist", positional = true, default = "", required = false, help= "Path to an allowlist (optional)" }, {name = "check_missing", positional = false, default = false, type = "boolean", required = false, help= "Report errors when the stubs are incomplete (off by default)"}]
+args = [{ name = "allowlist", positional = true, default = "", required = false, help= "Path to an allowlist (optional)" }, {name = "check_missing", positional = false, default = false, type = "boolean", required = false, help= "Report errors when the stubs are incomplete (off by default)"}, {name = "nightly", positional = false, default = false, type = "boolean", required = false, help= "Compare against pandas nightly (off by default)"}]
 
 
 [tool.black]

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -35,11 +35,14 @@ def test(
     run_job(steps)
 
 
-def stubtest(allowlist: str, check_missing: bool):
+def stubtest(allowlist: str, check_missing: bool, nightly: bool) -> None:
     stubtest = dataclasses.replace(
         _step.stubtest,
         run=partial(
             _step.stubtest.run, allowlist=allowlist, check_missing=check_missing
         ),
     )
-    run_job(_DIST_STEPS[:2] + [stubtest])
+    steps = _DIST_STEPS[:2]
+    if nightly:
+        steps.append(_step.nightly)
+    run_job(steps + [stubtest])

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -29,3 +29,6 @@ pyright_dist = Step(
 stubtest = Step(
     name="Run stubtest to compare the installed stubs against pandas", run=run.stubtest
 )
+nightly = Step(
+    name="Install pandas nightly", run=run.nightly_pandas, rollback=run.released_pandas
+)

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -47,7 +47,7 @@ def build_dist():
 
 def install_dist():
     path = sorted(Path("dist/").glob("pandas_stubs-*.whl"))[-1]
-    cmd = ["pip", "install", "--force-reinstall", str(path)]
+    cmd = [sys.executable, "-m", "pip", "install", "--force-reinstall", str(path)]
     subprocess.run(cmd, check=True)
 
 
@@ -69,7 +69,7 @@ def pyright_dist():
 
 
 def uninstall_dist():
-    cmd = ["pip", "uninstall", "-y", "pandas-stubs"]
+    cmd = [sys.executable, "-m", "pip", "uninstall", "-y", "pandas-stubs"]
     subprocess.run(cmd, check=True)
 
 
@@ -78,3 +78,25 @@ def restore_src():
         Path(r"_pandas-stubs").rename("pandas-stubs")
     else:
         raise FileNotFoundError("'_pandas-stubs' folder does not exists.")
+
+
+def nightly_pandas():
+    cmd = [sys.executable, "-m", "pip", "uninstall", "-y", "pandas"]
+    subprocess.run(cmd, check=True)
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-i",
+        "https://pypi.anaconda.org/scipy-wheels-nightly/simple",
+        "pandas",
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def released_pandas():
+    cmd = [sys.executable, "-m", "pip", "uninstall", "-y", "pandas"]
+    subprocess.run(cmd, check=True)
+    cmd = [sys.executable, "-m", "pip", "install", "pandas"]
+    subprocess.run(cmd, check=True)


### PR DESCRIPTION
`poe stubtest --nightly --check_missing | grep "pandas\._typing"` for #128 @Dr-Irv 

conda nightly seems to have timeout issues: might get one or multiple of these warnings (and could even fail after 4 tries):

> WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='pypi.anaconda.org', port=443): Read timed out. (read timeout=15)")': /scipy-wheels-nightly/simple/pandas/