### PR TITLE
Remove use of Never

### DIFF
--- a/pandas-stubs/core/indexes/interval.pyi
+++ b/pandas-stubs/core/indexes/interval.pyi
@@ -18,10 +18,7 @@ from pandas.core.series import (
     TimedeltaSeries,
     TimestampSeries,
 )
-from typing_extensions import (
-    Never,
-    TypeAlias,
-)
+from typing_extensions import TypeAlias
 
 from pandas._libs.interval import (
     Interval as Interval,
@@ -260,31 +257,29 @@ class IntervalIndex(IntervalMixin, ExtensionIndex, Generic[IntervalT]):
     # override is due to additional types for comparison
     # misc is due to overlap with object below
     @overload  # type: ignore[override]
-    def __gt__(  # type: ignore[misc]
+    def __gt__(
         self, other: IntervalT | IntervalIndex[IntervalT]
     ) -> np_ndarray_bool: ...
     @overload
-    def __gt__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...  # type: ignore[misc]
-    @overload
-    def __gt__(self, other: object) -> Never: ...
+    def __gt__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...
     @overload  # type: ignore[override]
-    def __ge__(self, other: IntervalT | IntervalIndex[IntervalT]) -> np_ndarray_bool: ...  # type: ignore[misc]
+    def __ge__(
+        self, other: IntervalT | IntervalIndex[IntervalT]
+    ) -> np_ndarray_bool: ...
     @overload
-    def __ge__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...  # type: ignore[misc]
-    @overload
-    def __ge__(self, other: object) -> Never: ...
+    def __ge__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...
     @overload  # type: ignore[override]
-    def __le__(self, other: IntervalT | IntervalIndex[IntervalT]) -> np_ndarray_bool: ...  # type: ignore[misc]
+    def __le__(
+        self, other: IntervalT | IntervalIndex[IntervalT]
+    ) -> np_ndarray_bool: ...
     @overload
-    def __le__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...  # type: ignore[misc]
-    @overload
-    def __le__(self, other: object) -> Never: ...
+    def __le__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...
     @overload  # type: ignore[override]
-    def __lt__(self, other: IntervalT | IntervalIndex[IntervalT]) -> np_ndarray_bool: ...  # type: ignore[misc]
+    def __lt__(
+        self, other: IntervalT | IntervalIndex[IntervalT]
+    ) -> np_ndarray_bool: ...
     @overload
     def __lt__(self, other: pd.Series[IntervalT]) -> bool: ...  # type: ignore[misc]
-    @overload
-    def __lt__(self, other: object) -> Never: ...
     @overload  # type: ignore[override]
     def __eq__(self, other: IntervalT | IntervalIndex[IntervalT]) -> np_ndarray_bool: ...  # type: ignore[misc]
     @overload

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -65,10 +65,7 @@ from pandas.core.window.rolling import (
     Rolling,
     Window,
 )
-from typing_extensions import (
-    Never,
-    TypeAlias,
-)
+from typing_extensions import TypeAlias
 import xarray as xr
 
 from pandas._libs.interval import Interval
@@ -1814,8 +1811,8 @@ class TimestampSeries(Series[Timestamp]):
     @property
     def dt(self) -> TimestampProperties: ...  # type: ignore[override]
     def __add__(self, other: TimedeltaSeries | np.timedelta64) -> TimestampSeries: ...  # type: ignore[override]
-    def __mul__(self, other: TimestampSeries | np.timedelta64 | TimedeltaSeries) -> Never: ...  # type: ignore[override]
-    def __truediv__(self, other: TimestampSeries | np.timedelta64 | TimedeltaSeries) -> Never: ...  # type: ignore[override]
+    def __mul__(self, other: int | float | Series[int] | Series[float] | Sequence[int | float]) -> TimestampSeries: ...  # type: ignore[override]
+    def __truediv__(self, other: int | float | Series[int] | Series[float] | Sequence[int | float]) -> TimestampSeries: ...  # type: ignore[override]
     def mean(  # type: ignore[override]
         self,
         axis: SeriesAxisType | None = ...,
@@ -1853,12 +1850,9 @@ class TimedeltaSeries(Series[Timedelta]):
     @overload
     def __add__(self, other: Timedelta | np.timedelta64) -> TimedeltaSeries: ...
     def __radd__(self, other: Timestamp | TimestampSeries) -> TimestampSeries: ...  # type: ignore[override]
-    @overload  # type: ignore[override]
-    def __mul__(
-        self, other: TimestampSeries | np.timedelta64 | Timedelta | TimedeltaSeries
-    ) -> Never: ...
-    @overload
-    def __mul__(self, other: num) -> TimedeltaSeries: ...
+    def __mul__(  # type: ignore[override]
+        self, other: num | Sequence[num] | Series[int] | Series[float]
+    ) -> TimedeltaSeries: ...
     def __sub__(  # type: ignore[override]
         self, other: Timedelta | TimedeltaSeries | TimedeltaIndex | np.timedelta64
     ) -> TimedeltaSeries: ...

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -14,10 +14,7 @@ from numpy import typing as npt
 import pandas as pd
 from pandas.core.indexes.numeric import IntegerIndex
 import pytz
-from typing_extensions import (
-    Never,
-    assert_type,
-)
+from typing_extensions import assert_type
 
 from pandas._libs import NaTType
 from pandas._libs.tslibs import BaseOffset
@@ -1088,9 +1085,9 @@ def test_timedelta64_and_arithmatic_operator() -> None:
     check(assert_type((s3 + td), "TimedeltaSeries"), pd.Series, pd.Timedelta)
     check(assert_type((s3 / td), "pd.Series[float]"), pd.Series, float)
     if TYPE_CHECKING_INVALID_USAGE:
-        assert_type((s1 * td), Never)  # pyright: ignore[reportGeneralTypeIssues]
-        assert_type((s1 / td), Never)  # pyright: ignore[reportGeneralTypeIssues]
-        assert_type((s3 * td), Never)  # pyright: ignore[reportGeneralTypeIssues]
+        r1 = s1 * td  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
+        r2 = s1 / td  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
+        r3 = s3 * td  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
 
 
 def test_timedeltaseries_add_timestampseries() -> None:


### PR DESCRIPTION
- [x] Closes #441
- [ ] Tests added: None

Turns out that I misunderstood the use of `Never`, and we don't need to use it.  See https://github.com/pandas-dev/pandas-stubs/issues/441#issuecomment-1379450907 .

