### PR TITLE
pin SQLAlchemy to 1.4.45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ xarray = ">=22.6.0"
 tabulate = ">=0.8.10"
 jinja2 = "^3.1"
 scipy = ">=1.9.1"
-SQLAlchemy = "^1.4.41"
+SQLAlchemy = "<=1.4.45"
 types-python-dateutil = ">=2.8.19"
 
 [build-system]


### PR DESCRIPTION
CI is failing because SQLAlchemy 1.4.46 issues a warning that is not issued with 1.4.45.  So pin SQLAlchemy 1.4.45 here.

pandas issue created at https://github.com/pandas-dev/pandas/issues/50558
