### PR TITLE
feat: add `table` to JsonSeriesOrient Literals

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -318,7 +318,7 @@ MergeHow: TypeAlias = Union[JoinHow, Literal["cross"]]
 JsonFrameOrient: TypeAlias = Literal[
     "split", "records", "index", "columns", "values", "table"
 ]
-JsonSeriesOrient: TypeAlias = Literal["split", "records", "index"]
+JsonSeriesOrient: TypeAlias = Literal["split", "records", "index", "table"]
 
 TimestampConvention: TypeAlias = Literal["start", "end", "s", "e"]
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -387,7 +387,7 @@ def test_json():
     check(assert_type(read_json(bin_json), DataFrame), DataFrame)
 
 
-def test_json_series(orient):
+def test_json_series():
     s = DF["a"]
     check(
         assert_type(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -389,6 +389,10 @@ def test_json():
 
 def test_json_series():
     s = DF["a"]
+    with ensure_clean() as path:
+        check(assert_type(s.to_json(path), None), type(None))
+        check(assert_type(read_json(path, typ="series"), Series), Series)
+    check(assert_type(DF.to_json(), str), str)
     check(
         assert_type(
             read_json(s.to_json(orient=None), typ="series", orient=None), Series

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -387,12 +387,12 @@ def test_json():
     check(assert_type(read_json(bin_json), DataFrame), DataFrame)
 
 
-def test_json_series():
+@pytest.mark.parametrize("orient", [None, "split", "records", "index", "table"])
+def test_json_series(orient):
     s = DF["a"]
     with ensure_clean() as path:
-        check(assert_type(s.to_json(path), None), type(None))
-        check(assert_type(read_json(path, typ="series"), Series), Series)
-    check(assert_type(DF.to_json(), str), str)
+        check(assert_type(s.to_json(path, orient=orient), None), type(None))
+        check(assert_type(read_json(path, typ="series", orient=orient), Series), Series)
 
 
 def test_json_chunk():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -387,12 +387,39 @@ def test_json():
     check(assert_type(read_json(bin_json), DataFrame), DataFrame)
 
 
-@pytest.mark.parametrize("orient", [None, "split", "records", "index", "table"])
 def test_json_series(orient):
     s = DF["a"]
-    with ensure_clean() as path:
-        check(assert_type(s.to_json(path, orient=orient), None), type(None))
-        check(assert_type(read_json(path, typ="series", orient=orient), Series), Series)
+    check(
+        assert_type(
+            read_json(s.to_json(orient=None), typ="series", orient=None), Series
+        ),
+        Series,
+    )
+    check(
+        assert_type(
+            read_json(s.to_json(orient="split"), typ="series", orient="split"), Series
+        ),
+        Series,
+    )
+    check(
+        assert_type(
+            read_json(s.to_json(orient="records"), typ="series", orient="records"),
+            Series,
+        ),
+        Series,
+    )
+    check(
+        assert_type(
+            read_json(s.to_json(orient="index"), typ="series", orient="index"), Series
+        ),
+        Series,
+    )
+    check(
+        assert_type(
+            read_json(s.to_json(orient="table"), typ="series", orient="table"), Series
+        ),
+        Series,
+    )
 
 
 def test_json_chunk():


### PR DESCRIPTION
- [ ] Closes #481

Includes the Literal `table` for the `orient` argument in s.to_json().