### PR TITLE
flake8-pyi's Y027: use collections.abc in pyi files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         - flake8-pyi==22.11.0
         types: [pyi]
         args: [
-          --ignore=E301 E302 E305 E402 E501 E701 E704 F401 F811 W503 Y019 Y027 Y034 Y037 Y041 Y042,
+          --ignore=E301 E302 E305 E402 E501 E701 E704 F401 F811 W503 Y019 Y034 Y037 Y041 Y042,
           # TypeVars in private files are already private
           --per-file-ignores=_*.pyi:Y001
         ]

--- a/pandas-stubs/_config/config.pyi
+++ b/pandas-stubs/_config/config.pyi
@@ -1,7 +1,7 @@
+from collections.abc import Iterable
 from contextlib import ContextDecorator
 from typing import (
     Any,
-    Iterable,
     Literal,
     overload,
 )

--- a/pandas-stubs/_libs/properties.pyi
+++ b/pandas-stubs/_libs/properties.pyi
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 class CachedProperty:
     def __init__(self, func: Callable) -> None: ...

--- a/pandas-stubs/_libs/tslibs/offsets.pyi
+++ b/pandas-stubs/_libs/tslibs/offsets.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from datetime import (
     date,
     datetime,
@@ -6,7 +7,6 @@ from datetime import (
 )
 from typing import (
     Any,
-    Collection,
     Literal,
     TypeVar,
     overload,

--- a/pandas-stubs/_libs/tslibs/vectorized.pyi
+++ b/pandas-stubs/_libs/tslibs/vectorized.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 

--- a/pandas-stubs/_testing/__init__.pyi
+++ b/pandas-stubs/_testing/__init__.pyi
@@ -1,7 +1,7 @@
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import (
     Any,
-    Generator,
     Literal,
     overload,
 )

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -1,17 +1,19 @@
 from builtins import type as type_t
+from collections.abc import (
+    Callable,
+    Hashable,
+    Iterator,
+    Mapping,
+    MutableSequence,
+    Sequence,
+)
 import datetime
 from os import PathLike
 from typing import (
     Any,
-    Callable,
-    Hashable,
-    Iterator,
     Literal,
-    Mapping,
-    MutableSequence,
     Optional,
     Protocol,
-    Sequence,
     TypedDict,
     TypeVar,
     Union,

--- a/pandas-stubs/core/algorithms.pyi
+++ b/pandas-stubs/core/algorithms.pyi
@@ -1,7 +1,5 @@
-from typing import (
-    Sequence,
-    overload,
-)
+from collections.abc import Sequence
+from typing import overload
 
 import numpy as np
 from pandas import (

--- a/pandas-stubs/core/arrays/base.pyi
+++ b/pandas-stubs/core/arrays/base.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 

--- a/pandas-stubs/core/arrays/categorical.pyi
+++ b/pandas-stubs/core/arrays/categorical.pyi
@@ -1,8 +1,10 @@
+from collections.abc import (
+    Callable,
+    Sequence,
+)
 from typing import (
     Any,
-    Callable,
     Literal,
-    Sequence,
     overload,
 )
 

--- a/pandas-stubs/core/arrays/datetimelike.pyi
+++ b/pandas-stubs/core/arrays/datetimelike.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 from pandas.core.arrays.base import (

--- a/pandas-stubs/core/arrays/period.pyi
+++ b/pandas-stubs/core/arrays/period.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 from pandas.core.arrays.datetimelike import (

--- a/pandas-stubs/core/arrays/timedeltas.pyi
+++ b/pandas-stubs/core/arrays/timedeltas.pyi
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from datetime import timedelta
-from typing import Sequence
 
 from pandas.core.arrays.datetimelike import (
     DatetimeLikeArrayMixin,

--- a/pandas-stubs/core/common.pyi
+++ b/pandas-stubs/core/common.pyi
@@ -1,4 +1,4 @@
-from typing import (
+from collections.abc import (
     Collection,
     Iterable,
 )

--- a/pandas-stubs/core/computation/eval.pyi
+++ b/pandas-stubs/core/computation/eval.pyi
@@ -1,7 +1,7 @@
+from collections.abc import Mapping
 from typing import (
     Any,
     Literal,
-    Mapping,
 )
 
 from pandas import (

--- a/pandas-stubs/core/computation/parsing.pyi
+++ b/pandas-stubs/core/computation/parsing.pyi
@@ -1,5 +1,5 @@
+from collections.abc import Iterator
 import tokenize
-from typing import Iterator
 
 BACKTICK_QUOTED_STRING: int
 

--- a/pandas-stubs/core/construction.pyi
+++ b/pandas-stubs/core/construction.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 from pandas.core.indexes.api import Index

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1,16 +1,18 @@
-import datetime
-import datetime as _dt
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
-    ClassVar,
     Hashable,
     Iterable,
     Iterator,
-    Literal,
     Mapping,
-    Pattern,
     Sequence,
+)
+import datetime
+import datetime as _dt
+from re import Pattern
+from typing import (
+    Any,
+    ClassVar,
+    Literal,
     TypeVar,
     overload,
 )

--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -1,13 +1,15 @@
+from collections.abc import (
+    Callable,
+    Hashable,
+    Iterable,
+    Mapping,
+    Sequence,
+)
 import sqlite3
 from typing import (
     Any,
-    Callable,
     ClassVar,
-    Hashable,
-    Iterable,
     Literal,
-    Mapping,
-    Sequence,
     final,
     overload,
 )

--- a/pandas-stubs/core/groupby/base.pyi
+++ b/pandas-stubs/core/groupby/base.pyi
@@ -1,6 +1,6 @@
 # from pandas.core.dtypes.common import is_list_like as is_list_like, is_scalar as is_scalar
+from collections.abc import Hashable
 import dataclasses
-from typing import Hashable
 
 @dataclasses.dataclass(order=True, frozen=True)
 class OutputKey:

--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -1,12 +1,14 @@
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
-    Generic,
     Iterable,
     Iterator,
+    Sequence,
+)
+from typing import (
+    Any,
+    Generic,
     Literal,
     NamedTuple,
-    Sequence,
     Union,
     overload,
 )

--- a/pandas-stubs/core/groupby/groupby.pyi
+++ b/pandas-stubs/core/groupby/groupby.pyi
@@ -1,4 +1,4 @@
-from typing import (
+from collections.abc import (
     Callable,
     Hashable,
 )

--- a/pandas-stubs/core/groupby/grouper.pyi
+++ b/pandas-stubs/core/groupby/grouper.pyi
@@ -1,4 +1,4 @@
-from typing import Hashable
+from collections.abc import Hashable
 
 import numpy as np
 from pandas import (

--- a/pandas-stubs/core/groupby/ops.pyi
+++ b/pandas-stubs/core/groupby/ops.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 from pandas import (

--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -1,11 +1,13 @@
-from typing import (
+from collections.abc import (
     Callable,
-    ClassVar,
     Hashable,
     Iterable,
     Iterator,
-    Literal,
     Sequence,
+)
+from typing import (
+    ClassVar,
+    Literal,
     overload,
 )
 

--- a/pandas-stubs/core/indexes/datetimes.pyi
+++ b/pandas-stubs/core/indexes/datetimes.pyi
@@ -1,12 +1,12 @@
+from collections.abc import (
+    Hashable,
+    Sequence,
+)
 from datetime import (
     timedelta,
     tzinfo,
 )
-from typing import (
-    Hashable,
-    Sequence,
-    overload,
-)
+from typing import overload
 
 import numpy as np
 from pandas import (

--- a/pandas-stubs/core/indexes/interval.pyi
+++ b/pandas-stubs/core/indexes/interval.pyi
@@ -1,9 +1,11 @@
+from collections.abc import (
+    Hashable,
+    Sequence,
+)
 import datetime as dt
 from typing import (
     Generic,
-    Hashable,
     Literal,
-    Sequence,
     Union,
     overload,
 )

--- a/pandas-stubs/core/indexes/multi.pyi
+++ b/pandas-stubs/core/indexes/multi.pyi
@@ -1,9 +1,9 @@
-from typing import (
+from collections.abc import (
     Callable,
     Hashable,
-    Literal,
     Sequence,
 )
+from typing import Literal
 
 import numpy as np
 import pandas as pd

--- a/pandas-stubs/core/indexes/numeric.pyi
+++ b/pandas-stubs/core/indexes/numeric.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from pandas.core.indexes.base import Index
 

--- a/pandas-stubs/core/indexes/period.pyi
+++ b/pandas-stubs/core/indexes/period.pyi
@@ -1,7 +1,5 @@
-from typing import (
-    Hashable,
-    overload,
-)
+from collections.abc import Hashable
+from typing import overload
 
 import numpy as np
 import pandas as pd

--- a/pandas-stubs/core/indexes/timedeltas.pyi
+++ b/pandas-stubs/core/indexes/timedeltas.pyi
@@ -1,8 +1,10 @@
+from collections.abc import (
+    Hashable,
+    Sequence,
+)
 import datetime as dt
 from typing import (
-    Hashable,
     Literal,
-    Sequence,
     overload,
 )
 

--- a/pandas-stubs/core/interchange/dataframe_protocol.pyi
+++ b/pandas-stubs/core/interchange/dataframe_protocol.pyi
@@ -3,11 +3,13 @@ from abc import (
     ABC,
     abstractmethod,
 )
+from collections.abc import (
+    Iterable,
+    Sequence,
+)
 import enum
 from typing import (
     Any,
-    Iterable,
-    Sequence,
     TypedDict,
 )
 

--- a/pandas-stubs/core/resample.pyi
+++ b/pandas-stubs/core/resample.pyi
@@ -1,10 +1,12 @@
-from typing import (
+from collections.abc import (
     Callable,
     Generator,
-    Generic,
     Hashable,
-    Literal,
     Mapping,
+)
+from typing import (
+    Generic,
+    Literal,
     overload,
 )
 

--- a/pandas-stubs/core/reshape/concat.pyi
+++ b/pandas-stubs/core/reshape/concat.pyi
@@ -1,8 +1,10 @@
-from typing import (
+from collections.abc import (
     Iterable,
-    Literal,
     Mapping,
     Sequence,
+)
+from typing import (
+    Literal,
     overload,
 )
 

--- a/pandas-stubs/core/reshape/encoding.pyi
+++ b/pandas-stubs/core/reshape/encoding.pyi
@@ -1,4 +1,4 @@
-from typing import (
+from collections.abc import (
     Hashable,
     Iterable,
 )

--- a/pandas-stubs/core/reshape/melt.pyi
+++ b/pandas-stubs/core/reshape/melt.pyi
@@ -1,4 +1,4 @@
-from typing import Hashable
+from collections.abc import Hashable
 
 import numpy as np
 from pandas.core.frame import DataFrame

--- a/pandas-stubs/core/reshape/pivot.pyi
+++ b/pandas-stubs/core/reshape/pivot.pyi
@@ -1,10 +1,12 @@
-import datetime
-from typing import (
+from collections.abc import (
     Callable,
     Hashable,
-    Literal,
     Mapping,
     Sequence,
+)
+import datetime
+from typing import (
+    Literal,
     Union,
     overload,
 )

--- a/pandas-stubs/core/reshape/tile.pyi
+++ b/pandas-stubs/core/reshape/tile.pyi
@@ -1,6 +1,6 @@
+from collections.abc import Sequence
 from typing import (
     Literal,
-    Sequence,
     overload,
 )
 

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1,3 +1,11 @@
+from collections.abc import (
+    Callable,
+    Hashable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from datetime import (
     date,
     datetime,
@@ -5,15 +13,9 @@ from datetime import (
 )
 from typing import (
     Any,
-    Callable,
     ClassVar,
     Generic,
-    Hashable,
-    Iterable,
-    Iterator,
     Literal,
-    Mapping,
-    Sequence,
     Union,
     overload,
 )

--- a/pandas-stubs/core/strings.pyi
+++ b/pandas-stubs/core/strings.pyi
@@ -1,10 +1,12 @@
+from collections.abc import (
+    Callable,
+    Sequence,
+)
 import re
 from typing import (
     Any,
-    Callable,
     Generic,
     Literal,
-    Sequence,
     TypeVar,
     overload,
 )

--- a/pandas-stubs/core/tools/datetimes.pyi
+++ b/pandas-stubs/core/tools/datetimes.pyi
@@ -1,10 +1,10 @@
+from collections.abc import Sequence
 from datetime import (
     date,
     datetime,
 )
 from typing import (
     Literal,
-    Sequence,
     Union,
     overload,
 )

--- a/pandas-stubs/core/tools/timedeltas.pyi
+++ b/pandas-stubs/core/tools/timedeltas.pyi
@@ -1,8 +1,6 @@
+from collections.abc import Sequence
 from datetime import timedelta
-from typing import (
-    Sequence,
-    overload,
-)
+from typing import overload
 
 from pandas import Index
 from pandas.core.indexes.timedeltas import TimedeltaIndex

--- a/pandas-stubs/core/window/expanding.pyi
+++ b/pandas-stubs/core/window/expanding.pyi
@@ -1,6 +1,6 @@
+from collections.abc import Callable
 from typing import (
     Any,
-    Callable,
     overload,
 )
 

--- a/pandas-stubs/core/window/rolling.pyi
+++ b/pandas-stubs/core/window/rolling.pyi
@@ -1,6 +1,6 @@
+from collections.abc import Callable
 from typing import (
     Any,
-    Callable,
     Generic,
     overload,
 )

--- a/pandas-stubs/io/clipboards.pyi
+++ b/pandas-stubs/io/clipboards.pyi
@@ -1,10 +1,12 @@
 from collections import defaultdict
+from collections.abc import (
+    Callable,
+    Sequence,
+)
 import csv
 from typing import (
     Any,
-    Callable,
     Literal,
-    Sequence,
     overload,
 )
 

--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -1,11 +1,13 @@
-from types import TracebackType
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
     Hashable,
     Iterable,
-    Literal,
     Sequence,
+)
+from types import TracebackType
+from typing import (
+    Any,
+    Literal,
     overload,
 )
 

--- a/pandas-stubs/io/formats/style.pyi
+++ b/pandas-stubs/io/formats/style.pyi
@@ -1,8 +1,10 @@
+from collections.abc import (
+    Callable,
+    Sequence,
+)
 from typing import (
     Any,
-    Callable,
     Literal,
-    Sequence,
     overload,
 )
 

--- a/pandas-stubs/io/formats/style_render.pyi
+++ b/pandas-stubs/io/formats/style_render.pyi
@@ -1,10 +1,12 @@
+from collections.abc import (
+    Callable,
+    Sequence,
+)
 from typing import (
     Any,
-    Callable,
     Generic,
     Literal,
     Optional,
-    Sequence,
     TypedDict,
     TypeVar,
     Union,

--- a/pandas-stubs/io/html.pyi
+++ b/pandas-stubs/io/html.pyi
@@ -1,11 +1,13 @@
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
     Hashable,
-    Literal,
     Mapping,
-    Pattern,
     Sequence,
+)
+from re import Pattern
+from typing import (
+    Any,
+    Literal,
 )
 
 from pandas.core.frame import DataFrame

--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -2,14 +2,16 @@ from collections import (
     abc,
     defaultdict,
 )
+from collections.abc import (
+    Callable,
+    Mapping,
+    Sequence,
+)
 import csv
 from types import TracebackType
 from typing import (
     Any,
-    Callable,
     Literal,
-    Mapping,
-    Sequence,
     overload,
 )
 

--- a/pandas-stubs/io/pytables.pyi
+++ b/pandas-stubs/io/pytables.pyi
@@ -1,9 +1,11 @@
+from collections.abc import (
+    Generator,
+    Sequence,
+)
 from types import TracebackType
 from typing import (
     Any,
-    Generator,
     Literal,
-    Sequence,
     overload,
 )
 

--- a/pandas-stubs/io/sas/sasreader.pyi
+++ b/pandas-stubs/io/sas/sasreader.pyi
@@ -2,8 +2,8 @@ from abc import (
     ABCMeta,
     abstractmethod,
 )
+from collections.abc import Hashable
 from typing import (
-    Hashable,
     Literal,
     overload,
 )

--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -1,9 +1,11 @@
-import sqlite3
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
     Generator,
     Iterable,
+)
+import sqlite3
+from typing import (
+    Any,
     Literal,
     Union,
     overload,

--- a/pandas-stubs/io/stata.pyi
+++ b/pandas-stubs/io/stata.pyi
@@ -1,10 +1,10 @@
 from collections import abc
+from collections.abc import Sequence
 import datetime
 from io import BytesIO
 from types import TracebackType
 from typing import (
     Literal,
-    Sequence,
     overload,
 )
 

--- a/pandas-stubs/io/xml.pyi
+++ b/pandas-stubs/io/xml.pyi
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from pandas.core.frame import DataFrame
 

--- a/pandas-stubs/plotting/_core.pyi
+++ b/pandas-stubs/plotting/_core.pyi
@@ -1,11 +1,13 @@
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
     Hashable,
     Iterable,
+    Sequence,
+)
+from typing import (
+    Any,
     Literal,
     NamedTuple,
-    Sequence,
     Union,
     overload,
 )

--- a/pandas-stubs/plotting/_misc.pyi
+++ b/pandas-stubs/plotting/_misc.pyi
@@ -1,8 +1,10 @@
+from collections.abc import (
+    Hashable,
+    Sequence,
+)
 from typing import (
     Any,
-    Hashable,
     Literal,
-    Sequence,
     Union,
 )
 

--- a/pandas-stubs/util/_decorators.pyi
+++ b/pandas-stubs/util/_decorators.pyi
@@ -1,8 +1,8 @@
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
     Mapping,
 )
+from typing import Any
 
 from pandas._libs.properties import cache_readonly as cache_readonly
 from pandas._typing import F

--- a/pandas-stubs/util/_validators.pyi
+++ b/pandas-stubs/util/_validators.pyi
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 


### PR DESCRIPTION
flake8-pyi encourages using `collections.abc` imports in pyi files.