### PR TITLE
Allow strings to crosstab's normalize argument

### DIFF
--- a/pandas-stubs/core/reshape/pivot.pyi
+++ b/pandas-stubs/core/reshape/pivot.pyi
@@ -1,5 +1,6 @@
 from typing import (
     Callable,
+    Literal,
     Sequence,
 )
 
@@ -40,5 +41,5 @@ def crosstab(
     margins: bool = ...,
     margins_name: str = ...,
     dropna: bool = ...,
-    normalize: bool = ...,
+    normalize: bool | Literal["all", "index", "columns"] = ...,
 ) -> DataFrame: ...

--- a/pandas-stubs/core/reshape/pivot.pyi
+++ b/pandas-stubs/core/reshape/pivot.pyi
@@ -41,5 +41,5 @@ def crosstab(
     margins: bool = ...,
     margins_name: str = ...,
     dropna: bool = ...,
-    normalize: bool | Literal["all", "index", "columns"] = ...,
+    normalize: bool | Literal[0, 1, "all", "index", "columns"] = ...,
 ) -> DataFrame: ...

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -271,3 +271,14 @@ def test_unique() -> None:
         ),
         np.ndarray,
     )
+
+
+def test_crosstab() -> None:
+    df = pd.DataFrame({"a": [1, 2, 1, 2], "b": [1, 1, 2, 2]})
+    pd.crosstab(
+        index=df["a"],
+        columns=df["b"],
+        margins=True,
+        dropna=False,
+        normalize="columns",
+    )

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -289,4 +289,3 @@ def test_crosstab() -> None:
         ),
         pd.DataFrame,
     )
-

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -273,12 +273,20 @@ def test_unique() -> None:
     )
 
 
+# GH 200
 def test_crosstab() -> None:
     df = pd.DataFrame({"a": [1, 2, 1, 2], "b": [1, 1, 2, 2]})
-    pd.crosstab(
-        index=df["a"],
-        columns=df["b"],
-        margins=True,
-        dropna=False,
-        normalize="columns",
+    check(
+        assert_type(
+            pd.crosstab(
+                index=df["a"],
+                columns=df["b"],
+                margins=True,
+                dropna=False,
+                normalize="columns",
+            ),
+            pd.DataFrame,
+        ),
+        pd.DataFrame,
     )
+


### PR DESCRIPTION
These are allowed ([docs page](https://pandas.pydata.org/docs/reference/api/pandas.crosstab.html?highlight=crosstab#pandas.crosstab)).