### PR TITLE
CI: nightly builds from additional index

### DIFF
--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -86,9 +86,10 @@ def nightly_pandas():
         "-m",
         "pip",
         "install",
+        "--pre",
         "--use-deprecated=legacy-resolver",
         "--upgrade",
-        "--index-url",
+        "--extra-index-url",
         "https://pypi.anaconda.org/scipy-wheels-nightly/simple",
         "pandas",
     ]


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [ ] Closes #579 (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

Seems to work for me locally. I think the issue is that the nightly index overwrote the normal pypi index so it didn't find any other packages. 