### PR TITLE
try pinning python 3.10 to 3.10.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10.6']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Because of the bug in `mypy` with python 3.10.7 (see https://github.com/pandas-dev/pandas-stubs/issues/296#issuecomment-1245527765) that has links to various mypy issues on this topic, we need to pin python 3.10 to 3.10.6 in the CI
