### PR TITLE
ENH: Add `to_tuples` method to `IntervalIndex`

### DIFF
--- a/pandas-stubs/core/indexes/interval.pyi
+++ b/pandas-stubs/core/indexes/interval.pyi
@@ -213,6 +213,7 @@ class IntervalIndex(IntervalMixin, ExtensionIndex, Generic[IntervalT]):
         copy: bool = ...,
         dtype: IntervalDtype | None = ...,
     ) -> IntervalIndex[pd.Interval[pd.Timedelta]]: ...
+    def to_tuples(self, na_tuple: bool = ...) -> pd.Index: ...
     @overload
     def __contains__(self, key: IntervalT) -> bool: ...  # type: ignore[misc]
     @overload

--- a/tests/test_interval_index.py
+++ b/tests/test_interval_index.py
@@ -31,6 +31,11 @@ def test_from_tuples() -> None:
     )
 
 
+def test_to_tuples() -> None:
+    ind = pd.IntervalIndex.from_tuples([(0, 1), (1, 2)]).to_tuples()
+    check(assert_type(ind, pd.Index), pd.Index, tuple)
+
+
 def test_is_overlapping() -> None:
     ind = pd.IntervalIndex.from_tuples([(0, 2), (1, 3), (4, 5)])
     check(assert_type(ind.is_overlapping, bool), bool)


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

Thank you for always maintaining this stub!
It contributes greatly to the robustness of Python programs using pandas.

### Problem

`IntervalIndex` has [`to_tuples` method](https://pandas.pydata.org/docs/reference/api/pandas.IntervalIndex.to_tuples.html), but its stub is currently missing.

### Solution

Add a stub for `IntervalIndex#to_tuples` and a test for it.

Note that the documentation above states that the return type of that method is an ndarray,
but it is actually `Index` (the test to be added checks for this).
This appears to be a mistake in the pandas doc.
(Probably the doc for `IntervalArray#to_tuples` is also being used for `IntervalIndex#to_tuples`, and since `IntervalArray#to_tuples` does indeed return an ndarray, it is incorrectly showing up in the doc for `IntervalIndex#to_tuples` as well.)