### PR TITLE
Allow int and None in DataFrame.loc

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -114,20 +114,20 @@ class _LocIndexerFrame(_LocIndexer):
         self,
         idx: IndexType
         | MaskType
-        | list[StrLike]
+        | list[HashableT]
         | tuple[
             IndexType
             | MaskType
             | slice
-            | list[StrLike]
+            | list[HashableT]
             | tuple[str | int | slice, ...],
-            list[StrLike] | slice | Series[bool] | Callable,
+            list[HashableT] | slice | Series[bool] | Callable,
         ],
     ) -> DataFrame: ...
     @overload
     def __getitem__(
         self,
-        idx: tuple[int | StrLike | tuple[StrLike, ...], StrLike],
+        idx: tuple[int | StrLike | tuple[HashableT, ...], int | StrLike],
     ) -> Scalar: ...
     @overload
     def __getitem__(
@@ -141,19 +141,19 @@ class _LocIndexerFrame(_LocIndexer):
         self,
         idx: MaskType
         | StrLike
-        | tuple[MaskType | Index | Sequence[Scalar] | Scalar | slice, ...],
+        | tuple[MaskType | Index | Sequence[ScalarT] | Scalar | slice, ...],
         value: S1 | ArrayLike | Series | DataFrame,
     ) -> None: ...
     @overload
     def __setitem__(
         self,
-        idx: tuple[tuple[StrLike | Scalar | slice, ...], StrLike],
+        idx: tuple[tuple[HashableT | Scalar | slice, ...], HashableT],
         value: S1 | ArrayLike | Series[S1] | list,
     ) -> None: ...
     @overload
     def __setitem__(
         self,
-        idx: tuple[tuple[StrLike | Scalar | slice, ...], StrLike],
+        idx: tuple[tuple[HashableT | Scalar | slice, ...], HashableT],
         value: S1 | ArrayLike | Series[S1] | list,
     ) -> None: ...
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1579,3 +1579,11 @@ def test_resample() -> None:
     check(assert_type(df.resample("2T").sem(), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.resample("2T").median(), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.resample("2T").ohlc(), pd.DataFrame), pd.DataFrame)
+
+
+def test_loclist() -> None:
+    # GH 189
+    df = pd.DataFrame({1: [1, 2], None: 5})
+
+    check(assert_type(df.loc[:, [None]], pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.loc[:, [1]], pd.DataFrame), pd.DataFrame)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1583,7 +1583,7 @@ def test_resample() -> None:
 
 def test_loclist() -> None:
     # GH 189
-    df = pd.DataFrame({1: [1, 2], None: 5})
+    df = pd.DataFrame({1: [1, 2], None: 5}, columns=pd.Index([1, None], dtype=object))
 
     check(assert_type(df.loc[:, [None]], pd.DataFrame), pd.DataFrame)
     check(assert_type(df.loc[:, [1]], pd.DataFrame), pd.DataFrame)


### PR DESCRIPTION
- [x] Closes #189
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
  - `test_frame.py:test_loclist()`

