### PR TITLE
fix NumericIndex for nightly

### DIFF
--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -12,7 +12,6 @@ from typing import (
 import numpy as np
 from numpy import typing as npt
 import pandas as pd
-from pandas.core.indexes.numeric import NumericIndex
 from typing_extensions import (
     Never,
     assert_type,
@@ -20,14 +19,24 @@ from typing_extensions import (
 
 from pandas._typing import Scalar
 
-if TYPE_CHECKING:
-    from pandas._typing import IndexIterScalar
-
 from tests import (
+    PD_LTE_15,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
 )
+
+if TYPE_CHECKING:
+    from pandas.core.indexes.numeric import NumericIndex
+
+    from pandas._typing import IndexIterScalar
+else:
+    if not PD_LTE_15:
+        from typing_extensions import TypeAlias
+
+        NumericIndex: TypeAlias = pd.Index
+    else:
+        from pandas.core.indexes.numeric import NumericIndex
 
 
 def test_index_unique() -> None:

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -32,9 +32,7 @@ if TYPE_CHECKING:
     from pandas._typing import IndexIterScalar
 else:
     if not PD_LTE_15:
-        from typing_extensions import TypeAlias
-
-        NumericIndex: TypeAlias = pd.Index
+        from pandas import Index as NumericIndex
     else:
         from pandas.core.indexes.numeric import NumericIndex
 

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -12,7 +12,6 @@ from typing import (
 import numpy as np
 from numpy import typing as npt
 import pandas as pd
-from pandas.core.indexes.numeric import NumericIndex
 import pytz
 from typing_extensions import assert_type
 
@@ -25,6 +24,7 @@ if TYPE_CHECKING:
 else:
     FulldatetimeDict = Any
 from tests import (
+    PD_LTE_15,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
@@ -45,6 +45,17 @@ if TYPE_CHECKING:
         TimedeltaSeries,
         TimestampSeries,
     )
+
+if TYPE_CHECKING:
+    from pandas.core.indexes.numeric import NumericIndex
+
+else:
+    if not PD_LTE_15:
+        from typing_extensions import TypeAlias
+
+        NumericIndex: TypeAlias = pd.Index
+    else:
+        from pandas.core.indexes.numeric import NumericIndex
 
 # Separately define here so pytest works
 np_ndarray_bool = npt.NDArray[np.bool_]

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -51,9 +51,7 @@ if TYPE_CHECKING:
 
 else:
     if not PD_LTE_15:
-        from typing_extensions import TypeAlias
-
-        NumericIndex: TypeAlias = pd.Index
+        from pandas import Index as NumericIndex
     else:
         from pandas.core.indexes.numeric import NumericIndex
 


### PR DESCRIPTION
Nightly builds were failing because `NumericIndex` is removed for 2.0, so this allows it to work for 1.5.x, but removes it from testing for 2.0. 

Once 2.0 is released, then we can remove `NumericIndex` in the PYI and tests.

