### PR TITLE
Allow None in .loc.__setitem__ and .iloc.__setitem__

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -141,7 +141,7 @@ class _iLocIndexerFrame(_iLocIndexer):
         | tuple[IndexType, int]
         | tuple[IndexType, IndexType]
         | tuple[int, IndexType],
-        value: float | Series | DataFrame | np.ndarray,
+        value: S1 | Series | DataFrame | np.ndarray | None,
     ) -> None: ...
 
 class _LocIndexerFrame(_LocIndexer):
@@ -172,13 +172,13 @@ class _LocIndexerFrame(_LocIndexer):
     def __setitem__(
         self,
         idx: MaskType | StrLike | _IndexSliceTuple | list[ScalarT],
-        value: S1 | ArrayLike | Series | DataFrame,
+        value: S1 | ArrayLike | Series | DataFrame | None,
     ) -> None: ...
     @overload
     def __setitem__(
         self,
         idx: tuple[_IndexSliceTuple, HashableT],
-        value: S1 | ArrayLike | Series[S1] | list,
+        value: S1 | ArrayLike | Series[S1] | list | None,
     ) -> None: ...
 
 class DataFrame(NDFrame, OpsMixin):

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -135,10 +135,10 @@ class _iLocIndexerSeries(_iLocIndexer, Generic[S1]):
     def __getitem__(self, idx: Index | slice | np_ndarray_anyint) -> Series[S1]: ...
     # set item
     @overload
-    def __setitem__(self, idx: int, value: S1) -> None: ...
+    def __setitem__(self, idx: int, value: S1 | None) -> None: ...
     @overload
     def __setitem__(
-        self, idx: Index | slice | np_ndarray_anyint, value: S1 | Series[S1]
+        self, idx: Index | slice | np_ndarray_anyint, value: S1 | Series[S1] | None
     ) -> None: ...
 
 class _LocIndexerSeries(_LocIndexer, Generic[S1]):
@@ -161,19 +161,19 @@ class _LocIndexerSeries(_LocIndexer, Generic[S1]):
     def __setitem__(
         self,
         idx: Index | MaskType,
-        value: S1 | ArrayLike | Series[S1],
+        value: S1 | ArrayLike | Series[S1] | None,
     ) -> None: ...
     @overload
     def __setitem__(
         self,
         idx: str,
-        value: S1,
+        value: S1 | None,
     ) -> None: ...
     @overload
     def __setitem__(
         self,
         idx: list[int] | list[str] | list[str | int],
-        value: S1 | ArrayLike | Series[S1],
+        value: S1 | ArrayLike | Series[S1] | None,
     ) -> None: ...
 
 class Series(IndexOpsMixin, NDFrame, Generic[S1]):

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1953,3 +1953,14 @@ def test_series_groupby_and_value_counts() -> None:
     )
     c: pd.Series = df.groupby("Animal")["Max Speed"].value_counts()
     check(assert_type(c, pd.Series), pd.Series)
+
+
+def test_setitem_none() -> None:
+    df = pd.DataFrame(
+        {"A": [1, 2, 3], "B": ["abc", "def", "ghi"]}, index=["x", "y", "z"]
+    )
+    df.loc["x", "B"] = None
+    df.iloc[2, 0] = None
+    sb = pd.Series([1, 2, 3], dtype=int)
+    sb.loc["y"] = None
+    sb.iloc[0] = None


### PR DESCRIPTION
- [x] Closes #382 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
  - No `assert_type` because it is testing `__setitem__()`
  - `test_frame.py/test_setitem_none()`

Either @twoertwein or @bashtage can review/approve/merge.