### PR TITLE
Turn isna() and notna() into TypeGuards

### DIFF
--- a/pandas-stubs/core/dtypes/missing.pyi
+++ b/pandas-stubs/core/dtypes/missing.pyi
@@ -1,7 +1,4 @@
-from typing import (
-    Literal,
-    overload,
-)
+from typing import overload
 
 import numpy as np
 from numpy import typing as npt
@@ -10,12 +7,14 @@ from pandas import (
     Index,
     Series,
 )
+from typing_extensions import TypeGuard
 
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs import NaTType
 from pandas._typing import (
     ArrayLike,
     Scalar,
+    ScalarT,
 )
 
 isposinf_scalar = ...
@@ -28,9 +27,9 @@ def isna(obj: Series) -> Series[bool]: ...
 @overload
 def isna(obj: Index | list | ArrayLike) -> npt.NDArray[np.bool_]: ...
 @overload
-def isna(obj: Scalar) -> bool: ...
-@overload
-def isna(obj: NaTType | NAType | None) -> Literal[True]: ...
+def isna(
+    obj: Scalar | NaTType | NAType | None,
+) -> TypeGuard[NaTType | NAType | None]: ...
 
 isnull = isna
 
@@ -41,8 +40,6 @@ def notna(obj: Series) -> Series[bool]: ...
 @overload
 def notna(obj: Index | list | ArrayLike) -> npt.NDArray[np.bool_]: ...
 @overload
-def notna(obj: Scalar) -> bool: ...
-@overload
-def notna(obj: NaTType | NAType | None) -> Literal[False]: ...
+def notna(obj: ScalarT | NaTType | NAType | None) -> TypeGuard[ScalarT]: ...
 
 notnull = notna

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -256,8 +256,8 @@ def test_isna() -> None:
     assert check(assert_type(pd.isna(None), bool), bool)
     assert not check(assert_type(pd.notna(None), bool), bool)
 
-    check(assert_type(pd.isna(2.5), bool), bool)
-    check(assert_type(pd.notna(2.5), bool), bool)
+    assert not check(assert_type(pd.isna(2.5), bool), bool)
+    assert check(assert_type(pd.notna(2.5), bool), bool)
 
     # Check type guard functionality
     nullable1 = random.choice(["value", None, pd.NA, pd.NaT])

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -259,29 +259,56 @@ def test_isna() -> None:
     assert not check(assert_type(pd.isna(2.5), bool), bool)
     assert check(assert_type(pd.notna(2.5), bool), bool)
 
-    # Check type guard functionality
+    # Check TypeGuard type narrowing functionality
+    # TODO: Due to limitations in TypeGuard spec, the true annotations are not always viable
+    # and as a result the type narrowing does not always work as it intuitively should
+    # There is a proposal being floated for a StrictTypeGuard that will have more rigid narrowing semantics
+    # In the test cases below, a commented out assertion will be included to document the optimal test result
     nullable1 = random.choice(["value", None, pd.NA, pd.NaT])
     if pd.notna(nullable1):
         check(assert_type(nullable1, str), str)
+    if not pd.isna(nullable1):
+        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
+        # check(assert_type(nullable1, str), str)
+        check(assert_type(nullable1, Union[str, NaTType, NAType, None]), str)
     if pd.isna(nullable1):
         assert_type(nullable1, Union[NaTType, NAType, None])
+    if not pd.notna(nullable1):
+        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
+        # assert_type(nullable1, Union[NaTType, NAType, None])
+        assert_type(nullable1, Union[str, NaTType, NAType, None])
 
     nullable2 = random.choice([2, None])
     if pd.notna(nullable2):
         check(assert_type(nullable2, int), int)
+    if not pd.isna(nullable2):
+        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
+        # check(assert_type(nullable2, int), int)
+        check(assert_type(nullable2, Union[int, None]), int)
     if pd.isna(nullable2):
