### PR TITLE
Fix annotations for DataFrame.apply() including additional overloads

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -8,6 +8,7 @@ from typing import (
     Iterator,
     Literal,
     Mapping,
+    MutableSequence,
     Optional,
     Protocol,
     Sequence,
@@ -155,6 +156,9 @@ AxisType: TypeAlias = Literal["columns", "index", 0, 1]
 DtypeNp = TypeVar("DtypeNp", bound=np.dtype[np.generic])
 KeysArgType: TypeAlias = Any
 ListLike = TypeVar("ListLike", Sequence, np.ndarray, "Series", "Index")
+ListLikeExceptSeriesAndStr = TypeVar(
+    "ListLikeExceptSeriesAndStr", MutableSequence, np.ndarray, tuple, "Index"
+)
 ListLikeU: TypeAlias = Union[Sequence, np.ndarray, Series, Index]
 StrLike: TypeAlias = Union[str, np.str_]
 Scalar: TypeAlias = Union[

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -152,7 +152,9 @@ num: TypeAlias = complex
 SeriesAxisType: TypeAlias = Literal[
     "index", 0
 ]  # Restricted subset of _AxisType for series
-AxisType: TypeAlias = Literal["columns", "index", 0, 1]
+AxisTypeIndex: TypeAlias = Literal["index", 0]
+AxisTypeColumn: TypeAlias = Literal["columns", 1]
+AxisType: TypeAlias = AxisTypeIndex | AxisTypeColumn
 DtypeNp = TypeVar("DtypeNp", bound=np.dtype[np.generic])
 KeysArgType: TypeAlias = Any
 ListLike = TypeVar("ListLike", Sequence, np.ndarray, "Series", "Index")

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1090,7 +1090,7 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs,
     ) -> DataFrame: ...
 
-    # First set of apply() overloads is with defaults
+    # apply() overloads with default result_type of None, and is indifferent to axis
     @overload
     def apply(
         self,
@@ -1104,26 +1104,26 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def apply(
         self,
-        f: Callable[..., Scalar],
+        f: Callable[..., S1],
         axis: AxisTypeIndex = ...,
         raw: _bool = ...,
         result_type: Literal[None] = ...,
         args=...,
         **kwargs,
-    ) -> Series: ...
+    ) -> Series[S1]: ...
 
-    # Second set of apply() overloads is with keyword result_type
+    # apply() overloads with keyword result_type, and axis does not matter
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr],
+        f: Callable[..., S1],
         axis: AxisType = ...,
         raw: _bool = ...,
         args=...,
         *,
-        result_type: Literal["reduce"],
+        result_type: Literal["expand", "reduce"],
         **kwargs,
-    ) -> Series: ...
+    ) -> Series[S1]: ...
     @overload
     def apply(
         self,
@@ -1138,7 +1138,18 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
+        f: Callable[..., ListLikeExceptSeriesAndStr],
+        axis: AxisType = ...,
+        raw: _bool = ...,
+        args=...,
+        *,
+        result_type: Literal["reduce"],
+        **kwargs,
+    ) -> Series: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series | Scalar],
         axis: AxisType = ...,
         raw: _bool = ...,
         args=...,
@@ -1147,11 +1158,35 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs,
     ) -> DataFrame: ...
 
-    # Third set of apply() overloads is with keyword axis=1, but only where the return values have changed
+    # apply() overloads with keyword result_type, and axis does matter
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Scalar],
+        f: Callable[..., Series],
+        axis: AxisTypeIndex = ...,
+        raw: _bool = ...,
+        args=...,
+        *,
+        result_type: Literal["reduce"],
+        **kwargs,
+    ) -> Series: ...
+
+    # apply() overloads with default result_type of None, and keyword axis=1 matters
+    @overload
+    def apply(
+        self,
+        f: Callable[..., S1],
+        raw: _bool = ...,
+        result_type: Literal[None] = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn,
+        **kwargs,
+    ) -> Series[S1]: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr],
         raw: _bool = ...,
         result_type: Literal[None] = ...,
         args=...,
