### PR TITLE
ENH: add dict to return type of func in `DataFrame#apply` when `result_type="expand"`

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1126,7 +1126,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
+        f: Callable[..., ListLikeExceptSeriesAndStr | Series | dict],
         axis: AxisType = ...,
         raw: _bool = ...,
         args=...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -477,6 +477,9 @@ def test_types_apply() -> None:
     def returns_listlike_of_3(x: pd.Series) -> tuple[int, int, int]:
         return (7, 8, 9)
 
+    def returns_dict(x: pd.Series) -> dict[str, int]:
+        return {"col4": 7, "col5": 8}
+
     # Misc checks
     check(assert_type(df.apply(np.exp), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.apply(str), "pd.Series[str]"), pd.Series, str)
@@ -516,6 +519,10 @@ def test_types_apply() -> None:
         assert_type(
             df.apply(returns_listlike_of_3, result_type="expand"), pd.DataFrame
         ),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.apply(returns_dict, result_type="expand"), pd.DataFrame),
         pd.DataFrame,
     )
 
@@ -597,6 +604,10 @@ def test_types_apply() -> None:
         assert_type(
             df.apply(returns_listlike_of_3, axis=1, result_type="expand"), pd.DataFrame
         ),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.apply(returns_dict, axis=1, result_type="expand"), pd.DataFrame),
         pd.DataFrame,
     )
 


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value


## Problem

It is perfectly valid to pass a function with a return type of `dict` as the `func` argument to `DataFrame#apply` when `result_type="expand"`, but the current type stub does not allow it.

For example, the following code

```py
def returns_dict(x: pd.Series) -> dict[str, int]:
    return {'x': 1, 'y': 2}

df.apply(returns_dict, axis=1, result_type="expand")
```

results in the following error when type-checked by Pyright:

```shell
error: Argument of type "(x: Series[Unknown]) -> dict[str, int]" cannot be assigned to parameter "f" of type "(...) -> Series[Unknown]" in function "apply"
    Type "(x: Series[Unknown]) -> dict[str, int]" cannot be assigned to type "(...) -> Series[Unknown]"
      Function return type "dict[str, int]" is incompatible with type "Series[Unknown]"
        "dict[str, int]" is incompatible with "Series[Unknown]" (reportGeneralTypeIssues)
error: Argument of type "Literal['expand']" cannot be assigned to parameter "result_type" of type "Literal['reduce']" in function "apply"
    "Literal['expand']" cannot be assigned to type "Literal['reduce']" (reportGeneralTypeIssues)
```

## Solution

Add `dict` to the return type of `func` argument of `DataFrame#apply` when `result_type="expand"`.

Also, add tests for passing a function that returns a dict to `DataFrame#apply` in the cases where `axis` is 0 and 1, respectively.