### PR TITLE
fix: test setter on df.columns with pyright, not mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ types-pytz = ">= 2022.1.1"
 mypy = "0.991"
 pyarrow = ">=10.0.1"
 pytest = ">=7.1.2"
-pyright = ">=1.1.284"
+pyright = ">=1.1.286"
 poethepoet = "0.16.0"
 loguru = ">=0.6.0"
 pandas = "1.5.2"
@@ -171,6 +171,7 @@ strict_equality = true
 show_error_context = false
 show_column_numbers = false
 show_error_codes = true
+always_true = "IS_TYPE_CHECKER_MYPY"
 
 [tool.pyright]
 typeCheckingMode = "strict"
@@ -192,3 +193,5 @@ reportUnusedVariable = false
 reportPrivateUsage = false
 # enable optional checks
 reportMissingModuleSource = true
+defineConstant = { IS_TYPE_CHECKER_MYPY = false }
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,6 +22,7 @@ from pandas._typing import T
 TYPE_CHECKING_INVALID_USAGE: Final = TYPE_CHECKING
 WINDOWS = os.name == "nt" or "cygwin" in platform.system().lower()
 PD_LTE_15 = Version(pd.__version__) < Version("1.5.999")
+IS_TYPE_CHECKER_MYPY = True
 
 lxml_skip = pytest.mark.skipif(
     sys.version_info >= (3, 11), reason="lxml is not available for 3.11 yet"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -38,6 +38,7 @@ import xarray as xr
 from pandas._typing import Scalar
 
 from tests import (
+    IS_TYPE_CHECKER_MYPY,
     PD_LTE_15,
     TYPE_CHECKING_INVALID_USAGE,
     check,
@@ -1775,18 +1776,20 @@ def test_iloc_tuple() -> None:
 def test_set_columns() -> None:
     # GH 73
     df = pd.DataFrame({"a": [1, 2, 3], "b": [0.0, 1, 1]})
-    # Next line should work, but it is a mypy bug
+    # Next lines should work, but it is a mypy bug
     # https://github.com/python/mypy/issues/3004
-    # pyright doesn't need the ignore
-    df.columns = ["c", "d"]  # type: ignore[assignment]
-    df.columns = [1, 2]  # type: ignore[assignment]
-    df.columns = [1, "a"]  # type: ignore[assignment]
-    df.columns = np.array([1, 2])  # type: ignore[assignment]
-    df.columns = pd.Series([1, 2])  # type: ignore[assignment]
-    df.columns = np.array([1, "a"])  # type: ignore[assignment]
-    df.columns = pd.Series([1, "a"])  # type: ignore[assignment]
-    df.columns = (1, 2)  # type: ignore[assignment]
-    df.columns = (1, "a")  # type: ignore[assignment]
+    # pyright accepts this, so we only type check for pyright,
+    # and also test the code with pytest
+    if (TYPE_CHECKING and not IS_TYPE_CHECKER_MYPY) or not TYPE_CHECKING:
+        df.columns = ["c", "d"]
+        df.columns = [1, 2]
+        df.columns = [1, "a"]
+        df.columns = np.array([1, 2])
+        df.columns = pd.Series([1, 2])
+        df.columns = np.array([1, "a"])
+        df.columns = pd.Series([1, "a"])
+        df.columns = (1, 2)
+        df.columns = (1, "a")
 
 
 def test_frame_index_numpy() -> None:


### PR DESCRIPTION
pyright 1.1.286 fixed an issue that didn't allow users to write `df.columns = ["abc", "def"]`.

Our testing code was not picking this up because we had `#type: ignore` comments on the testing code, which are needed because of a mypy bug.

So I've instrumented the test to be checked with `pyright`, but not `mypy`.  Unfortunately, `mypy` doesn't support a `mypy: ignore` comment.

- Issue reported to pyright  was here:  https://github.com/microsoft/pyright/issues/4293
- Discussion on how to see which type checker is being used is here:  https://github.com/microsoft/pyright/issues/4292