@@ -1171,38 +1206,16 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs,
     ) -> DataFrame: ...
 
-    # Fourth set of apply() overloads is with keyword axis=1 and keyword result_type
+    # apply() overloads with keyword axis=1 and keyword result_type
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr],
+        f: Callable[..., Series],
         raw: _bool = ...,
         args=...,
         *,
-        axis: AxisTypeColumn = ...,
+        axis: AxisTypeColumn,
         result_type: Literal["reduce"],
-        **kwargs,
-    ) -> Series: ...
-    @overload
-    def apply(
-        self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
-        raw: _bool = ...,
-        args=...,
-        *,
-        axis: AxisTypeColumn = ...,
-        result_type: Literal["expand"],
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
-    def apply(
-        self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
-        raw: _bool = ...,
-        args=...,
-        *,
-        axis: AxisTypeColumn = ...,
-        result_type: Literal["broadcast"],
         **kwargs,
     ) -> DataFrame: ...
 

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1094,17 +1094,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr],
-        axis: AxisTypeIndex = ...,
-        raw: _bool = ...,
-        result_type: Literal[None] = ...,
-        args=...,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
-    def apply(
-        self,
-        f: Callable[..., Series],
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
         axis: AxisTypeIndex = ...,
         raw: _bool = ...,
         result_type: Literal[None] = ...,
@@ -1127,7 +1117,7 @@ class DataFrame(NDFrame, OpsMixin):
     def apply(
         self,
         f: Callable[..., ListLikeExceptSeriesAndStr],
-        axis: AxisTypeIndex = ...,
+        axis: AxisType = ...,
         raw: _bool = ...,
         args=...,
         *,
@@ -1138,7 +1128,7 @@ class DataFrame(NDFrame, OpsMixin):
     def apply(
         self,
         f: Callable[..., ListLikeExceptSeriesAndStr | Series],
-        axis: AxisTypeIndex = ...,
+        axis: AxisType = ...,
         raw: _bool = ...,
         args=...,
         *,
@@ -1149,7 +1139,7 @@ class DataFrame(NDFrame, OpsMixin):
     def apply(
         self,
         f: Callable[..., ListLikeExceptSeriesAndStr | Series],
-        axis: AxisTypeIndex = ...,
+        axis: AxisType = ...,
         raw: _bool = ...,
         args=...,
         *,
@@ -1157,11 +1147,11 @@ class DataFrame(NDFrame, OpsMixin):
         **kwargs,
     ) -> DataFrame: ...
 
-    # Third set of apply() overloads is with keyword axis=1 only
+    # Third set of apply() overloads is with keyword axis=1, but only where the return values have changed
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr],
+        f: Callable[..., ListLikeExceptSeriesAndStr | Scalar],
         raw: _bool = ...,
         result_type: Literal[None] = ...,
         args=...,
@@ -1180,52 +1170,8 @@ class DataFrame(NDFrame, OpsMixin):
         axis: AxisTypeColumn,
         **kwargs,
     ) -> DataFrame: ...
-    @overload
-    def apply(
-        self,
-        f: Callable[..., Scalar],
-        raw: _bool = ...,
-        result_type: Literal[None] = ...,
-        args=...,
-        *,
-        axis: AxisTypeColumn,
-        **kwargs,
-    ) -> Series: ...
 
     # Fourth set of apply() overloads is with keyword axis=1 and keyword result_type
-    @overload
-    def apply(
-        self,
-        f: Callable[..., ListLikeExceptSeriesAndStr],
-        raw: _bool = ...,
-        args=...,
-        *,
-        axis: AxisTypeColumn = ...,
-        result_type: Literal[None] = ...,
-        **kwargs,
-    ) -> Series: ...
-    @overload
-    def apply(
-        self,
-        f: Callable[..., Series],
-        raw: _bool = ...,
-        args=...,
-        *,
-        axis: AxisTypeColumn = ...,
-        result_type: Literal[None] = ...,
-        **kwargs,
-    ) -> DataFrame: ...
-    @overload
-    def apply(
-        self,
-        f: Callable[..., Scalar],
-        raw: _bool = ...,
-        args=...,
-        *,
-        axis: AxisTypeColumn = ...,
-        result_type: Literal[None] = ...,
-        **kwargs,
-    ) -> Series: ...
     @overload
     def apply(
         self,

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -82,6 +82,7 @@ from pandas._typing import (
     Label,
     Level,
     ListLike,
+    ListLikeExceptSeriesAndStr,
     ListLikeU,
     MaskType,
     MergeHow,
@@ -1089,10 +1090,20 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def apply(
         self,
+        f: Callable[..., ListLikeExceptSeriesAndStr],
+        axis: AxisType = ...,
+        raw: _bool = ...,
+        result_type: Literal[None] = ...,
+        args=...,
+        **kwargs,
+    ) -> DataFrame: ...
+    @overload
+    def apply(
+        self,
         f: Callable[..., Series],
         axis: AxisType = ...,
         raw: _bool = ...,
-        result_type: Literal["expand", "reduce", "broadcast"] | None = ...,
+        result_type: Literal[None] = ...,
         args=...,
         **kwargs,
     ) -> DataFrame: ...
@@ -1102,18 +1113,41 @@ class DataFrame(NDFrame, OpsMixin):
         f: Callable[..., Scalar],
         axis: AxisType = ...,
         raw: _bool = ...,
-        result_type: Literal["expand", "reduce"] | None = ...,
+        result_type: Literal[None] = ...,
         args=...,
         **kwargs,
     ) -> Series: ...
     @overload
     def apply(
         self,
-        f: Callable[..., Scalar],
-        result_type: Literal["broadcast"],
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series | str | Scalar],
         axis: AxisType = ...,
         raw: _bool = ...,
         args=...,
+        *,
+        result_type: Literal["reduce"],
+        **kwargs,
+    ) -> Series: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
+        axis: AxisType = ...,
+        raw: _bool = ...,
+        args=...,
+        *,
+        result_type: Literal["expand"],
+        **kwargs,
+    ) -> DataFrame: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series | str | Scalar],
+        axis: AxisType = ...,
+        raw: _bool = ...,
+        args=...,
+        *,
+        result_type: Literal["broadcast"],
         **kwargs,
     ) -> DataFrame: ...
     def applymap(

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -59,6 +59,8 @@ from pandas._typing import (
     Axes,
     Axis,
     AxisType,
+    AxisTypeColumn,
+    AxisTypeIndex,
     CalculationMethod,
     ColspaceArgType,
     CompressionOptions,
@@ -1087,11 +1089,13 @@ class DataFrame(NDFrame, OpsMixin):
         *args,
         **kwargs,
     ) -> DataFrame: ...
+
+    # First set of apply() overloads is with defaults
     @overload
     def apply(
         self,
         f: Callable[..., ListLikeExceptSeriesAndStr],
-        axis: AxisType = ...,
+        axis: AxisTypeIndex = ...,
         raw: _bool = ...,
         result_type: Literal[None] = ...,
         args=...,
@@ -1101,7 +1105,7 @@ class DataFrame(NDFrame, OpsMixin):
     def apply(
         self,
         f: Callable[..., Series],
-        axis: AxisType = ...,
+        axis: AxisTypeIndex = ...,
         raw: _bool = ...,
         result_type: Literal[None] = ...,
         args=...,
@@ -1111,17 +1115,19 @@ class DataFrame(NDFrame, OpsMixin):
     def apply(
         self,
         f: Callable[..., Scalar],
-        axis: AxisType = ...,
+        axis: AxisTypeIndex = ...,
         raw: _bool = ...,
         result_type: Literal[None] = ...,
         args=...,
         **kwargs,
     ) -> Series: ...
+
+    # Second set of apply() overloads is with keyword result_type
     @overload
     def apply(
         self,
         f: Callable[..., ListLikeExceptSeriesAndStr],
-        axis: AxisType = ...,
+        axis: AxisTypeIndex = ...,
         raw: _bool = ...,
         args=...,
         *,
@@ -1132,7 +1138,7 @@ class DataFrame(NDFrame, OpsMixin):
     def apply(
         self,
         f: Callable[..., ListLikeExceptSeriesAndStr | Series],
-        axis: AxisType = ...,
+        axis: AxisTypeIndex = ...,
         raw: _bool = ...,
         args=...,
         *,
@@ -1143,13 +1149,118 @@ class DataFrame(NDFrame, OpsMixin):
     def apply(
         self,
         f: Callable[..., ListLikeExceptSeriesAndStr | Series],
-        axis: AxisType = ...,
+        axis: AxisTypeIndex = ...,
         raw: _bool = ...,
         args=...,
         *,
         result_type: Literal["broadcast"],
         **kwargs,
     ) -> DataFrame: ...
+
+    # Third set of apply() overloads is with keyword axis=1 only
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr],
+        raw: _bool = ...,
+        result_type: Literal[None] = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn,
+        **kwargs,
+    ) -> Series: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., Series],
+        raw: _bool = ...,
+        result_type: Literal[None] = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn,
+        **kwargs,
+    ) -> DataFrame: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., Scalar],
+        raw: _bool = ...,
+        result_type: Literal[None] = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn,
+        **kwargs,
+    ) -> Series: ...
+
+    # Fourth set of apply() overloads is with keyword axis=1 and keyword result_type
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr],
+        raw: _bool = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn = ...,
+        result_type: Literal[None] = ...,
+        **kwargs,
+    ) -> Series: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., Series],
+        raw: _bool = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn = ...,
+        result_type: Literal[None] = ...,
+        **kwargs,
+    ) -> DataFrame: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., Scalar],
+        raw: _bool = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn = ...,
+        result_type: Literal[None] = ...,
+        **kwargs,
+    ) -> Series: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr],
+        raw: _bool = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn = ...,
+        result_type: Literal["reduce"],
+        **kwargs,
+    ) -> Series: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
+        raw: _bool = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn = ...,
+        result_type: Literal["expand"],
+        **kwargs,
+    ) -> DataFrame: ...
+    @overload
+    def apply(
+        self,
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
+        raw: _bool = ...,
+        args=...,
+        *,
+        axis: AxisTypeColumn = ...,
+        result_type: Literal["broadcast"],
+        **kwargs,
+    ) -> DataFrame: ...
+
+    # Add spacing between apply() overloads and remaining annotations
     def applymap(
         self, func: Callable, na_action: Literal["ignore"] | None = ..., **kwargs
     ) -> DataFrame: ...

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1120,7 +1120,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Series | str | Scalar],
+        f: Callable[..., ListLikeExceptSeriesAndStr],
         axis: AxisType = ...,
         raw: _bool = ...,
         args=...,
