### PR TITLE
test for groupby axis=1 for v2.0 or less

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,6 +22,7 @@ from pandas._typing import T
 TYPE_CHECKING_INVALID_USAGE: Final = TYPE_CHECKING
 WINDOWS = os.name == "nt" or "cygwin" in platform.system().lower()
 PD_LTE_15 = Version(pd.__version__) < Version("1.5.999")
+PD_LTE_20 = Version(pd.__version__) < Version("2.0.999")
 
 lxml_skip = pytest.mark.skipif(
     sys.version_info >= (3, 11), reason="lxml is not available for 3.11 yet"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -40,6 +40,7 @@ from pandas._typing import Scalar
 
 from tests import (
     PD_LTE_15,
+    PD_LTE_20,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
@@ -364,8 +365,9 @@ def test_types_mean() -> None:
     s1: pd.Series = df.mean()
     s2: pd.Series = df.mean(axis=0)
     df2: pd.DataFrame = df.groupby(level=0).mean()
-    df3: pd.DataFrame = df.groupby(axis=1, level=0).mean()
-    df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).mean()
+    if PD_LTE_20:
+        df3: pd.DataFrame = df.groupby(axis=1, level=0).mean()
+        df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).mean()
     s3: pd.Series = df.mean(axis=1, skipna=True, numeric_only=False)
 
 
@@ -374,8 +376,9 @@ def test_types_median() -> None:
     s1: pd.Series = df.median()
     s2: pd.Series = df.median(axis=0)
     df2: pd.DataFrame = df.groupby(level=0).median()
-    df3: pd.DataFrame = df.groupby(axis=1, level=0).median()
-    df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).median()
+    if PD_LTE_20:
+        df3: pd.DataFrame = df.groupby(axis=1, level=0).median()
+        df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).median()
     s3: pd.Series = df.median(axis=1, skipna=True, numeric_only=False)
 
 


### PR DESCRIPTION
Nightly was failing due to features for 2.1 so added a test for 2.0 to fix that.

