### PR TITLE
Allow datetime values to be subtracted from a Series to create a TimedeltaSeries

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1,5 +1,6 @@
 from datetime import (
     date,
+    datetime,
     time,
 )
 from typing import (
@@ -1218,7 +1219,9 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     def __rtruediv__(self, other: num | _ListLike | Series[S1]) -> Series: ...
     def __rxor__(self, other: num | _ListLike | Series[S1]) -> Series[_bool]: ...
     @overload
-    def __sub__(self, other: Timestamp | TimestampSeries) -> TimedeltaSeries: ...
+    def __sub__(
+        self, other: Timestamp | datetime | TimestampSeries
+    ) -> TimedeltaSeries: ...
     @overload
     def __sub__(
         self, other: Timedelta | TimedeltaSeries | TimedeltaIndex

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -120,8 +120,6 @@ def test_timedelta_series_arithmetic() -> None:
 
 
 def test_timestamp_timedelta_series_arithmetic() -> None:
-    ts = pd.Timestamp("2022-03-05")
-    s1 = pd.Series(["2022-03-05", "2022-03-06"])
     ts1 = pd.to_datetime(pd.Series(["2022-03-05", "2022-03-06"]))
     assert isinstance(ts1.iloc[0], pd.Timestamp)
     td1 = pd.to_timedelta([2, 3], "seconds")
@@ -140,6 +138,13 @@ def test_timestamp_timedelta_series_arithmetic() -> None:
     check(assert_type(r5, "TimedeltaSeries"), pd.Series, pd.Timedelta)
     r6 = r1 * 4
     check(assert_type(r6, "TimedeltaSeries"), pd.Series, pd.Timedelta)
+
+    tsp1 = pd.Timestamp("2022-03-05")
+    dt1 = dt.datetime(2022, 9, 1, 12, 5, 30)
+    r7 = ts1 - tsp1
+    check(assert_type(r7, "TimedeltaSeries"), pd.Series, pd.Timedelta)
+    r8 = ts1 - dt1
+    check(assert_type(r8, "TimedeltaSeries"), pd.Series, pd.Timedelta)
 
 
 def test_timestamp_dateoffset_arithmetic() -> None:


### PR DESCRIPTION
- [X] Tests added: Please use `assert_type()` to assert the type of any return value

```
In [2]: import pandas as pd
   ...: from datetime import datetime
   ...: s = pd.Series(pd.date_range("1/1/2020", "2/1/2020"))
   ...: s - datetime.now()
Out[2]: 
0    -995 days +02:03:18.373842
1    -994 days +02:03:18.373842
2    -993 days +02:03:18.373842
3    -992 days +02:03:18.373842
4    -991 days +02:03:18.373842
5    -990 days +02:03:18.373842
6    -989 days +02:03:18.373842
7    -988 days +02:03:18.373842
8    -987 days +02:03:18.373842
9    -986 days +02:03:18.373842
10   -985 days +02:03:18.373842
11   -984 days +02:03:18.373842
12   -983 days +02:03:18.373842
13   -982 days +02:03:18.373842
14   -981 days +02:03:18.373842
15   -980 days +02:03:18.373842
16   -979 days +02:03:18.373842
17   -978 days +02:03:18.373842
18   -977 days +02:03:18.373842
19   -976 days +02:03:18.373842
20   -975 days +02:03:18.373842
21   -974 days +02:03:18.373842
22   -973 days +02:03:18.373842
23   -972 days +02:03:18.373842
24   -971 days +02:03:18.373842
25   -970 days +02:03:18.373842
26   -969 days +02:03:18.373842
27   -968 days +02:03:18.373842
28   -967 days +02:03:18.373842
29   -966 days +02:03:18.373842
30   -965 days +02:03:18.373842
31   -964 days +02:03:18.373842
dtype: timedelta64[ns]
```