### PR TITLE
Fix 288 - Add 'cross' as option for MergeHow

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -228,7 +228,7 @@ FillnaOptions = Literal["backfill", "bfill", "ffill", "pad"]
 ReplaceMethod = Literal["pad", "ffill", "bfill"]
 SortKind = Literal["quicksort", "mergesort", "heapsort", "stable"]
 NaPosition = Literal["first", "last"]
-MergeHow = Literal["left", "right", "outer", "inner"]
+MergeHow = Literal["left", "right", "outer", "inner", "cross"]
 JsonFrameOrient = Literal["split", "records", "index", "columns", "values", "table"]
 JsonSeriesOrient = Literal["split", "records", "index"]
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -700,6 +700,7 @@ def test_types_merge() -> None:
     df.merge(df2, on=("col1", "col2"), how="left", suffixes=(None, "s"))
     df.merge(df2, on=("col1", "col2"), how="left", suffixes=("t", "s"))
     df.merge(df2, on=("col1", "col2"), how="left", suffixes=("a", None))
+    df.merge(df2, how="cross")  # gh #289
     columns = ["col1", "col2"]
     df.merge(df2, on=columns)
 


### PR DESCRIPTION
- [x] Closes #288 (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
---

- Add 'cross' as potential value for `MergeHow`
- Add test for `how=cross` (fails without patch)