### PR TITLE
Permit covariance of key type in read_csv converters argument

### DIFF
--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -8,6 +8,7 @@ from typing import (
     Any,
     Callable,
     Literal,
+    Mapping,
     Sequence,
     overload,
 )
@@ -48,9 +49,9 @@ def read_csv(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]]
-    | dict[int, Callable[[str], Any]]
-    | dict[str, Callable[[str], Any]]
+    converters: Mapping[int | str, Callable[[str], Any]]
+    | Mapping[int, Callable[[str], Any]]
+    | Mapping[str, Callable[[str], Any]]
     | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
@@ -58,16 +59,16 @@ def read_csv(
     skiprows: int | Sequence[int] | Callable[[int], bool] = ...,
     skipfooter: int = ...,
     nrows: int | None = ...,
-    na_values: Sequence[str] | dict[str, Sequence[str]] = ...,
+    na_values: Sequence[str] | Mapping[str, Sequence[str]] = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
     skip_blank_lines: bool = ...,
     parse_dates: bool
-    | Sequence[int]
+    | list[int]
     | list[str]
     | Sequence[Sequence[int]]
-    | dict[str, Sequence[int]] = ...,
+    | Mapping[str, Sequence[int | str]] = ...,
     infer_datetime_format: bool = ...,
     keep_date_col: bool = ...,
     date_parser: Callable = ...,
@@ -114,9 +115,9 @@ def read_csv(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]]
-    | dict[int, Callable[[str], Any]]
-    | dict[str, Callable[[str], Any]]
+    converters: Mapping[int | str, Callable[[str], Any]]
+    | Mapping[int, Callable[[str], Any]]
+    | Mapping[str, Callable[[str], Any]]
     | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
@@ -124,16 +125,16 @@ def read_csv(
     skiprows: int | Sequence[int] | Callable[[int], bool] = ...,
     skipfooter: int = ...,
     nrows: int | None = ...,
-    na_values: Sequence[str] | dict[str, Sequence[str]] = ...,
+    na_values: Sequence[str] | Mapping[str, Sequence[str]] = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
     skip_blank_lines: bool = ...,
     parse_dates: bool
-    | Sequence[int]
+    | list[int]
     | list[str]
     | Sequence[Sequence[int]]
-    | dict[str, Sequence[int]] = ...,
+    | Mapping[str, Sequence[int | str]] = ...,
     infer_datetime_format: bool = ...,
     keep_date_col: bool = ...,
     date_parser: Callable = ...,
@@ -180,9 +181,9 @@ def read_csv(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]]
-    | dict[int, Callable[[str], Any]]
-    | dict[str, Callable[[str], Any]]
+    converters: Mapping[int | str, Callable[[str], Any]]
+    | Mapping[int, Callable[[str], Any]]
+    | Mapping[str, Callable[[str], Any]]
     | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
@@ -190,16 +191,16 @@ def read_csv(
     skiprows: int | Sequence[int] | Callable[[int], bool] = ...,
     skipfooter: int = ...,
     nrows: int | None = ...,
-    na_values: Sequence[str] | dict[str, Sequence[str]] = ...,
+    na_values: Sequence[str] | Mapping[str, Sequence[str]] = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
     skip_blank_lines: bool = ...,
     parse_dates: bool
-    | Sequence[int]
+    | list[int]
     | list[str]
     | Sequence[Sequence[int]]
-    | dict[str, Sequence[int]] = ...,
+    | Mapping[str, Sequence[int | str]] = ...,
     infer_datetime_format: bool = ...,
     keep_date_col: bool = ...,
     date_parser: Callable = ...,
@@ -246,9 +247,9 @@ def read_table(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]]
-    | dict[int, Callable[[str], Any]]
-    | dict[str, Callable[[str], Any]]
+    converters: Mapping[int | str, Callable[[str], Any]]
+    | Mapping[int, Callable[[str], Any]]
+    | Mapping[str, Callable[[str], Any]]
     | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
@@ -256,16 +257,16 @@ def read_table(
     skiprows: int | Sequence[int] | Callable[[int], bool] = ...,
     skipfooter: int = ...,
     nrows: int | None = ...,
-    na_values: Sequence[str] | dict[str, Sequence[str]] = ...,
+    na_values: Sequence[str] | Mapping[str, Sequence[str]] = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
     skip_blank_lines: bool = ...,
     parse_dates: bool
-    | Sequence[int]
+    | list[int]
     | list[str]
     | Sequence[Sequence[int]]
-    | dict[str, Sequence[int]] = ...,
+    | Mapping[str, Sequence[int | str]] = ...,
     infer_datetime_format: bool = ...,
     keep_date_col: bool = ...,
     date_parser: Callable = ...,
@@ -312,9 +313,9 @@ def read_table(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]]
-    | dict[int, Callable[[str], Any]]
-    | dict[str, Callable[[str], Any]]
+    converters: Mapping[int | str, Callable[[str], Any]]
+    | Mapping[int, Callable[[str], Any]]
+    | Mapping[str, Callable[[str], Any]]
     | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
