### PR TITLE
Remove redundant PyPI link “Source code”

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ packages = [
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/pandas-dev/pandas-stubs/issues"
 "Documentation" = "https://pandas.pydata.org/pandas-docs/stable"
-"Source Code" = "https://github.com/pandas-dev/pandas-stubs"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"


### PR DESCRIPTION
[PyPI](https://pypi.org/project/pandas-stubs/) shows both “Repository” and “Source Code”:

<img width="752" alt="Xnapper-2022-10-31-18 22 21" src="https://user-images.githubusercontent.com/857609/199081531-4eb86758-90af-4bab-9b41-d250674cf0d0.png">

I guess “Repository” comes from Poetry, so you don’t need a second declaration.