### PR TITLE
Accept `sqlalchemy.engine.Engine` for SQL IO API (`read_sql`, `to_sql`)

### DIFF
--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -160,7 +160,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
     def to_sql(
         self,
         name: _str,
-        con: str | sqlalchemy.engine.Connection | sqlite3.Connection,
+        con: str | sqlalchemy.engine.Connectable | sqlite3.Connection,
         schema: _str | None = ...,
         if_exists: Literal["fail", "replace", "append"] = ...,
         index: _bool = ...,

--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -23,7 +23,7 @@ class DatabaseError(IOError): ...
 @overload
 def read_sql_table(
     table_name: str,
-    con: str | sqlalchemy.engine.Connection | sqlite3.Connection,
+    con: str | sqlalchemy.engine.Connectable | sqlite3.Connection,
     schema: str | None = ...,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
@@ -35,7 +35,7 @@ def read_sql_table(
 @overload
 def read_sql_table(
     table_name: str,
-    con: str | sqlalchemy.engine.Connection | sqlite3.Connection,
+    con: str | sqlalchemy.engine.Connectable | sqlite3.Connection,
     schema: str | None = ...,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
@@ -46,7 +46,7 @@ def read_sql_table(
 @overload
 def read_sql_query(
     sql: str,
-    con: str | sqlalchemy.engine.Connection | sqlite3.Connection,
+    con: str | sqlalchemy.engine.Connectable | sqlite3.Connection,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
     params: list[str] | tuple[str, ...] | dict[str, str] | None = ...,
@@ -58,7 +58,7 @@ def read_sql_query(
 @overload
 def read_sql_query(
     sql: str,
-    con: str | sqlalchemy.engine.Connection | sqlite3.Connection,
+    con: str | sqlalchemy.engine.Connectable | sqlite3.Connection,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
     params: list[str] | tuple[str, ...] | dict[str, str] | None = ...,
@@ -69,7 +69,7 @@ def read_sql_query(
 @overload
 def read_sql(
     sql: str,
-    con: str | sqlalchemy.engine.Connection | sqlite3.Connection,
+    con: str | sqlalchemy.engine.Connectable | sqlite3.Connection,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
     params: list[str] | tuple[str, ...] | dict[str, str] | None = ...,
@@ -81,7 +81,7 @@ def read_sql(
 @overload
 def read_sql(
     sql: str,
-    con: str | sqlalchemy.engine.Connection | sqlite3.Connection,
+    con: str | sqlalchemy.engine.Connectable | sqlite3.Connection,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
     params: list[str] | tuple[str, ...] | dict[str, str] | None = ...,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ odfpy = ">=1.4.1"
 xarray = ">=22.6.0"
 tabulate = ">=0.8.10"
 scipy = ">=1.9.1"
+SQLAlchemy = "^1.4.41"
 
 
 [build-system]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -43,6 +43,7 @@ from pandas import (
 )
 from pandas._testing import ensure_clean
 import pytest
+import sqlalchemy
 from typing_extensions import assert_type
 
 from tests import check
@@ -690,6 +691,31 @@ def test_read_sql():
             assert_type(read_sql("select * from test", con=con), DataFrame), DataFrame
         )
         con.close()
+
+
+def test_read_sql_via_sqlalchemy_connection():
+    with ensure_clean() as path:
+        db_uri = "sqlite:///" + path
+        engine = sqlalchemy.create_engine(db_uri)
+
+        with engine.connect() as conn:
+            check(assert_type(DF.to_sql("test", con=conn), Union[int, None]), int)
+            check(
+                assert_type(read_sql("select * from test", con=conn), DataFrame),
+                DataFrame,
+            )
+
+
+def test_read_sql_via_sqlalchemy_engine():
+    with ensure_clean() as path:
+        db_uri = "sqlite:///" + path
+        engine = sqlalchemy.create_engine(db_uri)
+
+        check(assert_type(DF.to_sql("test", con=engine), Union[int, None]), int)
+        check(
+            assert_type(read_sql("select * from test", con=engine), DataFrame),
+            DataFrame,
+        )
 
 
 def test_read_sql_generator():


### PR DESCRIPTION
## Outline
The typecheck for sql io api developed in https://github.com/pandas-dev/pandas-stubs/commit/4c97ed3d8be74b6e982889f177dc6228b788e4da does not accept `sqlalchemy.engine.Engine` for the argument `con`. 

However, the original pandas implementation accepts them
* https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_sql.html
* https://pandas.pydata.org/docs/reference/api/pandas.read_sql.html

In fact, `pandasSQL_builder`, which is used in [`to_sql`](https://github.com/pandas-dev/pandas/blob/main/pandas/io/sql.py#L687) and [`read_sql`](https://github.com/pandas-dev/pandas/blob/main/pandas/io/sql.py#L562), requires `sqlalchemy.engine.Connectable` not only `sqlalchemy.engine.Connection`:
https://github.com/pandas-dev/pandas/blob/50c119dce9005cb3e49c0cfb89f396aeecab94f1/pandas/io/sql.py#L757

So, in this PR, I improve the typecheck wider, and introduce testcodes for the case of sqlalchemy connection.
## Check List
- [x] Closes #xxxx (Replace xxxx with the Github issue number)
    - No issues appeared
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

This is my first pull request for this repository, so I apologize if there are any problems. I would appreciate it if you could check it.