### PR TITLE
remove types_SQLAlchemy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 types-pytz = ">= 2022.1.1"
-types_SQLAlchemy = ">=1.4.50"
 
 [tool.poetry.dev-dependencies]
 mypy = ">=0.971"


### PR DESCRIPTION
conda-forge build broke because `types_SQLAlchemy` is not a conda package.   Apparently, it is automatically built from whatever is in typeshed.

Removing it to see if it passes CI.

