### PR TITLE
ENH: Allow TextClause

### DIFF
--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -28,6 +28,10 @@ _SQLConnection = Union[
     sqlite3.Connection,
 ]
 
+_SQLStatement = Union[
+    str, sqlalchemy.sql.expression.Selectable, sqlalchemy.sql.expression.TextClause
+]
+
 @overload
 def read_sql_table(
     table_name: str,
@@ -53,7 +57,7 @@ def read_sql_table(
 ) -> DataFrame: ...
 @overload
 def read_sql_query(
-    sql: str | sqlalchemy.sql.expression.Selectable,
+    sql: _SQLStatement,
     con: _SQLConnection,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
@@ -65,7 +69,7 @@ def read_sql_query(
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql_query(
-    sql: str | sqlalchemy.sql.expression.Selectable,
+    sql: _SQLStatement,
     con: _SQLConnection,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
@@ -76,7 +80,7 @@ def read_sql_query(
 ) -> DataFrame: ...
 @overload
 def read_sql(
-    sql: str | sqlalchemy.sql.expression.Selectable,
+    sql: _SQLStatement,
     con: _SQLConnection,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,
@@ -88,7 +92,7 @@ def read_sql(
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql(
-    sql: str | sqlalchemy.sql.expression.Selectable,
+    sql: _SQLStatement,
     con: _SQLConnection,
     index_col: str | list[str] | None = ...,
     coerce_float: bool = ...,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -819,3 +819,16 @@ def test_sqlalchemy_selectable() -> None:
                 pd.read_sql(
                     session.query(Temp.quantity).statement, session.connection()
                 )
+
+
+def test_sqlalchemy_text() -> None:
+    with ensure_clean() as path:
+        db_uri = "sqlite:///" + path
+        engine = sqlalchemy.create_engine(db_uri)
+        sql_select = sqlalchemy.text("select * from test")
+        with engine.connect() as conn:
+            check(assert_type(DF.to_sql("test", con=conn), Union[int, None]), int)
+            check(
+                assert_type(read_sql(sql_select, con=conn), DataFrame),
+                DataFrame,
+            )


### PR DESCRIPTION
Allow sqlalchemy TextClause for sql select statements

- [X] Tests added: Please use `assert_type()` to assert the type of any return value