@@ -1142,7 +1142,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Series | str | Scalar],
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
         axis: AxisType = ...,
         raw: _bool = ...,
         args=...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -486,6 +486,16 @@ def test_types_apply() -> None:
 
     check(assert_type(df.apply(gethead, args=(4,)), pd.DataFrame), pd.DataFrame)
 
+    def returns_tuple(x: pd.Series) -> tuple[str, str]:
+        return ("a", "b")
+
+    check(
+        assert_type(
+            df.apply(returns_tuple, axis=1, result_type="expand"), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
+
 
 def test_types_applymap() -> None:
     df = pd.DataFrame(data={"col1": [2, 1], "col2": [3, 4]})

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -569,8 +569,8 @@ def test_types_apply() -> None:
         pd.DataFrame,
     )
     check(
-        assert_type(df.apply(returns_listlike_of_3, axis=1), pd.DataFrame),
-        pd.DataFrame,
+        assert_type(df.apply(returns_listlike_of_3, axis=1), pd.Series),
+        pd.Series,
     )
 
     # While this call works in reality, it errors in the type checker, because this should never be called
@@ -636,6 +636,30 @@ def test_types_apply() -> None:
             pd.DataFrame,
         ),
         pd.DataFrame,
+    )
+
+    # Test various other argument combinations to ensure all overloads are supported
+    check(
+        assert_type(df.apply(returns_scalar, axis=0), pd.Series),
+        pd.Series,
+    )
+    check(
+        assert_type(df.apply(returns_scalar, axis=0, result_type=None), pd.Series),
+        pd.Series,
+    )
+    check(
+        assert_type(df.apply(returns_scalar, 0, False, None), pd.Series),
+        pd.Series,
+    )
+    check(
+        assert_type(df.apply(returns_scalar, 0, False, result_type=None), pd.Series),
+        pd.Series,
+    )
+    check(
+        assert_type(
+            df.apply(returns_scalar, 0, raw=False, result_type=None), pd.Series
+        ),
+        pd.Series,
     )
 
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -462,21 +462,21 @@ def test_types_unique() -> None:
 
 
 def test_types_apply() -> None:
