### PR TITLE
Fixed apply stubs when using a function returning a set

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -761,7 +761,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def apply(
         self,
-        func: Callable[..., Scalar | Sequence | Mapping],
+        func: Callable[..., Scalar | Sequence | set | Mapping],
         convertDType: _bool = ...,
         args: tuple = ...,
         **kwds,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1777,3 +1777,10 @@ def test_check_xs() -> None:
     s4 = pd.Series([1, 4])
     s4.xs(0, axis=0)
     check(assert_type(s4, pd.Series), pd.Series)
+
+
+def test_types_apply_set() -> None:
+    series_of_lists: pd.Series = pd.Series(
+        {"list1": [1, 2, 3], "list2": ["a", "b", "c"], "list3": [True, False, True]}
+    )
+    check(assert_type(series_of_lists.apply(lambda x: set(x)), pd.Series), pd.Series)


### PR DESCRIPTION
- [x] Closes #598
- [x] Tests added

When running `poe test_all`, my new test passes, but it seems that one* test (that wasn't modified by my commits) doesn't pass:
```py
Success: no issues found in 224 source files

===========================================
End: 'Run mypy on 'tests' (using the local stubs) and on the local stubs', runtime: 29.387 seconds.
===========================================

===========================================
End: 'Run pyright on 'tests' (using the local stubs) and on the local stubs', runtime: 12.964 seconds.
===========================================
```

\* pytest one:
```py
================================================= test session starts =================================================
platform win32 -- Python 3.10.2, pytest-7.2.2, pluggy-1.0.0
rootdir: C:\Users\lhott\Desktop\pandas-stubs
collected 665 items

tests\test_api_types.py ..........................................                                               [  6%]
tests\test_config.py ...                                                                                         [  6%]
tests\test_dtypes.py .........                                                                                   [  8%]
tests\test_errors.py .....................................                                                       [ 13%]
tests\test_extension.py ..                                                                                       [ 13%]
tests\test_frame.py ................................................................................s........... [ 27%]
................................................................                                                 [ 37%]
tests\test_indexes.py ........................                                                                   [ 41%]
tests\test_interval.py ....                                                                                      [ 41%]
tests\test_interval_index.py ......                                                                              [ 42%]
tests\test_io.py sssss........................................................                                   [ 51%]
tests\test_merge.py .                                                                                            [ 51%]
tests\test_pandas.py ............................                                                                [ 56%]
tests\test_plotting.py .F......................                                                                  [ 59%]
tests\test_resampler.py ...............................                                                          [ 64%]
tests\test_scalars.py .............................                                                              [ 68%]
tests\test_series.py ........................................................................................... [ 82%]
....................                                                                                             [ 85%]
tests\test_styler.py ...........................                                                                 [ 89%]
tests\test_testing.py ...                                                                                        [ 89%]
tests\test_timefuncs.py ...........................................                                              [ 96%]
tests\test_utility.py ....                                                                                       [ 96%]
tests\test_windowing.py ....................                                                                     [100%]

====================================================== FAILURES =======================================================
______________________________________________ test_autocorrelation_plot ______________________________________________

close_figures = None

    def test_autocorrelation_plot(close_figures) -> None:
        spacing = np.linspace(-9 * np.pi, 9 * np.pi, num=1000)
        s = pd.Series(0.7 * np.random.rand(1000) + 0.3 * np.sin(spacing))
>       check(assert_type(pd.plotting.autocorrelation_plot(s), plt.Axes), plt.Axes)

tests\test_plotting.py:190:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\pandas\plotting\_misc.py:542: in autocorrelation_plot
    return plot_backend.autocorrelation_plot(series=series, ax=ax, **kwargs)
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\pandas\plotting\_matplotlib\misc.py:453: in autocorrelation_plot
    ax = plt.gca()
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\pyplot.py:2309: in gca
    return gcf().gca()
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\pyplot.py:906: in gcf
    return figure()
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\_api\deprecation.py:454: in wrapper
    return func(*args, **kwargs)
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\pyplot.py:840: in figure
    manager = new_figure_manager(
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\pyplot.py:384: in new_figure_manager
    return _get_backend_mod().new_figure_manager(*args, **kwargs)
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\backend_bases.py:3574: in new_figure_manager
    return cls.new_figure_manager_given_figure(num, fig)
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\backend_bases.py:3579: in new_figure_manager_given_figure
    return cls.FigureCanvas.new_manager(figure, num)
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\backend_bases.py:1742: in new_manager
    return cls.manager_class.create_with_canvas(cls, figure, num)
..\..\AppData\Local\pypoetry\Cache\virtualenvs\pandas-stubs-k5t5DbFx-py3.10\lib\site-packages\matplotlib\backends\_backend_tk.py:483: in create_with_canvas
    window = tk.Tk(className="matplotlib")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tkinter.Tk object .>, screenName = None, baseName = 'pytest', className = 'matplotlib', useTk = True
sync = False, use = None

    def __init__(self, screenName=None, baseName=None, className='Tk',
                 useTk=True, sync=False, use=None):
        """Return a new Toplevel widget on screen SCREENNAME. A new Tcl interpreter will
        be created. BASENAME will be used for the identification of the profile file (see
        readprofile).
        It is constructed from sys.argv[0] without extensions if None is given. CLASSNAME
        is the name of the widget class."""
        self.master = None
        self.children = {}
        self._tkloaded = False
        # to avoid recursions in the getattr code in case of failure, we
        # ensure that self.tk is always _something_.
        self.tk = None
        if baseName is None:
            import os
            baseName = os.path.basename(sys.argv[0])
            baseName, ext = os.path.splitext(baseName)
            if ext not in ('.py', '.pyc'):
                baseName = baseName + ext
        interactive = False
>       self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
E       _tkinter.TclError: Can't find a usable tk.tcl in the following directories:
E           C:/Users/lhott/AppData/Local/Programs/Python/Python310/tcl/tcl8.6/tk8.6 C:/Users/lhott/AppData/Local/Programs/Python/Python310/tcl/tk8.6 C:/Users/lhott/AppData/Local/Programs/Python/lib/tk8.6 C:/Users/lhott/AppData/Local/Programs/Python/lib/tk8.6 C:/Users/lhott/AppData/Local/Programs/lib/tk8.6 C:/Users/lhott/AppData/Local/Programs/Python/library
E
E       C:/Users/lhott/AppData/Local/Programs/Python/Python310/tcl/tk8.6/tk.tcl: couldn't read file "C:/Users/lhott/AppData/Local/Programs/Python/Python310/tcl/tk8.6/menu.tcl": no such file or directory
E       couldn't read file "C:/Users/lhott/AppData/Local/Programs/Python/Python310/tcl/tk8.6/menu.tcl": no such file or directory
E           while executing
E       "source -encoding utf-8 C:/Users/lhott/AppData/Local/Programs/Python/Python310/tcl/tk8.6/menu.tcl"
E           (in namespace eval "::" script line 1)
E           invoked from within
E       "namespace eval :: [list source -encoding utf-8 [file join $::tk_library $file.tcl]]"
E           (procedure "SourceLibFile" line 2)
E           invoked from within
E       "SourceLibFile menu"
E           (in namespace eval "::tk" script line 6)
E           invoked from within
E       "namespace eval ::tk {
E               SourceLibFile icons
E               SourceLibFile button
E               SourceLibFile entry
E               SourceLibFile listbox
E               SourceLibFile menu
E               SourceLibFile panedw..."
E           (file "C:/Users/lhott/AppData/Local/Programs/Python/Python310/tcl/tk8.6/tk.tcl" line 501)
E           invoked from within
E       "source C:/Users/lhott/AppData/Local/Programs/Python/Python310/tcl/tk8.6/tk.tcl"
E           ("uplevel" body line 1)
E           invoked from within
E       "uplevel #0 [list source $file]"
E
E
E       This probably means that tk wasn't installed properly.

..\..\AppData\Local\Programs\Python\Python310\lib\tkinter\__init__.py:2299: TclError
=============================================== short test summary info ===============================================
FAILED tests/test_plotting.py::test_autocorrelation_plot - _tkinter.TclError: Can't find a usable tk.tcl in the following directories:
====================================== 1 failed, 658 passed, 6 skipped in 22.62s ======================================

===========================================
Step: 'Run pytest' failed!
===========================================

(pandas-stubs-py3.10) PS C:\Users\lhott\Desktop\pandas-stubs>
```