### PR TITLE
(🎁) update mypy to 0.982

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ python = ">=3.8,<3.11"
 types-pytz = ">= 2022.1.1"
 
 [tool.poetry.dev-dependencies]
-mypy = "==0.971"
+mypy = "==0.982"
 pyarrow = ">=9.0.0"
 pytest = ">=7.1.2"
 pyright = ">=1.1.266"


### PR DESCRIPTION
# Problems:
- `Scalar` seems to be getting screwed up somehow when `pd.to_numeric` is called
- `Series.count` has an invalid overload due to `None` being `Hashable`.
  - Perhaps we could just put a type ignore on this, the real type would be something along the lines of `Hashable & Not[None]`, which is currently not supported. 