### PR TITLE
Seris and DataFrame creation typing

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -178,8 +178,8 @@ class DataFrame(NDFrame, OpsMixin):
         | dict[Any, Any]
         | Iterable[tuple[Hashable, ListLikeU]]
         | None = ...,
-        index: Iterable[Hashable] | None = ...,
-        columns: Iterable[Hashable] | None = ...,
+        index: Axes | None = ...,
+        columns: Axes | None = ...,
         dtype=...,
         copy: _bool = ...,
     ) -> DataFrame: ...
@@ -187,8 +187,8 @@ class DataFrame(NDFrame, OpsMixin):
     def __new__(
         cls,
         data: Scalar,
-        index: Iterable[Hashable],
-        columns: Iterable[Hashable],
+        index: Axes,
+        columns: Axes,
         dtype=...,
         copy: _bool = ...,
     ) -> DataFrame: ...

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -170,6 +170,7 @@ class DataFrame(NDFrame, OpsMixin):
 
     __hash__: ClassVar[None]  # type: ignore[assignment]
 
+    @overload
     def __new__(
         cls,
         data: ListLikeU
@@ -177,8 +178,17 @@ class DataFrame(NDFrame, OpsMixin):
         | dict[Any, Any]
         | Iterable[tuple[Hashable, ListLikeU]]
         | None = ...,
-        index: Axes | None = ...,
-        columns: Axes | None = ...,
+        index: Iterable[Hashable] | None = ...,
+        columns: Iterable[Hashable] | None = ...,
+        dtype=...,
+        copy: _bool = ...,
+    ) -> DataFrame: ...
+    @overload
+    def __new__(
+        cls,
+        data: Scalar,
+        index: Iterable[Hashable],
+        columns: Iterable[Hashable],
         dtype=...,
         copy: _bool = ...,
     ) -> DataFrame: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -159,7 +159,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     def __new__(
         cls,
         data: DatetimeIndex,
-        index: Iterable[Hashable] | None = ...,
+        index: Axes | None = ...,
         dtype=...,
         name: Hashable | None = ...,
         copy: bool = ...,
@@ -169,7 +169,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     def __new__(
         cls,
         data: PeriodIndex,
-        index: Iterable[Hashable] | None = ...,
+        index: Axes | None = ...,
         dtype=...,
         name: Hashable | None = ...,
         copy: bool = ...,
@@ -180,7 +180,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         cls,
         data: object | _ListLike | Series[S1] | dict[int, S1] | dict[_str, S1] | None,
         dtype: type[S1],
-        index: Iterable[Hashable] | None = ...,
+        index: Axes | None = ...,
         name: Hashable | None = ...,
         copy: bool = ...,
         fastpath: bool = ...,
@@ -194,7 +194,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         | dict[int, S1]
         | dict[_str, S1]
         | None = ...,
-        index: Iterable[Hashable] | None = ...,
+        index: Axes | None = ...,
         dtype=...,
         name: Hashable | None = ...,
         copy: bool = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -122,14 +122,14 @@ class _LocIndexerSeries(_LocIndexer, Generic[S1]):
         idx: MaskType
         | Index
         | Sequence[float]
-        | list[_str]
+        | list[str]
         | slice
         | tuple[str | float | slice | Index, ...],
     ) -> Series[S1]: ...
     @overload
     def __getitem__(
         self,
-        idx: _str | float,
+        idx: str | float,
     ) -> S1: ...
     @overload
     def __setitem__(
@@ -159,7 +159,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     def __new__(
         cls,
         data: DatetimeIndex,
-        index: _str | int | Series | list | Index | None = ...,
+        index: Iterable[Hashable] | None = ...,
         dtype=...,
         name: Hashable | None = ...,
         copy: bool = ...,
@@ -169,7 +169,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     def __new__(
         cls,
         data: PeriodIndex,
-        index: _str | int | Series | list | Index | None = ...,
+        index: Iterable[Hashable] | None = ...,
         dtype=...,
         name: Hashable | None = ...,
         copy: bool = ...,
@@ -180,7 +180,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         cls,
         data: object | _ListLike | Series[S1] | dict[int, S1] | dict[_str, S1] | None,
         dtype: type[S1],
-        index: _str | int | Series | list | Index | None = ...,
+        index: Iterable[Hashable] | None = ...,
         name: Hashable | None = ...,
         copy: bool = ...,
         fastpath: bool = ...,
@@ -194,7 +194,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         | dict[int, S1]
         | dict[_str, S1]
         | None = ...,
-        index: _str | int | Series | list | Index | None = ...,
+        index: Iterable[Hashable] | None = ...,
         dtype=...,
         name: Hashable | None = ...,
         copy: bool = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -42,7 +42,10 @@ def test_types_init() -> None:
         dtype=np.int8,
         copy=True,
     )
-    pd.DataFrame(0, index=[0, 1], columns=[0, 1])
+    check(
+        assert_type(pd.DataFrame(0, index=[0, 1], columns=[0, 1]), pd.DataFrame),
+        pd.DataFrame,
+    )
 
 
 def test_types_all() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -42,6 +42,7 @@ def test_types_init() -> None:
         dtype=np.int8,
         copy=True,
     )
+    pd.DataFrame(0, index=[0, 1], columns=[0, 1])
 
 
 def test_types_all() -> None:


### PR DESCRIPTION
* Cleaned up typing on `Series.__new__, DataFrame.__new__`.
* Allowed `DataFrame` to be created from a scalar and index/columns.