-    df = pd.DataFrame(data={"col1": [2, 1], "col2": [3, 4]})
-
-    def returns_series(x: pd.Series) -> pd.Series:
-        return x**2
-
-    check(assert_type(df.apply(returns_series), pd.DataFrame), pd.DataFrame)
+    df = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4], "col3": [5, 6]})
 
     def returns_scalar(x: pd.Series) -> float:
         return 2
 
-    check(assert_type(df.apply(returns_scalar), pd.Series), pd.Series)
-    check(
-        assert_type(df.apply(returns_scalar, result_type="broadcast"), pd.DataFrame),
-        pd.DataFrame,
-    )
+    def returns_series(x: pd.Series) -> pd.Series:
+        return x**2
+
+    def returns_listlike_of_2(x: pd.Series) -> tuple[int, int]:
+        return (7, 8)
+
+    def returns_listlike_of_3(x: pd.Series) -> tuple[int, int, int]:
+        return (7, 8, 9)
+
+    # Misc checks
     check(assert_type(df.apply(np.exp), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.apply(str), pd.Series), pd.Series)
 
@@ -486,12 +486,154 @@ def test_types_apply() -> None:
 
     check(assert_type(df.apply(gethead, args=(4,)), pd.DataFrame), pd.DataFrame)
 
-    def returns_tuple(x: pd.Series) -> tuple[str, str]:
-        return ("a", "b")
+    # Check scalar/series/list-like for default (None), and result type of expand, reduce, broadcast
+    check(
+        assert_type(df.apply(returns_scalar), pd.Series),
+        pd.Series,
+    )
+    check(
+        assert_type(df.apply(returns_series), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.apply(returns_listlike_of_3), pd.DataFrame),
+        pd.DataFrame,
+    )
 
