### PR TITLE
Fix inclusion of pandas.testing in __init__.pyi

### DIFF
--- a/pandas-stubs/__init__.pyi
+++ b/pandas-stubs/__init__.pyi
@@ -1,5 +1,3 @@
-import pandas.testing as testing
-
 from . import (
     api as api,
     arrays as arrays,


### PR DESCRIPTION
The double-import of `pandas.testing` in `__init__.pyi` breaks detection of this module in pyright. Fixup by removing the unneeded absolute import in favor of the existing relative import used for other submodules.

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
