### PR TITLE
Make DataFrame drop allow sets. Fix failing tests with latest Numpy version.

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -161,7 +161,7 @@ ListLike = TypeVar("ListLike", Sequence, np.ndarray, "Series", "Index")
 ListLikeExceptSeriesAndStr = TypeVar(
     "ListLikeExceptSeriesAndStr", MutableSequence, np.ndarray, tuple, "Index"
 )
-ListLikeU: TypeAlias = Union[Sequence, np.ndarray, Series, Index]
+ListLikeU: TypeAlias = Union[Sequence, np.ndarray, Series, Index, set]
 StrLike: TypeAlias = Union[str, np.str_]
 Scalar: TypeAlias = Union[
     str,

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -563,11 +563,11 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def drop(
         self,
-        labels: Hashable | Sequence[Hashable] | Index = ...,
+        labels: Hashable | ListLikeU = ...,
         *,
         axis: Axis = ...,
-        index: Hashable | Sequence[Hashable] | Index = ...,
-        columns: Hashable | Sequence[Hashable] | Index = ...,
+        index: Hashable | ListLikeU = ...,
+        columns: Hashable | ListLikeU = ...,
         level: Level | None = ...,
         inplace: Literal[True],
         errors: IgnoreRaise = ...,
@@ -575,11 +575,11 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def drop(
         self,
-        labels: Hashable | Sequence[Hashable] | Index = ...,
+        labels: Hashable | ListLikeU = ...,
         *,
         axis: Axis = ...,
-        index: Hashable | Sequence[Hashable] | Index = ...,
-        columns: Hashable | Sequence[Hashable] | Index = ...,
+        index: Hashable | ListLikeU = ...,
+        columns: Hashable | ListLikeU = ...,
         level: Level | None = ...,
         inplace: Literal[False] = ...,
         errors: IgnoreRaise = ...,
@@ -587,11 +587,11 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def drop(
         self,
-        labels: Hashable | Sequence[Hashable] | Index = ...,
+        labels: Hashable | ListLikeU = ...,
         *,
         axis: Axis = ...,
-        index: Hashable | Sequence[Hashable] | Index = ...,
-        columns: Hashable | Sequence[Hashable] | Index = ...,
+        index: Hashable | ListLikeU = ...,
+        columns: Hashable | ListLikeU = ...,
         level: Level | None = ...,
         inplace: bool = ...,
         errors: IgnoreRaise = ...,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ jinja2 = "^3.1"
 scipy = ">=1.9.1"
 SQLAlchemy = "^1.4.41"
 types-python-dateutil = ">=2.8.19"
+numpy = "^1.24.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -267,6 +267,9 @@ def test_types_drop() -> None:
     check(assert_type(df.drop(pd.Index([1])), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.drop(index=pd.Index([1])), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.drop(columns=pd.Index(["col1"])), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.drop({1}), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.drop(index={1}), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.drop(columns={"col1"}), pd.DataFrame), pd.DataFrame)
 
 
 def test_types_dropna() -> None:

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1700,7 +1700,7 @@ def test_pivot_table() -> None:
         ),
         pd.DataFrame,
     )
-    with pytest.warns(np.VisibleDeprecationWarning):
+    with pytest.raises(ValueError):
         check(
             assert_type(
                 pd.pivot_table(
@@ -1714,7 +1714,7 @@ def test_pivot_table() -> None:
             ),
             pd.DataFrame,
         )
-    with pytest.warns(np.VisibleDeprecationWarning):
+    with pytest.raises(ValueError):
         check(
             assert_type(
                 pd.pivot_table(


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

The following example runs successfully in Pandas 1.5.2 but fails with Pandas-stubs 1.5.2.221124 and Mypy 0.991:
```
import pandas as pd
pd.DataFrame({"a": 1}, index=[1]).drop(columns={"a"})
```
Mypy error
```
error: No overload variant of "drop" of "DataFrame" matches argument type "Set[str]"  [call-overload]
note: Possible overload variants:
note:     def drop(self, labels: Union[Hashable, Sequence[Hashable], Index] = ..., *, axis: Union[str, int] = ..., index: Union[Hashable, Sequence[Hashable], Index] = ..., columns: Union[Hashable, Sequence[Hashable], Index] = ..., level: Optional[Union[Hashable, int]] = ..., inplace: Literal[True], errors: Literal['ignore', 'raise'] = ...) -> None
note:     def drop(self, labels: Union[Hashable, Sequence[Hashable], Index] = ..., *, axis: Union[str, int] = ..., index: Union[Hashable, Sequence[Hashable], Index] = ..., columns: Union[Hashable, Sequence[Hashable], Index] = ..., level: Optional[Union[Hashable, int]] = ..., inplace: Literal[False] = ..., errors: Literal['ignore', 'raise'] = ...) -> DataFrame
note:     def drop(self, labels: Union[Hashable, Sequence[Hashable], Index] = ..., *, axis: Union[str, int] = ..., index: Union[Hashable, Sequence[Hashable], Index] = ..., columns: Union[Hashable, Sequence[Hashable], Index] = ..., level: Optional[Union[Hashable, int]] = ..., inplace: bool = ..., errors: Literal['ignore', 'raise'] = ...) -> Optional[DataFrame]
```
According to the Pandas documentation the labels, index and columns arguments should accept list-like types, and that includes sets accroding to this: https://pandas.pydata.org/docs/reference/api/pandas.api.types.is_list_like.html

Also some previously deprecated ways of calling `pivot_table` have been removed as of Numpy 1.24.0, so some tests had to be changed to succeed.