### PR TITLE
BUG: Fix assert_series_equal

### DIFF
--- a/pandas-stubs/_testing/__init__.pyi
+++ b/pandas-stubs/_testing/__init__.pyi
@@ -74,7 +74,7 @@ def assert_series_equal(
     obj: str = ...,
     *,
     check_index: Literal[False],
-    check_like: Literal[False],
+    check_like: Literal[False] = ...,
 ) -> None: ...
 @overload
 def assert_series_equal(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -37,6 +37,8 @@ def test_types_assert_series_equal() -> None:
             check_names=True,
         )
     assert_series_equal(s1, s2, check_like=True)
+    # GH 417
+    assert_series_equal(s1, s2, check_index=False)
 
 
 def test_assert_frame_equal():


### PR DESCRIPTION
Add default arg for overload

closes #417

- [X] Closes #417 
- [X] Tests added: Please use `assert_type()` to assert the type of any return value
