### PR TITLE
Follow up PR for changes requested in #445

### DIFF
--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -65,14 +65,24 @@ class SeriesGroupBy(GroupBy, Generic[S1]):
     def filter(self, func, dropna: bool = ..., *args, **kwargs): ...
     def nunique(self, dropna: bool = ...) -> Series: ...
     def describe(self, **kwargs) -> DataFrame: ...
+    @overload
     def value_counts(
         self,
-        normalize: Literal[False, True] = ...,
+        normalize: Literal[False] = ...,
         sort: bool = ...,
         ascending: bool = ...,
         bins=...,
         dropna: bool = ...,
-    ) -> Series: ...
+    ) -> Series[int]: ...
+    @overload
+    def value_counts(
+        self,
+        normalize: Literal[True],
+        sort: bool = ...,
+        ascending: bool = ...,
+        bins=...,
+        dropna: bool = ...,
+    ) -> Series[float]: ...
     def count(self) -> Series[int]: ...
     def pct_change(
         self,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2042,8 +2042,8 @@ def test_series_groupby_and_value_counts() -> None:
     )
     c1 = df.groupby("Animal")["Max Speed"].value_counts()
     c2 = df.groupby("Animal")["Max Speed"].value_counts(normalize=True)
-    check(assert_type(c1, pd.Series), pd.Series)
-    check(assert_type(c2, pd.Series), pd.Series)
+    check(assert_type(c1, "pd.Series[int]"), pd.Series, int)
+    check(assert_type(c2, "pd.Series[float]"), pd.Series, float)
 
 
 def test_setitem_none() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2040,8 +2040,10 @@ def test_series_groupby_and_value_counts() -> None:
             "Max Speed": [380, 370, 24, 26],
         }
     )
-    c: pd.Series = df.groupby("Animal")["Max Speed"].value_counts()
-    check(assert_type(c, pd.Series), pd.Series)
+    c1 = df.groupby("Animal")["Max Speed"].value_counts()
+    c2 = df.groupby("Animal")["Max Speed"].value_counts(normalize=True)
+    check(assert_type(c1, pd.Series), pd.Series)
+    check(assert_type(c2, pd.Series), pd.Series)
 
 
 def test_setitem_none() -> None:


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

Follow up PR for #445 

Added the two value_counts method as told, tried to change the tests but I have some questions here:-
1) Sir actually when I write  test `check(assert_type(c1, pd.Series[int]), pd.Series, pd.Series[int])`
it shows  this error `Type application has too few types (2 expected)  [misc]` it only works when we write the test like
this `check(assert_type(c1, pd.Series[int]), pd.Series)`
2) and when the above change is made pytest does not work it shows this error `type' object is not subscriptable`
and only works when we write the test like `check(assert_type(c1, pd.Series), pd.Series)` but `mypy` fails here it says `Expression is of type "Series[float]", not "Series[Any]"  [assert-type]`
3) @Dr-Irv  Sir the recent changes you made in test_pandas.py in line 1443 also shows this error ` Failed: DID NOT WARN. No warnings of type (<class 'FutureWarni...` while running `poe pytest`