### PR TITLE
Deprecated the level argument

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1392,17 +1392,6 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs,
     ) -> DataFrame: ...
     def keys(self) -> Index: ...
-    @overload
-    def kurt(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def kurt(
         self,
         axis: AxisType | None = ...,
@@ -1411,17 +1400,6 @@ class DataFrame(NDFrame, OpsMixin):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> Series: ...
-    @overload
-    def kurtosis(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def kurtosis(
         self,
         axis: AxisType | None = ...,
@@ -1464,17 +1442,6 @@ class DataFrame(NDFrame, OpsMixin):
         errors: _str = ...,
         try_cast: _bool = ...,
     ) -> DataFrame: ...
-    @overload
-    def max(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def max(
         self,
         axis: AxisType | None = ...,
@@ -1483,17 +1450,6 @@ class DataFrame(NDFrame, OpsMixin):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> Series: ...
-    @overload
-    def mean(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def mean(
         self,
         axis: AxisType | None = ...,
@@ -1502,17 +1458,6 @@ class DataFrame(NDFrame, OpsMixin):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> Series: ...
-    @overload
-    def median(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def median(
         self,
         axis: AxisType | None = ...,
@@ -1521,17 +1466,6 @@ class DataFrame(NDFrame, OpsMixin):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> Series: ...
-    @overload
-    def min(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def min(
         self,
         axis: AxisType | None = ...,
@@ -1586,18 +1520,6 @@ class DataFrame(NDFrame, OpsMixin):
         level: Level | None = ...,
         fill_value: float | None = ...,
     ) -> DataFrame: ...
-    @overload
-    def prod(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        min_count: int = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def prod(
         self,
         axis: AxisType | None = ...,
@@ -1611,11 +1533,11 @@ class DataFrame(NDFrame, OpsMixin):
         self,
         axis: AxisType | None = ...,
         skipna: _bool = ...,
-        level: Level | None = ...,
+        level: None = ...,
         numeric_only: _bool | None = ...,
         min_count: int = ...,
         **kwargs,
-    ) -> DataFrame: ...
+    ) -> Series: ...
     def radd(
         self,
         other,
@@ -1777,18 +1699,6 @@ class DataFrame(NDFrame, OpsMixin):
         axis: SeriesAxisType | None = ...,
         ignore_index: _bool = ...,
     ) -> DataFrame: ...
-    @overload
-    def sem(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        ddof: int = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def sem(
         self,
         axis: AxisType | None = ...,
@@ -1815,17 +1725,6 @@ class DataFrame(NDFrame, OpsMixin):
         axis: AxisType = ...,
         inplace: _bool | None = ...,
     ) -> DataFrame | None: ...
-    @overload
-    def skew(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def skew(
         self,
         axis: AxisType | None = ...,
@@ -1836,18 +1735,6 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> Series: ...
     def slice_shift(self, periods: int = ..., axis: AxisType = ...) -> DataFrame: ...
     def squeeze(self, axis: AxisType | None = ...): ...
-    @overload
-    def std(
-        self,
-        axis: AxisType = ...,
-        skipna: _bool = ...,
-        ddof: int = ...,
-        numeric_only: _bool = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def std(
         self,
         axis: AxisType = ...,
@@ -1871,7 +1758,6 @@ class DataFrame(NDFrame, OpsMixin):
         level: Level | None = ...,
         fill_value: float | None = ...,
     ) -> DataFrame: ...
-    @overload
     def sum(
         self,
         axis: AxisType | None = ...,
@@ -1881,17 +1767,6 @@ class DataFrame(NDFrame, OpsMixin):
         min_count: int = ...,
         **kwargs,
     ) -> Series: ...
-    @overload
-    def sum(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        min_count: int = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
     def swapaxes(
         self, axis1: AxisType, axis2: AxisType, copy: _bool = ...
     ) -> DataFrame: ...
@@ -2105,18 +1980,6 @@ class DataFrame(NDFrame, OpsMixin):
         ambiguous=...,
         nonexistent: _str = ...,
     ) -> DataFrame: ...
-    @overload
-    def var(
-        self,
-        axis: AxisType | None = ...,
-        skipna: _bool | None = ...,
-        ddof: int = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
     def var(
         self,
         axis: AxisType | None = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1326,17 +1326,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         axis: SeriesAxisType = ...,
     ) -> Series[_bool]: ...
     def item(self) -> S1: ...
-    @overload
-    def kurt(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def kurt(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1345,17 +1334,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> Scalar: ...
-    @overload
-    def kurtosis(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level | None,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def kurtosis(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1395,17 +1373,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         level: None = ...,
         **kwargs,
     ) -> Scalar: ...
-    @overload
-    def max(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool = ...,
-        *,
-        level: Level,
-        numeric_only: _bool | None = ...,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def max(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1415,17 +1382,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> S1: ...
-    @overload
-    def mean(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def mean(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1434,17 +1390,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> float: ...
-    @overload
-    def median(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def median(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1453,17 +1398,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> float: ...
-    @overload
-    def min(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def min(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1508,18 +1442,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         fill_value: float | None = ...,
         axis: SeriesAxisType | None = ...,
     ) -> Series[S1]: ...
-    @overload
-    def prod(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        min_count: int = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def prod(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1529,18 +1451,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         min_count: int = ...,
         **kwargs,
     ) -> Scalar: ...
-    @overload
-    def product(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        min_count: int = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def product(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1629,18 +1539,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         fill_value: float | None = ...,
         axis: SeriesAxisType = ...,
     ) -> Series[S1]: ...
-    @overload
-    def sem(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool | None = ...,
-        ddof: int = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def sem(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1650,17 +1548,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> Scalar: ...
-    @overload
-    def skew(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool | None = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def skew(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1669,18 +1556,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         numeric_only: _bool | None = ...,
         **kwargs,
     ) -> Scalar: ...
-    @overload
-    def std(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool | None = ...,
-        ddof: int = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[float]: ...
-    @overload
     def std(
         self,
         axis: SeriesAxisType | None = ...,
@@ -1708,7 +1583,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         self: Series[S1],
         axis: SeriesAxisType | None = ...,
         skipna: _bool | None = ...,
-        level: Level | None = ...,
+        level: None = ...,
         numeric_only: _bool | None = ...,
         min_count: int = ...,
         **kwargs,
@@ -1729,18 +1604,6 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         fill_value: float | None = ...,
         axis: SeriesAxisType = ...,
     ) -> Series[float]: ...
-    @overload
-    def var(
-        self,
-        axis: SeriesAxisType | None = ...,
-        skipna: _bool | None = ...,
-        ddof: int = ...,
-        numeric_only: _bool | None = ...,
-        *,
-        level: Level,
-        **kwargs,
-    ) -> Series[S1]: ...
-    @overload
     def var(
         self,
         axis: SeriesAxisType | None = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -332,6 +332,9 @@ def test_types_mean() -> None:
     df = pd.DataFrame(data={"col1": [2, 1], "col2": [3, 4]})
     s1: pd.Series = df.mean()
     s2: pd.Series = df.mean(axis=0)
+    df2: pd.DataFrame = df.groupby(level=0).mean()
+    df3: pd.DataFrame = df.groupby(axis=1, level=0).mean()
+    df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).mean()
     s3: pd.Series = df.mean(axis=1, skipna=True, numeric_only=False)
 
 
@@ -339,6 +342,9 @@ def test_types_median() -> None:
     df = pd.DataFrame(data={"col1": [2, 1], "col2": [3, 4]})
     s1: pd.Series = df.median()
     s2: pd.Series = df.median(axis=0)
+    df2: pd.DataFrame = df.groupby(level=0).median()
+    df3: pd.DataFrame = df.groupby(axis=1, level=0).median()
+    df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).median()
     s3: pd.Series = df.median(axis=1, skipna=True, numeric_only=False)
 
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -332,12 +332,6 @@ def test_types_mean() -> None:
     df = pd.DataFrame(data={"col1": [2, 1], "col2": [3, 4]})
     s1: pd.Series = df.mean()
     s2: pd.Series = df.mean(axis=0)
-    with pytest.warns(FutureWarning, match="Using the level"):
-        df2: pd.DataFrame = df.mean(level=0)
-    with pytest.warns(FutureWarning, match="Using the level"):
-        df3: pd.DataFrame = df.mean(axis=1, level=0)
-    with pytest.warns(FutureWarning, match="Using the level"):
-        df4: pd.DataFrame = df.mean(1, True, level=0)
     s3: pd.Series = df.mean(axis=1, skipna=True, numeric_only=False)
 
 
@@ -345,12 +339,6 @@ def test_types_median() -> None:
     df = pd.DataFrame(data={"col1": [2, 1], "col2": [3, 4]})
     s1: pd.Series = df.median()
     s2: pd.Series = df.median(axis=0)
-    with pytest.warns(FutureWarning, match="Using the level keyword"):
-        df2: pd.DataFrame = df.median(level=0)
-    with pytest.warns(FutureWarning, match="Using the level keyword"):
-        df3: pd.DataFrame = df.median(axis=1, level=0)
-    with pytest.warns(FutureWarning, match="Using the level keyword"):
-        df4: pd.DataFrame = df.median(1, True, level=0)
     s3: pd.Series = df.median(axis=1, skipna=True, numeric_only=False)
 
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -253,6 +253,7 @@ def test_types_rank() -> None:
 def test_types_mean() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     f1: float = s.mean()
+    s1: pd.Series = s.groupby(level=0).mean()
     f2: float = s.mean(skipna=False)
     f3: float = s.mean(numeric_only=False)
 
@@ -260,6 +261,7 @@ def test_types_mean() -> None:
 def test_types_median() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     f1: float = s.median()
+    s1: pd.Series = s.groupby(level=0).median()
     f2: float = s.median(skipna=False)
     f3: float = s.median(numeric_only=False)
 
@@ -267,6 +269,7 @@ def test_types_median() -> None:
 def test_types_sum() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     s.sum()
+    s.groupby(level=0).sum()
     s.sum(skipna=False)
     s.sum(numeric_only=False)
     s.sum(min_count=4)
@@ -283,6 +286,7 @@ def test_types_min() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     s.min()
     s.min(axis=0)
+    s.groupby(level=0).min()
     s.min(skipna=False)
 
 
@@ -290,6 +294,7 @@ def test_types_max() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     s.max()
     s.max(axis=0)
+    s.groupby(level=0).max()
     s.max(skipna=False)
 
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -253,8 +253,6 @@ def test_types_rank() -> None:
 def test_types_mean() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     f1: float = s.mean()
-    with pytest.warns(FutureWarning, match="Using the level keyword"):
-        s1: pd.Series = s.mean(axis=0, level=0)
     f2: float = s.mean(skipna=False)
     f3: float = s.mean(numeric_only=False)
 
@@ -262,8 +260,6 @@ def test_types_mean() -> None:
 def test_types_median() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     f1: float = s.median()
-    with pytest.warns(FutureWarning, match="Using the level keyword"):
-        s1: pd.Series = s.median(axis=0, level=0)
     f2: float = s.median(skipna=False)
     f3: float = s.median(numeric_only=False)
 
@@ -271,8 +267,6 @@ def test_types_median() -> None:
 def test_types_sum() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     s.sum()
-    with pytest.warns(FutureWarning, match="Using the level keyword"):
-        s.sum(axis=0, level=0)
     s.sum(skipna=False)
     s.sum(numeric_only=False)
     s.sum(min_count=4)
@@ -289,8 +283,6 @@ def test_types_min() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     s.min()
     s.min(axis=0)
-    with pytest.warns(FutureWarning, match="Using the level keyword"):
-        s.min(level=0)
     s.min(skipna=False)
 
 
@@ -298,8 +290,6 @@ def test_types_max() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     s.max()
     s.max(axis=0)
-    with pytest.warns(FutureWarning, match="Using the level keyword"):
-        s.max(level=0)
     s.max(skipna=False)
 
 


### PR DESCRIPTION
Deprecated the `level` argument for several functions, in accordance to the pandas documentation.