### PR TITLE
gh-544: Fix pd.options.display.float_format

### DIFF
--- a/pandas-stubs/_config/config.pyi
+++ b/pandas-stubs/_config/config.pyi
@@ -1,4 +1,7 @@
-from collections.abc import Iterable
+from collections.abc import (
+    Callable,
+    Iterable,
+)
 from contextlib import ContextDecorator
 from typing import (
     Any,
@@ -51,7 +54,7 @@ class Display(DictWrapper):
     date_yearfirst: bool
     encoding: str
     expand_frame_repr: bool
-    float_format: str | None
+    float_format: Callable[[float], str] | None
     html: DisplayHTML
     large_repr: str
     latex: DisplayLaTeX

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
+    Optional,
 )
 
 import pandas as pd
@@ -36,3 +38,13 @@ def test_specific_option():
     check(assert_type(pd.options.plotting.backend, str), str)
     # Just check assignment
     pd.options.plotting.backend = "matplotlib"
+
+
+def test_display_float_format():
+    check(
+        assert_type(pd.options.display.float_format, Optional[Callable[[float], str]]),
+        type(None),
+    )
+    formatter = "{,.2f}".format
+    with pd.option_context("display.float_format", formatter):
+        assert pd.get_option("display.float_format") == formatter


### PR DESCRIPTION
Set the correct type for pd.options.display.float_format.

<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #544
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
