### PR TITLE
IntervalIndex is a subclass of Index

### DIFF
--- a/pandas-stubs/core/algorithms.pyi
+++ b/pandas-stubs/core/algorithms.pyi
@@ -25,7 +25,7 @@ def unique(values: PeriodIndex) -> PeriodIndex: ...  # type: ignore[misc] # pyri
 @overload
 def unique(values: CategoricalIndex) -> CategoricalIndex: ...  # type: ignore[misc]
 @overload
-def unique(values: IntervalIndex[IntervalT]) -> IntervalIndex[IntervalT]: ...
+def unique(values: IntervalIndex[IntervalT]) -> IntervalIndex[IntervalT]: ...  # type: ignore[misc]
 @overload
 def unique(values: Index) -> np.ndarray: ...
 @overload

--- a/pandas-stubs/core/indexes/interval.pyi
+++ b/pandas-stubs/core/indexes/interval.pyi
@@ -12,6 +12,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 from pandas import Index
+from pandas.core.indexes.extension import ExtensionIndex
 from pandas.core.series import (
     Series,
     TimedeltaSeries,
@@ -65,7 +66,7 @@ _EdgesTimedelta: TypeAlias = (
 _TimestampLike: TypeAlias = pd.Timestamp | np.datetime64 | dt.datetime
 _TimedeltaLike: TypeAlias = pd.Timedelta | np.timedelta64 | dt.timedelta
 
-class IntervalIndex(IntervalMixin, Generic[IntervalT]):
+class IntervalIndex(ExtensionIndex, IntervalMixin, Generic[IntervalT]):
     closed: IntervalClosedType
 
     def __new__(
@@ -248,7 +249,7 @@ class IntervalIndex(IntervalMixin, Generic[IntervalT]):
     @property
     def length(self) -> Index: ...
     def get_value(self, series: ABCSeries, key): ...
-    @overload
+    @overload  # type: ignore[override]
     def __getitem__(
         self,
         idx: slice
@@ -262,37 +263,37 @@ class IntervalIndex(IntervalMixin, Generic[IntervalT]):
     def __getitem__(self, idx: int) -> IntervalT: ...
     @property
     def is_all_dates(self) -> bool: ...
-    @overload
+    @overload  # type: ignore[override]
     def __gt__(
         self, other: IntervalT | IntervalIndex[IntervalT]
     ) -> np_ndarray_bool: ...
     @overload
     def __gt__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...
-    @overload
+    @overload  # type: ignore[override]
     def __ge__(
         self, other: IntervalT | IntervalIndex[IntervalT]
     ) -> np_ndarray_bool: ...
     @overload
     def __ge__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...
-    @overload
+    @overload  # type: ignore[override]
     def __le__(
         self, other: IntervalT | IntervalIndex[IntervalT]
     ) -> np_ndarray_bool: ...
     @overload
     def __le__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...
-    @overload
+    @overload  # type: ignore[override]
     def __lt__(
         self, other: IntervalT | IntervalIndex[IntervalT]
     ) -> np_ndarray_bool: ...
     @overload
-    def __lt__(self, other: pd.Series[IntervalT]) -> bool: ...
-    @overload
+    def __lt__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...
+    @overload  # type: ignore[override]
     def __eq__(self, other: IntervalT | IntervalIndex[IntervalT]) -> np_ndarray_bool: ...  # type: ignore[misc]
     @overload
     def __eq__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...  # type: ignore[misc]
     @overload
     def __eq__(self, other: object) -> Literal[False]: ...
-    @overload
+    @overload  # type: ignore[override]
     def __ne__(self, other: IntervalT | IntervalIndex[IntervalT]) -> np_ndarray_bool: ...  # type: ignore[misc]
     @overload
     def __ne__(self, other: pd.Series[IntervalT]) -> pd.Series[bool]: ...  # type: ignore[misc]

--- a/tests/test_interval_index.py
+++ b/tests/test_interval_index.py
@@ -44,7 +44,9 @@ def test_subclass() -> None:
     def index(test: pd.Index) -> None:
         ...
 
-    index(pd.IntervalIndex.from_tuples([(0, 1), (1, 2)]))
+    interval_index = pd.IntervalIndex.from_tuples([(0, 1), (1, 2)])
+    index(interval_index)
+    pd.DataFrame({"a": [1, 2]}, interval_index)
 
 
 def test_is_overlapping() -> None:

--- a/tests/test_interval_index.py
+++ b/tests/test_interval_index.py
@@ -46,7 +46,7 @@ def test_subclass() -> None:
 
     interval_index = pd.IntervalIndex.from_tuples([(0, 1), (1, 2)])
     index(interval_index)
-    pd.DataFrame({"a": [1, 2]}, interval_index)
+    pd.DataFrame({"a": [1, 2]}, index=interval_index)
 
 
 def test_is_overlapping() -> None:

--- a/tests/test_interval_index.py
+++ b/tests/test_interval_index.py
@@ -38,6 +38,15 @@ def test_to_tuples() -> None:
     check(assert_type(ind, pd.Index), pd.Index, tuple)
 
 
+def test_subclass() -> None:
+    assert issubclass(pd.IntervalIndex, pd.Index)
+
+    def index(test: pd.Index) -> None:
+        ...
+
+    index(pd.IntervalIndex.from_tuples([(0, 1), (1, 2)]))
+
+
 def test_is_overlapping() -> None:
     ind = pd.IntervalIndex.from_tuples([(0, 2), (1, 3), (4, 5)])
     check(assert_type(ind.is_overlapping, bool), bool)


### PR DESCRIPTION
`pd.DataFrame(some_data, pd.IntervalIndex(...))` did not work as `IntervalIndex` was not declared as a subclass of `Index`.

For some reason `poe pyright` creates 800+ errors for me locally - it doesn't find any of the packages (including pandas/pytest/numpy/...) Using the CI to find the pyright errors for now.