### PR TITLE
allow dict_items in DataFrame constructor.  Clean up _ListLike

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -98,7 +98,7 @@ SeriesAxisType = Literal["index", 0]  # Restricted subset of _AxisType for serie
 AxisType = Literal["columns", "index", 0, 1]
 DtypeNp = TypeVar("DtypeNp", bound=np.dtype[np.generic])
 KeysArgType = Any
-ListLike = TypeVar("ListLike", Sequence, np.ndarray, "Series")
+ListLike = TypeVar("ListLike", Sequence, np.ndarray, "Series", "Index")
 StrLike = Union[str, np.str_]
 Scalar = Union[
     str,

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1,3 +1,4 @@
+from collections.abc import ItemsView
 import datetime
 import datetime as _dt
 from typing import (
@@ -11,7 +12,6 @@ from typing import (
     Mapping,
     Pattern,
     Sequence,
-    Union,
     overload,
 )
 
@@ -61,6 +61,7 @@ from pandas._typing import (
     IndexType,
     Label,
     Level,
+    ListLike,
     MaskType,
     Renamer,
     Scalar,
@@ -158,19 +159,16 @@ class _LocIndexerFrame(_LocIndexer):
     ) -> None: ...
 
 class DataFrame(NDFrame, OpsMixin):
-    _ListLike = Union[
-        np.ndarray,
-        list[Dtype],
-        dict[_str, np.ndarray],
-        Sequence,
-        Index,
-        Series,
-    ]
+
     __hash__: ClassVar[None]  # type: ignore[assignment]
 
     def __new__(
         cls,
-        data: _ListLike | DataFrame | dict[Any, Any] | None = ...,
+        data: ListLike
+        | DataFrame
+        | dict[Any, Any]
+        | ItemsView[Hashable, ListLike]
+        | None = ...,
         index: Axes | None = ...,
         columns: Axes | None = ...,
         dtype=...,
@@ -377,7 +375,7 @@ class DataFrame(NDFrame, OpsMixin):
         self,
         loc: int,
         column,
-        value: int | _ListLike,
+        value: int | ListLike,
         allow_duplicates: _bool = ...,
     ) -> None: ...
     def assign(self, **kwargs) -> DataFrame: ...
@@ -972,7 +970,7 @@ class DataFrame(NDFrame, OpsMixin):
         | Series
         | dict[Any, Any]
         | Sequence[Scalar]
-        | Sequence[_ListLike],
+        | Sequence[ListLike],
         ignore_index: _bool = ...,
         verify_integrity: _bool = ...,
         sort: _bool = ...,
@@ -1081,7 +1079,7 @@ class DataFrame(NDFrame, OpsMixin):
     def hist(
         self,
         column: _str | list[_str] | None = ...,
-        by: _str | _ListLike | None = ...,
+        by: _str | ListLike | None = ...,
         grid: _bool = ...,
         xlabelsize: int | None = ...,
         xrot: float | None = ...,
@@ -1099,7 +1097,7 @@ class DataFrame(NDFrame, OpsMixin):
     def boxplot(
         self,
         column: _str | list[_str] | None = ...,
-        by: _str | _ListLike | None = ...,
+        by: _str | ListLike | None = ...,
         ax: PlotAxes | None = ...,
         fontsize: float | _str | None = ...,
         rot: int = ...,
@@ -1154,7 +1152,7 @@ class DataFrame(NDFrame, OpsMixin):
     def abs(self) -> DataFrame: ...
     def add(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
@@ -1277,14 +1275,14 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> DataFrame: ...
     def div(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
     ) -> DataFrame: ...
     def divide(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
@@ -1339,7 +1337,7 @@ class DataFrame(NDFrame, OpsMixin):
     def first_valid_index(self) -> Scalar: ...
     def floordiv(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
@@ -1555,21 +1553,21 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> Series: ...
     def mod(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
     ) -> DataFrame: ...
     def mul(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
     ) -> DataFrame: ...
     def multiply(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
@@ -1594,7 +1592,7 @@ class DataFrame(NDFrame, OpsMixin):
     def pop(self, item: _str) -> Series: ...
     def pow(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
@@ -1785,7 +1783,7 @@ class DataFrame(NDFrame, OpsMixin):
         n: int | None = ...,
         frac: float | None = ...,
         replace: _bool = ...,
-        weights: _str | _ListLike | np.ndarray | None = ...,
+        weights: _str | ListLike | None = ...,
         random_state: int | None = ...,
         axis: SeriesAxisType | None = ...,
         ignore_index: _bool = ...,
@@ -1872,14 +1870,14 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> Series: ...
     def sub(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
     ) -> DataFrame: ...
     def subtract(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,
@@ -2089,7 +2087,7 @@ class DataFrame(NDFrame, OpsMixin):
     def to_xarray(self): ...
     def truediv(
         self,
-        other: num | _ListLike | DataFrame,
+        other: num | ListLike | DataFrame,
         axis: AxisType | None = ...,
         level: Level | None = ...,
         fill_value: float | None = ...,

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1,4 +1,3 @@
-from collections.abc import ItemsView
 import datetime
 import datetime as _dt
 from typing import (
@@ -167,7 +166,7 @@ class DataFrame(NDFrame, OpsMixin):
         data: ListLike
         | DataFrame
         | dict[Any, Any]
-        | ItemsView[Hashable, ListLike]
+        | Iterable[tuple[Hashable, ListLike]]
         | None = ...,
         index: Axes | None = ...,
         columns: Axes | None = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1579,3 +1579,9 @@ def test_resample() -> None:
     check(assert_type(df.resample("2T").sem(), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.resample("2T").median(), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.resample("2T").ohlc(), pd.DataFrame), pd.DataFrame)
+
+
+def test_dict_items() -> None:
+    # GH 180
+    x = {"a": [1]}
+    check(assert_type(pd.DataFrame(x.items()), pd.DataFrame), pd.DataFrame)


### PR DESCRIPTION
- [x] Closes #180
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
  - `test_frame.py:test_dict_items()`

Also clean up use of `_ListLike` which was too broad for most of the methods in `frame.pyi`

