### PR TITLE
Fix issue for pandera allowing generic Series to work

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -70,6 +70,7 @@ from typing_extensions import (
 )
 import xarray as xr
 
+from pandas._libs.interval import Interval
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs import BaseOffset
 from pandas._typing import (
@@ -94,7 +95,6 @@ from pandas._typing import (
     IgnoreRaise,
     IndexingInt,
     IntervalClosedType,
-    IntervalT,
     JoinHow,
     JsonSeriesOrient,
     Level,
@@ -216,13 +216,43 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def __new__(
         cls,
-        data: IntervalIndex[IntervalT],
+        data: IntervalIndex[Interval[int]],
         index: Axes | None = ...,
         dtype=...,
         name: Hashable | None = ...,
         copy: bool = ...,
         fastpath: bool = ...,
-    ) -> Series[IntervalT]: ...
+    ) -> Series[Interval[int]]: ...
+    @overload
+    def __new__(
+        cls,
+        data: IntervalIndex[Interval[float]],
+        index: Axes | None = ...,
+        dtype=...,
+        name: Hashable | None = ...,
+        copy: bool = ...,
+        fastpath: bool = ...,
+    ) -> Series[Interval[float]]: ...
+    @overload
+    def __new__(
+        cls,
+        data: IntervalIndex[Interval[Timestamp]],
+        index: Axes | None = ...,
+        dtype=...,
+        name: Hashable | None = ...,
+        copy: bool = ...,
+        fastpath: bool = ...,
+    ) -> Series[Interval[Timestamp]]: ...
+    @overload
+    def __new__(
+        cls,
+        data: IntervalIndex[Interval[Timedelta]],
+        index: Axes | None = ...,
+        dtype=...,
+        name: Hashable | None = ...,
+        copy: bool = ...,
+        fastpath: bool = ...,
+    ) -> Series[Interval[Timedelta]]: ...
     @overload
     def __new__(
         cls,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1367,7 +1367,7 @@ def test_AnyArrayLike_and_clip() -> None:
 
 
 def test_pandera_generic() -> None:
-    # GH 497
+    # GH 471
     T = TypeVar("T")
 
     class MySeries(pd.Series, Generic[T]):

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -7,11 +7,13 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Generic,
     Hashable,
     Iterable,
     Iterator,
     List,
     Sequence,
+    TypeVar,
     cast,
 )
 
@@ -1362,3 +1364,16 @@ def test_AnyArrayLike_and_clip() -> None:
     s2 = ser.clip(upper=ser)
     check(assert_type(s1, pd.Series), pd.Series)
     check(assert_type(s2, pd.Series), pd.Series)
+
+
+def test_pandera_generic() -> None:
+    # GH 497
+    T = TypeVar("T")
+
+    class MySeries(pd.Series, Generic[T]):
+        ...
+
+    def func() -> MySeries[float]:
+        return MySeries[float]([1, 2, 3])
+
+    func()


### PR DESCRIPTION
- [x] Closes #471
- [x] Tests added: 
  - `test_series.py:test_pandera_generic()`

Fix here is to expand the `Series[IntervalT].__new__()` into each individual part.  Seems like a double `TypeVar` causes issues for `mypy`.  Had to do a similar fix for `Interval.__contains__()`

Either @twoertwein or @bashtage can approve or merge (both not required)