@@ -322,16 +323,16 @@ def read_table(
     skiprows: int | Sequence[int] | Callable[[int], bool] = ...,
     skipfooter: int = ...,
     nrows: int | None = ...,
-    na_values: Sequence[str] | dict[str, Sequence[str]] = ...,
+    na_values: Sequence[str] | Mapping[str, Sequence[str]] = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
     skip_blank_lines: bool = ...,
     parse_dates: bool
-    | Sequence[int]
+    | list[int]
     | list[str]
     | Sequence[Sequence[int]]
-    | dict[str, Sequence[int]] = ...,
+    | Mapping[str, Sequence[int | str]] = ...,
     infer_datetime_format: bool = ...,
     keep_date_col: bool = ...,
     date_parser: Callable = ...,
@@ -378,9 +379,9 @@ def read_table(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]]
-    | dict[int, Callable[[str], Any]]
-    | dict[str, Callable[[str], Any]]
+    converters: Mapping[int | str, Callable[[str], Any]]
+    | Mapping[int, Callable[[str], Any]]
+    | Mapping[str, Callable[[str], Any]]
     | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
@@ -388,16 +389,16 @@ def read_table(
     skiprows: int | Sequence[int] | Callable[[int], bool] = ...,
     skipfooter: int = ...,
     nrows: int | None = ...,
-    na_values: Sequence[str] | dict[str, Sequence[str]] = ...,
+    na_values: Sequence[str] | Mapping[str, Sequence[str]] = ...,
     keep_default_na: bool = ...,
     na_filter: bool = ...,
     verbose: bool = ...,
     skip_blank_lines: bool = ...,
     parse_dates: bool
-    | Sequence[int]
+    | list[int]
     | list[str]
     | Sequence[Sequence[int]]
-    | dict[str, Sequence[int]] = ...,
+    | Mapping[str, Sequence[int | str]] = ...,
     infer_datetime_format: bool = ...,
     keep_date_col: bool = ...,
     date_parser: Callable = ...,
@@ -461,7 +462,7 @@ def read_fwf(
 
 class TextFileReader(abc.Iterator):
     engine: CSVEngine
-    orig_options: dict[str, Any]
+    orig_options: Mapping[str, Any]
     chunksize: int | None
     nrows: int | None
     squeeze: bool

--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -48,7 +48,10 @@ def read_csv(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]] | None = ...,
+    converters: dict[int | str, Callable[[str], Any]]
+    | dict[int, Callable[[str], Any]]
+    | dict[str, Callable[[str], Any]]
+    | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
     skipinitialspace: bool = ...,
@@ -111,7 +114,10 @@ def read_csv(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]] | None = ...,
+    converters: dict[int | str, Callable[[str], Any]]
+    | dict[int, Callable[[str], Any]]
+    | dict[str, Callable[[str], Any]]
+    | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
     skipinitialspace: bool = ...,
@@ -174,7 +180,10 @@ def read_csv(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]] | None = ...,
+    converters: dict[int | str, Callable[[str], Any]]
+    | dict[int, Callable[[str], Any]]
+    | dict[str, Callable[[str], Any]]
+    | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
     skipinitialspace: bool = ...,
@@ -237,7 +246,10 @@ def read_table(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]] | None = ...,
+    converters: dict[int | str, Callable[[str], Any]]
+    | dict[int, Callable[[str], Any]]
+    | dict[str, Callable[[str], Any]]
+    | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
     skipinitialspace: bool = ...,
@@ -300,7 +312,10 @@ def read_table(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]] | None = ...,
+    converters: dict[int | str, Callable[[str], Any]]
+    | dict[int, Callable[[str], Any]]
+    | dict[str, Callable[[str], Any]]
+    | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
     skipinitialspace: bool = ...,
@@ -363,7 +378,10 @@ def read_table(
     | None = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
-    converters: dict[int | str, Callable[[str], Any]] | None = ...,
+    converters: dict[int | str, Callable[[str], Any]]
+    | dict[int, Callable[[str], Any]]
+    | dict[str, Callable[[str], Any]]
+    | None = ...,
     true_values: list[str] = ...,
     false_values: list[str] = ...,
     skipinitialspace: bool = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1280,29 +1280,29 @@ def test_read_csv() -> None:
         )
 
         # Allow a variety of dict types for the converters parameter
-        converters1 = {"A": lambda x: str, "B": lambda x: str}
+        converters1 = {"A": str, "B": str}
         check(
             assert_type(pd.read_csv(path, converters=converters1), pd.DataFrame),
             pd.DataFrame,
         )
-        converters2 = {"A": lambda x: str, "B": lambda x: float}
+        converters2 = {"A": str, "B": float}
         check(
             assert_type(pd.read_csv(path, converters=converters2), pd.DataFrame),
             pd.DataFrame,
         )
