### PR TITLE
Support time start/end for BusinessHour & CustomBusinessHour

### DIFF
--- a/pandas-stubs/_libs/tslibs/offsets.pyi
+++ b/pandas-stubs/_libs/tslibs/offsets.pyi
@@ -1,6 +1,7 @@
 from datetime import (
     date,
     datetime,
+    time,
     timedelta,
 )
 from typing import (
@@ -131,8 +132,8 @@ class BusinessHour(BusinessMixin):
         self,
         n: int = ...,
         normalize: bool = ...,
-        start: str | Collection[str] = ...,
-        end: str | Collection[str] = ...,
+        start: str | time | Collection[str | time] = ...,
+        end: str | time | Collection[str | time] = ...,
         offset: timedelta = ...,
     ): ...
 
@@ -217,8 +218,8 @@ class CustomBusinessHour(BusinessHour):
         self,
         n: int = ...,
         normalize: bool = ...,
-        start: str = ...,
-        end: str = ...,
+        start: str | time | Collection[str | time] = ...,
+        end: str | time | Collection[str | time] = ...,
         offset: timedelta = ...,
         holidays: list | None = ...,
     ): ...

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -31,7 +31,9 @@ from tests import (
 from pandas.tseries.holiday import USFederalHolidayCalendar
 from pandas.tseries.offsets import (
     BusinessDay,
+    BusinessHour,
     CustomBusinessDay,
+    CustomBusinessHour,
     Day,
 )
 
@@ -595,6 +597,45 @@ def test_some_offsets() -> None:
     check(assert_type(tswm1, pd.Timestamp), pd.Timestamp)
     tswm2 = pd.Timestamp("9/23/2022") + pd.offsets.LastWeekOfMonth(2, 3)
     check(assert_type(tswm2, pd.Timestamp), pd.Timestamp)
+    # GH 396
+    check(
+        assert_type(
+            BusinessHour(start=dt.time(9, 30), end=dt.time(16, 0)), BusinessHour
+        ),
+        BusinessHour,
+    )
+    check(
+        assert_type(BusinessHour(start="9:30", end="16:00"), BusinessHour), BusinessHour
+    )
+    check(
+        assert_type(
+            BusinessHour(
+                start=["9:30", dt.time(11, 30)], end=[dt.time(10, 30), "13:00"]
+            ),
+            BusinessHour,
+        ),
+        BusinessHour,
+    )
+    check(
+        assert_type(
+            CustomBusinessHour(start=dt.time(9, 30), end=dt.time(16, 0)),
+            CustomBusinessHour,
+        ),
+        CustomBusinessHour,
+    )
+    check(
+        assert_type(CustomBusinessHour(start="9:30", end="16:00"), CustomBusinessHour),
+        CustomBusinessHour,
+    )
+    check(
+        assert_type(
+            CustomBusinessHour(
+                start=["9:30", dt.time(11, 30)], end=[dt.time(10, 30), "13:00"]
+            ),
+            CustomBusinessHour,
+        ),
+        CustomBusinessHour,
+    )
 
 
 def test_types_to_numpy() -> None:


### PR DESCRIPTION
- [X] Closes #396 
- [X] Tests added: Please use `assert_type()` to assert the type of any return value
