### PR TITLE
remove types from Index.__iter__()`

### DIFF
--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -33,7 +33,6 @@ from pandas._typing import (
     DtypeObj,
     FillnaOptions,
     HashableT,
-    IndexIterScalar,
     IndexT,
     Label,
     Level,
@@ -223,7 +222,7 @@ class Index(IndexOpsMixin, PandasObject):
     def shape(self) -> tuple[int, ...]: ...
     # Extra methods from old stubs
     def __eq__(self, other: object) -> np_ndarray_bool: ...  # type: ignore[override]
-    def __iter__(self) -> Iterator[IndexIterScalar | tuple[Hashable, ...]]: ...
+    def __iter__(self) -> Iterator: ...
     def __ne__(self, other: object) -> np_ndarray_bool: ...  # type: ignore[override]
     def __le__(self, other: Index | Scalar) -> np_ndarray_bool: ...  # type: ignore[override]
     def __ge__(self, other: Index | Scalar) -> np_ndarray_bool: ...  # type: ignore[override]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1813,7 +1813,6 @@ def test_frame_index_numpy() -> None:
 
 
 def test_frame_stack() -> None:
-
     multicol2 = pd.MultiIndex.from_tuples([("weight", "kg"), ("height", "m")])
     df_multi_level_cols2 = pd.DataFrame(
         [[1.0, 2.0], [3.0, 4.0]], index=["cat", "dog"], columns=multicol2
@@ -2406,6 +2405,10 @@ def test_npint_loc_indexer() -> None:
 
 
 def test_in_columns() -> None:
+    # GH 532 (PR)
     df = pd.DataFrame(np.random.random((3, 4)), columns=["cat", "dog", "rat", "pig"])
     cols = [c for c in df.columns if "at" in c]
     check(assert_type(cols, list), list, str)
+    check(assert_type(df.loc[:, cols], pd.DataFrame), pd.DataFrame)
+    check(assert_type(df[cols], pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.groupby(by=cols).sum(), pd.DataFrame), pd.DataFrame)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2403,3 +2403,9 @@ def test_npint_loc_indexer() -> None:
 
     a: npt.NDArray[np.uint64] = np.array([10, 30], dtype="uint64")
     check(assert_type(get_NDArray(df, a), pd.DataFrame), pd.DataFrame)
+
+
+def test_in_columns() -> None:
+    df = pd.DataFrame(np.random.random((3, 4)), columns=["cat", "dog", "rat", "pig"])
+    cols = [c for c in df.columns if "at" in c]
+    check(assert_type(cols, list), list, str)

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import datetime as dt
 from typing import (
     TYPE_CHECKING,
-    Hashable,
-    List,
     Tuple,
     Union,
 )
@@ -29,7 +27,6 @@ from tests import (
 if TYPE_CHECKING:
     from pandas.core.indexes.numeric import NumericIndex
 
-    from pandas._typing import IndexIterScalar
 else:
     if not PD_LTE_15:
         from pandas import Index as NumericIndex
@@ -108,7 +105,7 @@ def test_column_sequence() -> None:
     df = pd.DataFrame([1, 2, 3])
     col_list = list(df.columns)
     check(
-        assert_type(col_list, List[Union["IndexIterScalar", Tuple[Hashable, ...]]]),
+        assert_type(col_list, list),
         list,
         int,
     )
@@ -684,14 +681,14 @@ def test_sorted_and_list() -> None:
     check(
         assert_type(
             sorted(i1),
-            List[Union["IndexIterScalar", Tuple[Hashable, ...]]],
+            list,
         ),
         list,
     )
     check(
         assert_type(
             list(i1),
-            List[Union["IndexIterScalar", Tuple[Hashable, ...]]],
+            list,
         ),
         list,
     )


### PR DESCRIPTION
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
  - `test_frame.py/test_in_columns()`

Without this fix, the following code reports errors:
```python
import pandas as pd
import numpy as np

df = pd.DataFrame(np.random.random((3,4)), columns=["cat", "dog", "rat", "pig"])
cols = [c for c in df.columns if "at" in c]
print(df[cols])
```
pyright then reports:
```text
colcheck.py:5:34 - error: Operator "in" not supported for types "Literal['at']" and "IndexIterScalar | tuple[Hashable, ...]"
    Operator "in" not supported for types "Literal['at']" and "bytes"
    Operator "in" not supported for types "Literal['at']" and "date"
    Operator "in" not supported for types "Literal['at']" and "datetime"
    Operator "in" not supported for types "Literal['at']" and "timedelta"
    Operator "in" not supported for types "Literal['at']" and "bool"
    Operator "in" not supported for types "Literal['at']" and "int"
    Operator "in" not supported for types "Literal['at']" and "float"
    Operator "in" not supported for types "Literal['at']" and "Timestamp"
    ... (reportGeneralTypeIssues)
```
mypy reports:
```text
colcheck.py:5: error: Unsupported operand types for in (likely involving Union)
 [operator]
colcheck.py:5: error: Unsupported right operand type for in ("Union[Union[str, bytes, date, datetime, timedelta, bool, int, float, Timestamp, Timedelta], Tuple[Hashable, ...]]")  [operator]
```

This is because of a change made in #367 by @gandhis1 .  Comments welcome from @gandhis1 if I missed something here.

Our application code uses this pattern a lot, and it would be really painful to keep having to do `cast` when selecting a subset of the columns.

