### PR TITLE
remove np.datetime64 from S1, make adding two TimestampSeries fail

### DIFF
--- a/pandas-stubs/_libs/tslibs/timestamps.pyi
+++ b/pandas-stubs/_libs/tslibs/timestamps.pyi
@@ -217,7 +217,7 @@ class Timestamp(datetime):
     @overload
     def __eq__(self, other: Timestamp | datetime | np.datetime64) -> bool: ...  # type: ignore[misc] # pyright: ignore[reportOverlappingOverload]
     @overload
-    def __eq__(self, other: TimestampSeries | Series[np.datetime64]) -> Series[bool]: ...  # type: ignore[misc]
+    def __eq__(self, other: TimestampSeries) -> Series[bool]: ...  # type: ignore[misc]
     @overload
     def __eq__(self, other: npt.NDArray[np.datetime64] | Index) -> np_ndarray_bool: ...  # type: ignore[misc]
     @overload
@@ -225,7 +225,7 @@ class Timestamp(datetime):
     @overload
     def __ne__(self, other: Timestamp | datetime | np.datetime64) -> bool: ...  # type: ignore[misc] # pyright: ignore[reportOverlappingOverload]
     @overload
-    def __ne__(self, other: TimestampSeries | Series[np.datetime64]) -> Series[bool]: ...  # type: ignore[misc]
+    def __ne__(self, other: TimestampSeries) -> Series[bool]: ...  # type: ignore[misc]
     @overload
     def __ne__(self, other: npt.NDArray[np.datetime64] | Index) -> np_ndarray_bool: ...  # type: ignore[misc]
     @overload

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -207,7 +207,6 @@ S1 = TypeVar(
     complex,
     Timestamp,
     Timedelta,
-    np.datetime64,
     Period,
     Interval[int],
     Interval[float],

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -178,7 +178,6 @@ class _LocIndexerSeries(_LocIndexer, Generic[S1]):
     ) -> None: ...
 
 class Series(IndexOpsMixin, NDFrame, Generic[S1]):
-
     _ListLike: TypeAlias = Union[ArrayLike, dict[_str, np.ndarray], list, tuple, Index]
     __hash__: ClassVar[None]
 
@@ -188,6 +187,16 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         data: DatetimeIndex | Sequence[Timestamp | np.datetime64 | datetime],
         index: Axes | None = ...,
         dtype=...,
+        name: Hashable | None = ...,
+        copy: bool = ...,
+        fastpath: bool = ...,
+    ) -> TimestampSeries: ...
+    @overload
+    def __new__(
+        cls,
+        data: _ListLike,
+        dtype: Literal["datetime64[ns]"],
+        index: Axes | None = ...,
         name: Hashable | None = ...,
         copy: bool = ...,
         fastpath: bool = ...,
@@ -1800,6 +1809,7 @@ class TimestampSeries(Series[Timestamp]):
     @property
     def dt(self) -> TimestampProperties: ...  # type: ignore[override]
     def __add__(self, other: TimedeltaSeries | np.timedelta64) -> TimestampSeries: ...  # type: ignore[override]
+    def __radd__(self, other: TimedeltaSeries | np.timedelta64) -> TimestampSeries: ...  # type: ignore[override]
     def __mul__(self, other: int | float | Series[int] | Series[float] | Sequence[int | float]) -> TimestampSeries: ...  # type: ignore[override]
     def __truediv__(self, other: int | float | Series[int] | Series[float] | Sequence[int | float]) -> TimestampSeries: ...  # type: ignore[override]
     def mean(  # type: ignore[override]

--- a/tests/test_scalars.py
+++ b/tests/test_scalars.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
 
     from pandas._typing import np_ndarray_bool
 else:
-
     np_ndarray_bool = npt.NDArray[np.bool_]
     TimedeltaSeries: TypeAlias = pd.Series
     TimestampSeries: TypeAlias = pd.Series
@@ -386,7 +385,6 @@ def test_interval_cmp():
 
 
 def test_timedelta_construction() -> None:
-
     check(assert_type(pd.Timedelta(1, "H"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta(1, "T"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta(1, "S"), pd.Timedelta), pd.Timedelta)
@@ -1078,7 +1076,6 @@ def test_timedelta_cmp_rhs() -> None:
 
 
 def test_timestamp_construction() -> None:
-
     check(assert_type(pd.Timestamp("2000-1-1"), pd.Timestamp), pd.Timestamp)
     check(
         assert_type(pd.Timestamp("2000-1-1", tz="US/Pacific"), pd.Timestamp),
@@ -1256,9 +1253,7 @@ def test_timestamp_cmp() -> None:
     c_dt_datetime = dt.datetime(year=2000, month=1, day=1)
     c_datetimeindex = pd.DatetimeIndex(["2000-1-1"])
     c_np_ndarray_dt64 = np_dt64_arr
-    c_series_dt64: pd.Series[np.datetime64] = pd.Series(
-        [1, 2, 3], dtype="datetime64[ns]"
-    )
+    c_series_dt64: TimestampSeries = pd.Series([1, 2, 3], dtype="datetime64[ns]")
     c_series_timestamp = pd.Series(pd.DatetimeIndex(["2000-1-1"]))
     check(assert_type(c_series_timestamp, TimestampSeries), pd.Series, pd.Timestamp)
     # Use xor to ensure one is True and the other is False

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -259,7 +259,7 @@ def test_fail_on_adding_two_timestamps() -> None:
     s1 = pd.Series(pd.to_datetime(["2022-05-01", "2022-06-01"]))
     s2 = pd.Series(pd.to_datetime(["2022-05-15", "2022-06-15"]))
     if TYPE_CHECKING_INVALID_USAGE:
-        ssum: pd.Series = s1 + s2  # type: ignore[operator]
+        ssum: pd.Series = s1 + s2  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
         ts = pd.Timestamp("2022-06-30")
         tsum: pd.Series = s1 + ts  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
 


### PR DESCRIPTION
Turns out that it is not possible to have a `Series` containing `np.datetime64` types - they get converted to `Timestamp`.  Discovered this with some experiments that showed we were allowing two `Series` of `Timestamp` to be added, which is not possible, so fixed that as well.