-        converters3 = {0: lambda x: str, 1: lambda x: str}
+        converters3 = {0: str, 1: str}
         check(
             assert_type(pd.read_csv(path, converters=converters3), pd.DataFrame),
             pd.DataFrame,
         )
-        converters4 = {0: lambda x: str, 1: lambda x: float}
+        converters4 = {0: str, 1: float}
         check(
             assert_type(pd.read_csv(path, converters=converters4), pd.DataFrame),
             pd.DataFrame,
         )
         converters5: dict[int | str, Callable[[str], Any]] = {
-            0: lambda x: str,
-            "A": lambda x: float,
+            0: str,
+            "A": float,
         }
         check(
             assert_type(pd.read_csv(path, converters=converters5), pd.DataFrame),
@@ -1316,6 +1316,54 @@ def test_read_csv() -> None:
 
         check(
             assert_type(pd.read_csv(path, **read_csv_kwargs), pd.DataFrame),
+            pd.DataFrame,
+        )
+
+        # Check value covariance for various other parameters too (these only accept a str key)
+        na_values = {"A": ["1"], "B": ["1"]}
+        check(
+            assert_type(pd.read_csv(path, na_values=na_values), pd.DataFrame),
+            pd.DataFrame,
+        )
+
+    # There are several possible inputs for parse_dates
+    with ensure_clean() as path:
+        Path(path).write_text("Date,Year,Month,Day\n20221125,2022,11,25")
+        parse_dates_1 = ["Date"]
+        check(
+            assert_type(pd.read_csv(path, parse_dates=parse_dates_1), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(
+                pd.read_csv(path, index_col="Date", parse_dates=True), pd.DataFrame
+            ),
+            pd.DataFrame,
+        )
+        parse_dates_2 = {"combined_date": ["Year", "Month", "Day"]}
+        check(
+            assert_type(pd.read_csv(path, parse_dates=parse_dates_2), pd.DataFrame),
+            pd.DataFrame,
+        )
+        parse_dates_3 = {"combined_date": [1, 2, 3]}
+        check(
+            assert_type(pd.read_csv(path, parse_dates=parse_dates_3), pd.DataFrame),
+            pd.DataFrame,
+        )
+        # MyPy calls this Dict[str, object] by default which necessitates the explicit annotation (Pyright does not)
+        parse_dates_4: dict[str, list[str | int]] = {"combined_date": [1, "Month", 3]}
+        check(
+            assert_type(pd.read_csv(path, parse_dates=parse_dates_4), pd.DataFrame),
+            pd.DataFrame,
+        )
+        parse_dates_5 = [2]
+        check(
+            assert_type(pd.read_csv(path, parse_dates=parse_dates_5), pd.DataFrame),
+            pd.DataFrame,
+        )
+        parse_dates_6 = [[1, 2], [1, 2, 3]]
+        check(
+            assert_type(pd.read_csv(path, parse_dates=parse_dates_6), pd.DataFrame),
             pd.DataFrame,
         )
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Mapping,
     Tuple,
+    TypedDict,
     TypeVar,
     Union,
 )
@@ -1275,6 +1276,46 @@ def test_read_csv() -> None:
         # https://github.com/microsoft/python-type-stubs/issues/118
         check(
             assert_type(pd.read_csv(path, storage_options=None), pd.DataFrame),
+            pd.DataFrame,
+        )
+
+        # Allow a variety of dict types for the converters parameter
+        converters1 = {"A": lambda x: str, "B": lambda x: str}
+        check(
+            assert_type(pd.read_csv(path, converters=converters1), pd.DataFrame),
+            pd.DataFrame,
+        )
+        converters2 = {"A": lambda x: str, "B": lambda x: float}
+        check(
+            assert_type(pd.read_csv(path, converters=converters2), pd.DataFrame),
+            pd.DataFrame,
+        )
+        converters3 = {0: lambda x: str, 1: lambda x: str}
+        check(
+            assert_type(pd.read_csv(path, converters=converters3), pd.DataFrame),
+            pd.DataFrame,
+        )
+        converters4 = {0: lambda x: str, 1: lambda x: float}
+        check(
+            assert_type(pd.read_csv(path, converters=converters4), pd.DataFrame),
+            pd.DataFrame,
+        )
+        converters5: dict[int | str, Callable[[str], Any]] = {
+            0: lambda x: str,
+            "A": lambda x: float,
+        }
+        check(
+            assert_type(pd.read_csv(path, converters=converters5), pd.DataFrame),
+            pd.DataFrame,
+        )
+
+        class ReadCsvKwargs(TypedDict):
+            converters: dict[int, Callable[[str], Any]]
+
+        read_csv_kwargs: ReadCsvKwargs = {"converters": {0: int}}
+
+        check(
+            assert_type(pd.read_csv(path, **read_csv_kwargs), pd.DataFrame),
             pd.DataFrame,
         )
 


### PR DESCRIPTION
- [X] Tests added: Please use `assert_type()` to assert the type of any return value

If it accepts a `Dict[int | str, ...]` it should accept a `Dict` of either key type.