-        # TODO: Due to limitations in TypeGuard spec, the true annotation is not viable at this time
-        # There is a proposal being floated for a StrictTypeGuard that will have more rigid narrowing semantics
-        # assert_type(nullable2, None)
-        assert_type(nullable2, Union[NaTType, NAType, None])
+        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
+        # check(assert_type(nullable2, None), type(None))
+        check(assert_type(nullable2, Union[NaTType, NAType, None]), type(None))
+    if not pd.notna(nullable2):
+        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
+        # check(assert_type(nullable2, None), type(None))
+        assert_type(nullable2, Union[int, NaTType, NAType, None])
 
-    nullable3 = random.choice([2, None, pd.NA])
+    nullable3 = random.choice([True, None, pd.NA])
     if pd.notna(nullable3):
-        check(assert_type(nullable3, int), int)
+        check(assert_type(nullable3, bool), bool)
+    if not pd.isna(nullable3):
+        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
+        # check(assert_type(nullable3, bool), bool)
+        check(assert_type(nullable3, Union[bool, NAType, None]), bool)
     if pd.isna(nullable3):
-        # TODO: See comment above about the limitations of TypeGuard
+        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
         # assert_type(nullable3, Union[NAType, None])
         assert_type(nullable3, Union[NaTType, NAType, None])
+    if not pd.notna(nullable3):
+        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
+        # assert_type(nullable3, Union[NAType, None])
+        assert_type(nullable3, Union[bool, NaTType, NAType, None])
 
 
 # GH 55

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -268,53 +268,49 @@ def test_isna() -> None:
     if pd.notna(nullable1):
         check(assert_type(nullable1, str), str)
     if not pd.isna(nullable1):
-        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
-        # check(assert_type(nullable1, str), str)
+        # check(assert_type(nullable1, str), str)  # TODO: Desired result (see comments above)
         check(assert_type(nullable1, Union[str, NaTType, NAType, None]), str)
     if pd.isna(nullable1):
         assert_type(nullable1, Union[NaTType, NAType, None])
     if not pd.notna(nullable1):
-        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
-        # assert_type(nullable1, Union[NaTType, NAType, None])
+        # assert_type(nullable1, Union[NaTType, NAType, None])  # TODO: Desired result (see comments above)
         assert_type(nullable1, Union[str, NaTType, NAType, None])
 
     nullable2 = random.choice([2, None])
     if pd.notna(nullable2):
         check(assert_type(nullable2, int), int)
     if not pd.isna(nullable2):
-        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
-        # check(assert_type(nullable2, int), int)
+        # check(assert_type(nullable2, int), int)  # TODO: Desired result (see comments above)
         check(assert_type(nullable2, Union[int, None]), int)
     if pd.isna(nullable2):
-        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
-        # check(assert_type(nullable2, None), type(None))
+        # check(assert_type(nullable2, None), type(None))  # TODO: Desired result (see comments above)
         check(assert_type(nullable2, Union[NaTType, NAType, None]), type(None))
     if not pd.notna(nullable2):
-        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
-        # check(assert_type(nullable2, None), type(None))
-        assert_type(nullable2, Union[int, None])  # TODO: MyPy result
-        assert_type(
-            nullable2, Union[int, NaTType, NAType, None]
-        )  # TODO: Pyright result
+        # check(assert_type(nullable2, None), type(None))  # TODO: Desired result (see comments above)
+        # TODO: MyPy and Pyright produce conflicting results:
+        # assert_type(nullable2, Union[int, None])  # MyPy result
+        # assert_type(
+        #     nullable2, Union[int, NaTType, NAType, None]
+        # )  # Pyright result
+        pass
 
     nullable3 = random.choice([True, None, pd.NA])
     if pd.notna(nullable3):
         check(assert_type(nullable3, bool), bool)
     if not pd.isna(nullable3):
-        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
-        # check(assert_type(nullable3, bool), bool)
+        # check(assert_type(nullable3, bool), bool)  # TODO: Desired result (see comments above)
         check(assert_type(nullable3, Union[bool, NAType, None]), bool)
     if pd.isna(nullable3):
