### PR TITLE
unpin poetry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Poetry
-      run: pip install poetry==1.1.15
+      run: pip install poetry
 
     - name: Determine poetry version
       run: echo "::set-output name=VERSION::$(poetry --version)"


### PR DESCRIPTION
We had pinned poetry to 1.1.15 when we were testing the Windows CI issues.  This removes that.
