### PR TITLE
BUG: Generalize options

### DIFF
--- a/pandas-stubs/_config/config.pyi
+++ b/pandas-stubs/_config/config.pyi
@@ -22,7 +22,157 @@ class DictWrapper:
     def __getattr__(self, key: str) -> str | bool | int | DictWrapper | None: ...
     def __dir__(self) -> Iterable[str]: ...
 
-options: DictWrapper = ...
+class Compute(DictWrapper):
+    use_bottleneck: bool
+    use_numba: bool
+    use_numexpr: bool
+
+class DisplayHTML(DictWrapper):
+    border: int
+    table_schema: bool
+    use_mathjax: bool
+
+class DisplayLaTeX(DictWrapper):
+    escape: bool
+    longtable: bool
+    multicolumn: bool
+    multicolumn_format: str
+    multirow: bool
+    repr: bool
+
+class DisplayUnicode(DictWrapper):
+    ambiguous_as_wide: bool
+    east_asian_width: bool
+
+class Display(DictWrapper):
+    chop_threshold: int | None
+    colheader_justify: str
+    column_space: int
+    date_dayfirst: bool
+    date_yearfirst: bool
+    encoding: str
+    expand_frame_repr: bool
+    float_format: str | None
+    html: DisplayHTML
+    large_repr: str
+    latex: DisplayLaTeX
+    max_categories: int
+    max_columns: int
+    max_colwidth: int
+    max_dir_items: int
+    max_info_columns: int
+    max_info_rows: int
+    max_rows: int
+    max_seq_items: int
+    memory_usage: bool
+    min_rows: int
+    multi_sparse: bool
+    notebook_repr_html: bool
+    pprint_nest_depth: int
+    precision: int
+    show_dimensions: str
+    unicode: DisplayUnicode
+    width: int
+
+class IOExcelODS(DictWrapper):
+    reader: str
+    writer: str
+
+class IOExcelXLS(DictWrapper):
+    writer: str
+
+class IOExcelXLSB(DictWrapper):
+    reader: str
+
+class IOExcelXLSM(DictWrapper):
+    reader: str
+    writer: str
+
+class IOExcelXLSX(DictWrapper):
+    reader: str
+    writer: str
+
+class IOExcel(DictWrapper):
+    ods: IOExcelODS
+    xls: DictWrapper
+    xlsb: DictWrapper
+    xlsm: DictWrapper
+    xlsx: DictWrapper
+
+class IOHDF(DictWrapper):
+    default_format: Literal["table", "fixed"] | None
+    dropna_table: bool
+
+class IOParquet(DictWrapper):
+    engine: str
+
+class IOSQL(DictWrapper):
+    engine: str
+
+class IO(DictWrapper):
+    excel: IOExcel
+    hdf: IOHDF
+    parquet: IOParquet
+    sql: IOSQL
+
+class Mode(DictWrapper):
+    chained_assignment: str
+    data_manager: str
+    sim_interactive: bool
+    string_storage: str
+    use_inf_as_na: bool
+
+class PlottingMatplotlib(DictWrapper):
+    register_converters: str
+
+class Plotting(DictWrapper):
+    backend: str
+    matplotlib: PlottingMatplotlib
+
+class StylerFormat:
+    decimal: str
+    escape: str | None
+    formatter: str | None
+    na_rep: str | None
+    precision: int
+    thousands: str | None
+
+class StylerHTML:
+    mathjax: bool
+
+class StylerLatex:
+    environment: str | None
+    hrules: bool
+    multicol_align: str
+    multirow_align: str
+
+class StylerRender:
+    encoding: str
+    max_columns: int | None
+    max_elements: int
+    max_rows: int | None
+    repr: str
+
+class StylerSparse:
+    columns: bool
+    index: bool
+
+class Styler(DictWrapper):
+    format: StylerFormat
+    html: StylerHTML
+    latex: StylerLatex
+    render: StylerRender
+    sparse: StylerSparse
+
+class Options(DictWrapper):
+    compute: Compute
+    display: Display
+    io: IO
+    mode: Mode
+    plotting: Plotting
+    styler: Styler
+
+options: Options
 
 class option_context(ContextDecorator):
     def __init__(self, /, pat: str, val: Any, *args: Any) -> None: ...

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Union,
 )
 
 import pandas as pd
@@ -10,17 +10,29 @@ from pandas._config.config import DictWrapper
 
 from tests import check
 
+if TYPE_CHECKING:
+    from pandas._config.config import (
+        Display,
+        Options,
+    )
+else:
+    Display = Options = Any
+
 
 def test_option_tools():
     check(assert_type(pd.reset_option("display.width"), None), type(None))
     check(assert_type(pd.set_option("display.width", 80), None), type(None))
     check(assert_type(pd.describe_option("display.width", False), str), str)
     check(assert_type(pd.describe_option("display.width", True), None), type(None))
-    check(assert_type(pd.options, DictWrapper), DictWrapper)
-    check(
-        assert_type(pd.options.display, Union[str, bool, int, None, DictWrapper]),
-        DictWrapper,
-    )
+    check(assert_type(pd.options, Options), DictWrapper)
+    check(assert_type(pd.options.display, Display), DictWrapper)
     check(assert_type(pd.get_option("display.width"), Any), int)
     with pd.option_context("display.width", 120):
         assert pd.get_option("display.width") == 120
+
+
+def test_specific_option():
+    # GH 294
+    check(assert_type(pd.options.plotting.backend, str), str)
+    # Just check assignment
+    pd.options.plotting.backend = "plotly"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,4 +35,4 @@ def test_specific_option():
     # GH 294
     check(assert_type(pd.options.plotting.backend, str), str)
     # Just check assignment
-    pd.options.plotting.backend = "plotly"
+    pd.options.plotting.backend = "matplotlib"


### PR DESCRIPTION
Generalize using specific classes for each level

- [x] Closes #294
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
