### PR TITLE
Support `DataFrame.astype('category')`

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -160,6 +160,7 @@ AstypeArg: TypeAlias = (
     | TimedeltaDtypeArg
     | TimestampDtypeArg
     | CategoricalDtype
+    | CategoryDtypeArg
     | ExtensionDtype
 )
 # DtypeArg specifies all allowable dtypes in a functions its dtype argument

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -148,7 +148,7 @@ ComplexDtypeArg: TypeAlias = (
 )
 TimedeltaDtypeArg: TypeAlias = Literal["timedelta64[ns]"]
 TimestampDtypeArg: TypeAlias = Literal["datetime64[ns]"]
-CategoryDtypeArg: TypeAlias = Literal["category"]
+CategoryDtypeArg: TypeAlias = CategoricalDtype | Literal["category"]
 
 AstypeArg: TypeAlias = (
     BooleanDtypeArg
@@ -159,7 +159,6 @@ AstypeArg: TypeAlias = (
     | ComplexDtypeArg
     | TimedeltaDtypeArg
     | TimestampDtypeArg
-    | CategoricalDtype
     | CategoryDtypeArg
     | ExtensionDtype
 )

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2442,3 +2442,5 @@ def test_astype() -> None:
         assert_type(ab.astype({"col1": "int32", "col2": str}), "pd.DataFrame"),
         pd.DataFrame,
     )
+    check(assert_type(s.astype(pd.CategoricalDtype()), "pd.DataFrame"), pd.DataFrame)
+    check(assert_type(s.astype("category"), "pd.DataFrame"), pd.DataFrame)  # GH 559

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1596,10 +1596,10 @@ def test_updated_astype() -> None:
     check(
         assert_type(s.astype(pd.CategoricalDtype()), "pd.Series[Any]"),
         pd.Series,
-        pd.CategoricalDtype,
+        np.integer,
     )
     check(
         assert_type(s.astype("category"), "pd.Series[Any]"),
         pd.Series,
-        pd.CategoricalDtype,
+        np.integer,
     )

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1591,3 +1591,15 @@ def test_updated_astype() -> None:
         pd.Series,
         Decimal,
     )
+
+    # Categorical
+    check(
+        assert_type(s.astype(pd.CategoricalDtype()), "pd.Series[Any]"),
+        pd.Series,
+        pd.CategoricalDtype,
+    )
+    check(
+        assert_type(s.astype("category"), "pd.Series[Any]"),
+        pd.Series,
+        pd.CategoricalDtype,
+    )


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #558 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