+    # While this call works in reality, it errors in the type checker, because this should never be called
+    # It does not make sense to pass a result_type of "expand" to a scalar return
+    # check(
+    #     assert_type(
+    #         df.apply(returns_scalar, result_type="expand"), pd.DataFrame
+    #     ),
+    #     pd.DataFrame,
+    # )
+    check(
+        assert_type(df.apply(returns_series, result_type="expand"), pd.DataFrame),
+        pd.DataFrame,
+    )
     check(
         assert_type(
-            df.apply(returns_tuple, axis=1, result_type="expand"), pd.DataFrame
+            df.apply(returns_listlike_of_3, result_type="expand"), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
+
+    # While this call works in reality, it errors in the type checker, because this should never be called
+    # It does not make sense to pass a result_type of "reduce" to a scalar or series return
+    # check(
+    #     assert_type(
+    #         df.apply(returns_scalar, result_type="reduce"), pd.DataFrame
+    #     ),
+    #     pd.DataFrame,
+    # )
+    # check(
+    #     assert_type(
+    #         df.apply(returns_series, result_type="reduce"), pd.Series
+    #     ),
+    #     pd.Series,
+    # )
+    check(
+        assert_type(df.apply(returns_listlike_of_3, result_type="reduce"), pd.Series),
+        pd.Series,
+    )
+
+    # While this call works in reality, it errors in the type checker, because this should never be called
+    # It does not make sense to pass a result_type of "broadcast" to a scalar return
+    # check(
+    #     assert_type(
+    #         df.apply(returns_scalar, result_type="broadcast"), pd.DataFrame
+    #     ),
+    #     pd.DataFrame,
+    # )
+    check(
+        assert_type(df.apply(returns_series, result_type="broadcast"), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(
+            # Can only broadcast a list-like of 2 elements, not 3, because there are 2 rows
+            df.apply(returns_listlike_of_2, result_type="broadcast"),
+            pd.DataFrame,
+        ),
+        pd.DataFrame,
+    )
+
+    # Check the same combinations with axis=1
+    check(
+        assert_type(df.apply(returns_scalar, axis=1), pd.Series),
+        pd.Series,
+    )
+    check(
+        assert_type(df.apply(returns_series, axis=1), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.apply(returns_listlike_of_3, axis=1), pd.DataFrame),
+        pd.DataFrame,
+    )
+
+    # While this call works in reality, it errors in the type checker, because this should never be called
+    # It does not make sense to pass a result_type of "expand" to a scalar return
+    # check(
+    #     assert_type(
+    #         df.apply(returns_scalar, axis=1, result_type="expand"), pd.DataFrame
+    #     ),
+    #     pd.DataFrame,
+    # )
+    check(
+        assert_type(
+            df.apply(returns_series, axis=1, result_type="expand"), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(
+            df.apply(returns_listlike_of_3, axis=1, result_type="expand"), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
+
+    # While this call works in reality, it errors in the type checker, because this should never be called
+    # It does not make sense to pass a result_type of "reduce" to a scalar or series return
+    # check(
+    #     assert_type(
+    #         df.apply(returns_scalar, axis=1, result_type="reduce"), pd.DataFrame
+    #     ),
+    #     pd.DataFrame,
+    # )
+    # check(
+    #     assert_type(
+    #         df.apply(returns_series, axis=1, result_type="reduce"), pd.DataFrame
+    #     ),
+    #     pd.DataFrame,
+    # )
+    check(
+        assert_type(
+            df.apply(returns_listlike_of_3, axis=1, result_type="reduce"), pd.Series
+        ),
+        pd.Series,
+    )
+
+    # While this call works in reality, it errors in the type checker, because this should never be called
+    # It does not make sense to pass a result_type of "broadcast" to a scalar return
+    # check(
+    #     assert_type(
+    #         df.apply(returns_scalar, axis=1, result_type="broadcast"), pd.DataFrame
+    #     ),
+    #     pd.DataFrame,
+    # )
+    check(
+        assert_type(
+            df.apply(returns_series, axis=1, result_type="broadcast"), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(
+            # Can only broadcast a list-like of 3 elements, not 2, as there are 3 columns
+            df.apply(returns_listlike_of_3, axis=1, result_type="broadcast"),
+            pd.DataFrame,
         ),
         pd.DataFrame,
     )


### PR DESCRIPTION
- [X] Tests added: Please use `assert_type()` to assert the type of any return value

In #401 the annotations for `apply` was changed. This introduced false negatives in my code base, because the particular mix of return types and arguments I was using was not supported. Here I am still not sure it is exhaustive but I think it's an improvement. In particular the `result_type` needs to be accounted for, as well as differentiating between a true list-like, `str`, and `Series` in the return value of the function.

@Dr-Irv @bashtage @danielroseman
