### PR TITLE
Add accessors for TimedeltaIndex

### DIFF
--- a/pandas-stubs/core/arrays/datetimes.pyi
+++ b/pandas-stubs/core/arrays/datetimes.pyi
@@ -1,13 +1,17 @@
 from datetime import tzinfo
 
 import numpy as np
-from pandas.core.arrays import datetimelike as dtl
+from pandas.core.arrays.datetimelike import (
+    DatelikeOps,
+    DatetimeLikeArrayMixin,
+    TimelikeOps,
+)
 
 from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtype
 
 def tz_to_dtype(tz): ...
 
-class DatetimeArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps, dtl.DatelikeOps):
+class DatetimeArray(DatetimeLikeArrayMixin, TimelikeOps, DatelikeOps):
     __array_priority__: int = ...
     def __init__(self, values, dtype=..., freq=..., copy: bool = ...) -> None: ...
     # ignore in dtype() is from the pandas source

--- a/pandas-stubs/core/arrays/period.pyi
+++ b/pandas-stubs/core/arrays/period.pyi
@@ -1,14 +1,17 @@
 from typing import Sequence
 
 import numpy as np
-from pandas.core.arrays import datetimelike as dtl
+from pandas.core.arrays.datetimelike import (
+    DatelikeOps,
+    DatetimeLikeArrayMixin,
+)
 
 from pandas._libs.tslibs import Timestamp
 from pandas._libs.tslibs.period import Period as Period
 
 from pandas.tseries.offsets import Tick as Tick
 
-class PeriodArray(dtl.DatetimeLikeArrayMixin, dtl.DatelikeOps):
+class PeriodArray(DatetimeLikeArrayMixin, DatelikeOps):
     __array_priority__: int = ...
     def __init__(self, values, freq=..., dtype=..., copy: bool = ...) -> None: ...
     def dtype(self): ...

--- a/pandas-stubs/core/arrays/timedeltas.pyi
+++ b/pandas-stubs/core/arrays/timedeltas.pyi
@@ -1,9 +1,12 @@
 from datetime import timedelta
 from typing import Sequence
 
-from pandas.core.arrays import datetimelike as dtl
+from pandas.core.arrays.datetimelike import (
+    DatetimeLikeArrayMixin,
+    TimelikeOps,
+)
 
-class TimedeltaArray(dtl.DatetimeLikeArrayMixin, dtl.TimelikeOps):
+class TimedeltaArray(DatetimeLikeArrayMixin, TimelikeOps):
     __array_priority__: int = ...
     @property
     def dtype(self): ...

