### PR TITLE
Permit generators (and any Iterable) in DataFrame initializer

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -188,7 +188,7 @@ class DataFrame(NDFrame, OpsMixin):
         data: ListLikeU
         | DataFrame
         | dict[Any, Any]
-        | Iterable[tuple[Hashable, ListLikeU]]
+        | Iterable[ListLikeU | tuple[Hashable, ListLikeU]]
         | None = ...,
         index: Axes | None = ...,
         columns: Axes | None = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 import csv
 import datetime
 import io
+import itertools
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -48,6 +49,9 @@ DF = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
 def test_types_init() -> None:
     pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
     pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]}, index=[2, 1])
+    pd.DataFrame(data=[[1, 2, 3], [4, 5, 6]])
+    pd.DataFrame(data=itertools.repeat([1, 2, 3], 3))
+    pd.DataFrame(data=(range(i) for i in range(5)))
     pd.DataFrame(data=[1, 2, 3, 4], dtype=np.int8)
     pd.DataFrame(
         np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),


### PR DESCRIPTION
- [X] Closes #324 
- [X] Tests added: Please use `assert_type()` to assert the type of any return value
