### PR TITLE
BUG: Fix MultiIndex.dtypes (#597)

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -306,6 +306,7 @@ S1 = TypeVar(
     int,
     float,
     complex,
+    Dtype,
     Timestamp,
     Timedelta,
     Period,

--- a/pandas-stubs/core/indexes/multi.pyi
+++ b/pandas-stubs/core/indexes/multi.pyi
@@ -4,7 +4,6 @@ from collections.abc import (
     Sequence,
 )
 from typing import (
-    Any,
     Literal,
     overload,
 )
@@ -16,6 +15,7 @@ from typing_extensions import Self
 
 from pandas._typing import (
     T1,
+    Dtype,
     DtypeArg,
     HashableT,
     np_ndarray_anyint,
@@ -70,7 +70,7 @@ class MultiIndex(Index):
     @property
     def dtype(self) -> np.dtype: ...
     @property
-    def dtypes(self) -> pd.Series[Any]: ...
+    def dtypes(self) -> pd.Series[Dtype]: ...
     def memory_usage(self, deep: bool = ...) -> int: ...
     @property
     def nbytes(self) -> int: ...

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -15,6 +15,7 @@ from typing_extensions import (
     assert_type,
 )
 
+from pandas._typing import Dtype  # noqa: F401
 from pandas._typing import Scalar
 
 from tests import (
@@ -859,4 +860,4 @@ def test_getitem() -> None:
 def test_multiindex_dtypes():
     # GH-597
     mi = pd.MultiIndex.from_tuples([(1, 2.0), (2, 3.0)], names=["foo", "bar"])
-    check(assert_type(mi.dtypes, pd.Series), pd.Series)
+    check(assert_type(mi.dtypes, "pd.Series[Dtype]"), pd.Series)


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #597 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