--- a/pandas-stubs/core/indexes/accessors.pyi
+++ b/pandas-stubs/core/indexes/accessors.pyi
@@ -13,6 +13,7 @@ from pandas import (
     Index,
     PeriodIndex,
     Timedelta,
+    TimedeltaIndex,
 )
 from pandas.core.accessor import PandasDelegate
 from pandas.core.arrays import (
@@ -156,6 +157,7 @@ _DTRoundingMethodReturnType = TypeVar(
     TimedeltaSeries,
     TimestampSeries,
     DatetimeIndex,
+    # TimedeltaIndex
 )
 
 class _DatetimeRoundingMethods(Generic[_DTRoundingMethodReturnType]):
@@ -278,23 +280,30 @@ class DatetimeProperties(
     def to_pydatetime(self) -> np.ndarray: ...
     def isocalendar(self) -> DataFrame: ...
 
-class _TimedeltaPropertiesNoRounding:
+_TDNoRoundingMethodReturnType = TypeVar(
+    "_TDNoRoundingMethodReturnType", Series[int], Index
+)
+_TDTotalSecondsReturnType = TypeVar("_TDTotalSecondsReturnType", Series[float], Index)
+
+class _TimedeltaPropertiesNoRounding(
+    Generic[_TDNoRoundingMethodReturnType, _TDTotalSecondsReturnType]
+):
     def to_pytimedelta(self) -> np.ndarray: ...
     @property
     def components(self) -> DataFrame: ...
     @property
-    def days(self) -> Series[int]: ...
+    def days(self) -> _TDNoRoundingMethodReturnType: ...
     @property
-    def seconds(self) -> Series[int]: ...
+    def seconds(self) -> _TDNoRoundingMethodReturnType: ...
     @property
-    def microseconds(self) -> Series[int]: ...
+    def microseconds(self) -> _TDNoRoundingMethodReturnType: ...
     @property
-    def nanoseconds(self) -> Series[int]: ...
-    def total_seconds(self) -> Series[float]: ...
+    def nanoseconds(self) -> _TDNoRoundingMethodReturnType: ...
+    def total_seconds(self) -> _TDTotalSecondsReturnType: ...
 
 class TimedeltaProperties(
     Properties,
-    _TimedeltaPropertiesNoRounding,
+    _TimedeltaPropertiesNoRounding[Series[int], Series[float]],
     _DatetimeRoundingMethods[TimedeltaSeries],
 ): ...
 
@@ -337,7 +346,7 @@ class CombinedDatetimelikeProperties(
         Series[str],
         PeriodSeries,
     ],
-    _TimedeltaPropertiesNoRounding,
+    _TimedeltaPropertiesNoRounding[Series[int], Series[float]],
     _PeriodProperties,
 ):
     def __new__(cls, data: Series): ...
@@ -379,3 +388,32 @@ class DatetimeIndexProperties(
     def std(
         self, axis: int | None = ..., ddof: int = ..., skipna: bool = ...
     ) -> Timedelta: ...
+
+# For some reason, using TimedeltaIndex as an argument to _DatetimeRoundingMethods
+# doesn't work for pyright.  So we just make the rounding methods explicit here.
+class TimedeltaIndexProperties(
+    Properties,
+    _TimedeltaPropertiesNoRounding[Index, Index],
+    # _DatetimeRoundingMethods[TimedeltaIndex],
+):
+    def round(
+        self,
+        freq: str | BaseOffset | None,
+        ambiguous: Literal["raise", "infer", "NaT"] | np_ndarray_bool = ...,
+        nonexistent: Literal["shift_forward", "shift_backward", "NaT", "raise"]
+        | Timedelta = ...,
+    ) -> TimedeltaIndex: ...
+    def floor(
+        self,
+        freq: str | BaseOffset | None,
+        ambiguous: Literal["raise", "infer", "NaT"] | np_ndarray_bool = ...,
+        nonexistent: Literal["shift_forward", "shift_backward", "NaT", "raise"]
+        | Timedelta = ...,
+    ) -> TimedeltaIndex: ...
+    def ceil(
+        self,
+        freq: str | BaseOffset | None,
+        ambiguous: Literal["raise", "infer", "NaT"] | np_ndarray_bool = ...,
+        nonexistent: Literal["shift_forward", "shift_backward", "NaT", "raise"]
+        | Timedelta = ...,
+    ) -> TimedeltaIndex: ...

--- a/pandas-stubs/core/indexes/datetimes.pyi
+++ b/pandas-stubs/core/indexes/datetimes.pyi
@@ -5,12 +5,12 @@ import numpy as np
 from pandas import (
     DataFrame,
     Timedelta,
+    TimedeltaIndex,
     Timestamp,
 )
 from pandas.core.indexes.accessors import DatetimeIndexProperties
 from pandas.core.indexes.api import Float64Index
 from pandas.core.indexes.datetimelike import DatetimeTimedeltaMixin
-from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.series import (
     TimedeltaSeries,
     TimestampSeries,

--- a/pandas-stubs/core/indexes/timedeltas.pyi
+++ b/pandas-stubs/core/indexes/timedeltas.pyi
@@ -1,6 +1,6 @@
 from typing import overload
 
-from pandas.core.arrays.datetimelike import TimelikeOps
+from pandas.core.indexes.accessors import TimedeltaIndexProperties
 from pandas.core.indexes.datetimelike import DatetimeTimedeltaMixin
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.series import TimedeltaSeries
@@ -11,7 +11,7 @@ from pandas._libs import (
 )
 from pandas._typing import num
 
-class TimedeltaIndex(DatetimeTimedeltaMixin, TimelikeOps):
+class TimedeltaIndex(DatetimeTimedeltaMixin, TimedeltaIndexProperties):
     def __new__(
         cls,
         data=...,

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -436,6 +436,26 @@ def test_datetimeindex_accessors() -> None:
     check(assert_type(i0.is_normalized, bool), bool)
 
 
+def test_timedeltaindex_accessors() -> None:
+    # GH 292
+    i0 = pd.date_range("1/1/2021", "1/5/2021") - pd.Timestamp("1/3/2019")
+    check(assert_type(i0, pd.TimedeltaIndex), pd.TimedeltaIndex)
+    check(assert_type(i0.days, pd.Index), pd.Index, int)
+    check(assert_type(i0.seconds, pd.Index), pd.Index, int)
+    check(assert_type(i0.microseconds, pd.Index), pd.Index, int)
+    check(assert_type(i0.nanoseconds, pd.Index), pd.Index, int)
+    check(assert_type(i0.components, pd.DataFrame), pd.DataFrame)
+    check(assert_type(i0.to_pytimedelta(), np.ndarray), np.ndarray)
+    check(assert_type(i0.total_seconds(), pd.Index), pd.Index, float)
+    check(
+        assert_type(i0.round("D"), pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta
+    )
+    check(
+        assert_type(i0.floor("D"), pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta
+    )
+    check(assert_type(i0.ceil("D"), pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+
 def test_some_offsets() -> None:
     # GH 222
 


### PR DESCRIPTION
- [x] Closes #292 
- [x] Tests added:
    - `test_timefuncs.py:test_timedeltaindex_accessors()`

Notes:
1. For some reason, I couldn't use the existing classes to hook in the rounding methods, so had to duplicate them for `TimedeltaIndex`.  Maybe it is because `DatetimeIndex` and `TimedeltaIndex` have a common base class.  In `_DTRoundingMethodReturnType`, just changing the order of `DatetimeIndex` and `TimedeltaIndex` causes different failures with pyright.  Maybe doing `Generic[SomeTypeVar]` doesn't work if the classes for `SomeTypeVar` share some common base class.  mypy was OK with doing things this way.
2. Adding this feature caused mypy to complain about using `dtl` to represent a module in some of the array classes, so I removed it and explicitly imported the classes.


