### PR TITLE
read_excel accepts PathLike, buffers

### DIFF
--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -10,12 +10,14 @@ from pandas.core.frame import DataFrame
 
 from pandas._typing import (
     Dtype,
+    FilePath,
+    ReadBuffer,
     Scalar,
 )
 
 @overload
 def read_excel(
-    filepath: str,
+    filepath: FilePath | ReadBuffer[bytes] | bytes,
     sheet_name: list[int | str] | None,
     header: int | Sequence[int] | None = ...,
     names: list[str] | None = ...,
@@ -42,7 +44,7 @@ def read_excel(
 ) -> dict[int | str, DataFrame]: ...
 @overload
 def read_excel(
-    filepath: str,
+    filepath: FilePath | ReadBuffer[bytes] | bytes,
     sheet_name: int | str = ...,
     header: int | Sequence[int] | None = ...,
     names: list[str] | None = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1273,20 +1273,20 @@ def test_read_excel() -> None:
 
 def test_read_excel_io_types() -> None:
     df = pd.DataFrame([[1, 2], [8, 9]], columns=["A", "B"])
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as file:
+    with tempfile.NamedTemporaryFile(suffix=".xlsx") as file:
         as_str: str = file.name
         df.to_excel(file.name)
-        file.close()
 
-    pd.read_excel(as_str)
-    as_path = Path(as_str)
-    pd.read_excel(as_path)
+        check(assert_type(pd.read_excel(as_str), pd.DataFrame), pd.DataFrame)
 
-    with as_path.open("rb") as as_file:
-        pd.read_excel(as_file)
+        as_path = Path(as_str)
+        check(assert_type(pd.read_excel(as_path), pd.DataFrame), pd.DataFrame)
 
-    as_bytes = as_path.read_bytes()
-    pd.read_excel(as_bytes)
+        with as_path.open("rb") as as_file:
+            check(assert_type(pd.read_excel(as_file), pd.DataFrame), pd.DataFrame)
+
+        as_bytes = as_path.read_bytes()
+        check(assert_type(pd.read_excel(as_bytes), pd.DataFrame), pd.DataFrame)
 
 
 def test_join() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1277,19 +1277,19 @@ def test_read_excel_io_types() -> None:
     with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as file:
         as_str: str = file.name
         df.to_excel(file)
-    try:
-        check(assert_type(pd.read_excel(as_str), pd.DataFrame), pd.DataFrame)
 
-        as_path = Path(as_str)
-        check(assert_type(pd.read_excel(as_path), pd.DataFrame), pd.DataFrame)
+    check(assert_type(pd.read_excel(as_str), pd.DataFrame), pd.DataFrame)
 
-        with as_path.open("rb") as as_file:
-            check(assert_type(pd.read_excel(as_file), pd.DataFrame), pd.DataFrame)
+    as_path = Path(as_str)
+    check(assert_type(pd.read_excel(as_path), pd.DataFrame), pd.DataFrame)
 
-        as_bytes = as_path.read_bytes()
-        check(assert_type(pd.read_excel(as_bytes), pd.DataFrame), pd.DataFrame)
-    finally:
-        Path(as_str).unlink()
+    with as_path.open("rb") as as_file:
+        check(assert_type(pd.read_excel(as_file), pd.DataFrame), pd.DataFrame)
+
+    as_bytes = as_path.read_bytes()
+    check(assert_type(pd.read_excel(as_bytes), pd.DataFrame), pd.DataFrame)
+
+    Path(as_str).unlink()
 
 
 def test_join() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1271,6 +1271,24 @@ def test_read_excel() -> None:
         df17: dict[int | str, pd.DataFrame] = pd.read_excel("foo", sheet_name=None)
 
 
+def test_read_excel_io_types() -> None:
+    df = pd.DataFrame([[1, 2], [8, 9]], columns=["A", "B"])
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as file:
+        as_str: str = file.name
+        df.to_excel(file.name)
+        file.close()
+    
+    pd.read_excel(as_str)
+    as_path = Path(as_str)
+    pd.read_excel(as_path)
+
+    with as_path.open("rb") as as_file:
+        pd.read_excel(as_file)
+    
+    as_bytes = as_path.read_bytes()
+    pd.read_excel(as_bytes)
+
+
 def test_join() -> None:
     float_frame = pd.DataFrame(getSeriesData())
     # GH 29

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1277,14 +1277,14 @@ def test_read_excel_io_types() -> None:
         as_str: str = file.name
         df.to_excel(file.name)
         file.close()
-    
+
     pd.read_excel(as_str)
     as_path = Path(as_str)
     pd.read_excel(as_path)
 
     with as_path.open("rb") as as_file:
         pd.read_excel(as_file)
-    
+
     as_bytes = as_path.read_bytes()
     pd.read_excel(as_bytes)
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1274,10 +1274,10 @@ def test_read_excel() -> None:
 def test_read_excel_io_types() -> None:
     # GH 195
     df = pd.DataFrame([[1, 2], [8, 9]], columns=["A", "B"])
-    with tempfile.NamedTemporaryFile(suffix=".xlsx") as file:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as file:
         as_str: str = file.name
-        df.to_excel(file.name)
-
+        df.to_excel(file)
+    try:
         check(assert_type(pd.read_excel(as_str), pd.DataFrame), pd.DataFrame)
 
         as_path = Path(as_str)
@@ -1288,6 +1288,8 @@ def test_read_excel_io_types() -> None:
 
         as_bytes = as_path.read_bytes()
         check(assert_type(pd.read_excel(as_bytes), pd.DataFrame), pd.DataFrame)
+    finally:
+        Path(as_str).unlink()
 
 
 def test_join() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1272,6 +1272,7 @@ def test_read_excel() -> None:
 
 
 def test_read_excel_io_types() -> None:
+    # GH 195
     df = pd.DataFrame([[1, 2], [8, 9]], columns=["A", "B"])
     with tempfile.NamedTemporaryFile(suffix=".xlsx") as file:
         as_str: str = file.name


### PR DESCRIPTION
pandas.read_excel is documented to accept

> str, bytes, ExcelFile, xlrd.Book, path object, or file-like object

This expands the annotation to include str, bytes, paths,
and file-likes. Bytes are coerced into a BytesIO inside ExcelReader.

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
