### PR TITLE
Fixed axis and return types for DataFrame.all/any

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1160,7 +1160,6 @@ class DataFrame(NDFrame, OpsMixin):
         axis: None,
         bool_only: _bool | None = ...,
         skipna: _bool = ...,
-        level: None = ...,
         **kwargs,
     ) -> _bool: ...
     @overload
@@ -1169,26 +1168,14 @@ class DataFrame(NDFrame, OpsMixin):
         axis: AxisType = ...,
         bool_only: _bool | None = ...,
         skipna: _bool = ...,
-        level: None = ...,
         **kwargs,
     ) -> Series[_bool]: ...
-    @overload
-    def all(
-        self,
-        axis: AxisType = ...,
-        bool_only: _bool | None = ...,
-        skipna: _bool = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
     @overload
     def any(
         self,
         axis: None,
         bool_only: _bool | None = ...,
         skipna: _bool = ...,
-        level: None = ...,
         **kwargs,
     ) -> _bool: ...
     @overload
@@ -1197,19 +1184,8 @@ class DataFrame(NDFrame, OpsMixin):
         axis: AxisType = ...,
         bool_only: _bool | None = ...,
         skipna: _bool = ...,
-        level: None = ...,
         **kwargs,
     ) -> Series[_bool]: ...
-    @overload
-    def any(
-        self,
-        axis: AxisType = ...,
-        bool_only: _bool = ...,
-        skipna: _bool = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
     def asof(self, where, subset: _str | list[_str] | None = ...) -> DataFrame: ...
     def asfreq(
         self,

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1157,12 +1157,21 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def all(
         self,
+        axis: None,
+        bool_only: _bool | None = ...,
+        skipna: _bool = ...,
+        level: None = ...,
+        **kwargs,
+    ) -> _bool: ...
+    @overload
+    def all(
+        self,
         axis: AxisType = ...,
         bool_only: _bool | None = ...,
         skipna: _bool = ...,
         level: None = ...,
         **kwargs,
-    ) -> Series: ...
+    ) -> Series[_bool]: ...
     @overload
     def all(
         self,
@@ -1176,12 +1185,21 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def any(
         self,
+        axis: None,
+        bool_only: _bool | None = ...,
+        skipna: _bool = ...,
+        level: None = ...,
+        **kwargs,
+    ) -> _bool: ...
+    @overload
+    def any(
+        self,
         axis: AxisType = ...,
         bool_only: _bool | None = ...,
         skipna: _bool = ...,
         level: None = ...,
         **kwargs,
-    ) -> Series: ...
+    ) -> Series[_bool]: ...
     @overload
     def any(
         self,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1248,7 +1248,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         axis: SeriesAxisType = ...,
         bool_only: _bool | None = ...,
         skipna: _bool = ...,
-        level: Level | None = ...,
         **kwargs,
     ) -> _bool: ...
     def any(
@@ -1256,7 +1255,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         axis: SeriesAxisType = ...,
         bool_only: _bool | None = ...,
         skipna: _bool = ...,
-        level: Level | None = ...,
         **kwargs,
     ) -> _bool: ...
     def cummax(

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -44,6 +44,18 @@ def test_types_init() -> None:
     )
 
 
+def test_types_all() -> None:
+    df = pd.DataFrame([[False, True], [False, False]], columns=["col1", "col2"])
+    check(assert_type(df.all(), "pd.Series[bool]"), pd.Series, bool)
+    check(assert_type(df.all(axis=None), bool), np.bool_)
+
+
+def test_types_any() -> None:
+    df = pd.DataFrame([[False, True], [False, False]], columns=["col1", "col2"])
+    check(assert_type(df.any(), "pd.Series[bool]"), pd.Series, bool)
+    check(assert_type(df.any(axis=None), bool), np.bool_)
+
+
 def test_types_append() -> None:
     df = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
     df2 = pd.DataFrame({"col1": [10, 20], "col2": [30, 40]})


### PR DESCRIPTION
- Added the option to pass `None` as `axis` in `DataFrame.all\any`.
- Fixed the return type to be `Series[bool]` instead of just `Series`.