-        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
-        # assert_type(nullable3, Union[NAType, None])
+        # assert_type(nullable3, Union[NAType, None])  # TODO: Desired result (see comments above)
         assert_type(nullable3, Union[NaTType, NAType, None])
     if not pd.notna(nullable3):
-        # TODO: This is the true type (see comments above on the limitations of TypeGuard)
-        # assert_type(nullable3, Union[NAType, None])
-        assert_type(nullable3, Union[bool, NAType, None])  # TODO: Mypy result
-        assert_type(
-            nullable3, Union[bool, NaTType, NAType, None]
-        )  # TODO: Pyright result
+        # assert_type(nullable3, Union[NAType, None])  # TODO: Desired result (see comments above)
+        # TODO: MyPy and Pyright produce conflicting results:
+        # assert_type(nullable3, Union[bool, NAType, None])  # Mypy result
+        # assert_type(
+        #     nullable3, Union[bool, NaTType, NAType, None]
+        # )  # Pyright result
+        pass
 
 
 # GH 55

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -264,7 +264,9 @@ def test_isna() -> None:
     # and as a result the type narrowing does not always work as it intuitively should
     # There is a proposal being floated for a StrictTypeGuard that will have more rigid narrowing semantics
     # In the test cases below, a commented out assertion will be included to document the optimal test result
-    nullable1 = random.choice(["value", None, pd.NA, pd.NaT])
+    nullable1: str | None | NAType | NaTType = random.choice(
+        ["value", None, pd.NA, pd.NaT]
+    )
     if pd.notna(nullable1):
         check(assert_type(nullable1, str), str)
     if not pd.isna(nullable1):
@@ -276,7 +278,7 @@ def test_isna() -> None:
         # assert_type(nullable1, Union[NaTType, NAType, None])  # TODO: Desired result (see comments above)
         assert_type(nullable1, Union[str, NaTType, NAType, None])
 
-    nullable2 = random.choice([2, None])
+    nullable2: int | None = random.choice([2, None])
     if pd.notna(nullable2):
         check(assert_type(nullable2, int), int)
     if not pd.isna(nullable2):
@@ -294,7 +296,7 @@ def test_isna() -> None:
         # )  # Pyright result
         pass
 
-    nullable3 = random.choice([True, None, pd.NA])
+    nullable3: bool | None | NAType = random.choice([True, None, pd.NA])
     if pd.notna(nullable3):
         check(assert_type(nullable3, bool), bool)
     if not pd.isna(nullable3):

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -292,7 +292,10 @@ def test_isna() -> None:
     if not pd.notna(nullable2):
         # TODO: This is the true type (see comments above on the limitations of TypeGuard)
         # check(assert_type(nullable2, None), type(None))
-        assert_type(nullable2, Union[int, NaTType, NAType, None])
+        assert_type(nullable2, Union[int, None])  # TODO: MyPy result
+        assert_type(
+            nullable2, Union[int, NaTType, NAType, None]
+        )  # TODO: Pyright result
 
     nullable3 = random.choice([True, None, pd.NA])
     if pd.notna(nullable3):
@@ -308,7 +311,10 @@ def test_isna() -> None:
     if not pd.notna(nullable3):
         # TODO: This is the true type (see comments above on the limitations of TypeGuard)
         # assert_type(nullable3, Union[NAType, None])
-        assert_type(nullable3, Union[bool, NaTType, NAType, None])
+        assert_type(nullable3, Union[bool, NAType, None])  # TODO: Mypy result
+        assert_type(
+            nullable3, Union[bool, NaTType, NAType, None]
+        )  # TODO: Pyright result
 
 
 # GH 55


### PR DESCRIPTION
- [X] Tests added: Please use `assert_type()` to assert the type of any return value

Putting up a draft first because I actually am not quite sure what the best way to go about this is. I wrote the tests first, as to what the behavior intuitively should be, but getting the annotations to match is the challenging part.

Further, I'm still not perfectly happy with these annotations, because I have seen tons of code use `pd.isnull` on any random object, and the annotations currently do not support this, they only really allow `pandas` objects and a curated list of `Scalar` objects.
