### PR TITLE
gh:610 - added warnings 

### DIFF
--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1388,57 +1388,75 @@ def test_bitwise_operators() -> None:
     s2 = pd.Series([9, 10, 11, 12], dtype=int)
     # for issue #348 (bitwise operators on Series should support int)
     # The bitwise integers return platform-dependent numpy integers in the Series
+    check(assert_type(s & 3, "pd.Series[int]"), pd.Series, np.integer)
+    check(assert_type(3 & s, "pd.Series[int]"), pd.Series, np.integer)
+
+    check(assert_type(s | 3, "pd.Series[int]"), pd.Series, np.integer)
+    check(assert_type(3 | s, "pd.Series[int]"), pd.Series, np.integer)
+
+    check(assert_type(s ^ 3, "pd.Series[int]"), pd.Series, np.integer)
+    check(assert_type(3 ^ s, "pd.Series[int]"), pd.Series, np.integer)
+
+    check(assert_type(s & s2, "pd.Series[int]"), pd.Series, np.integer)
+    check(assert_type(s2 & s, "pd.Series[int]"), pd.Series, np.integer)
+
+    check(assert_type(s | s2, "pd.Series[int]"), pd.Series, np.integer)
+    check(assert_type(s2 | s, "pd.Series[int]"), pd.Series, np.integer)
+
+    check(assert_type(s ^ s2, "pd.Series[int]"), pd.Series, np.integer)
+    check(assert_type(s2 ^ s, "pd.Series[int]"), pd.Series, np.integer)
+
     with pytest_warns_bounded(
         FutureWarning, match="Logical Ops(and, or, xor) is deprecated", lower="2.1"
     ):
-        check(assert_type(s & 3, "pd.Series[int]"), pd.Series, np.integer)
-        check(assert_type(3 & s, "pd.Series[int]"), pd.Series, np.integer)
-
-        check(assert_type(s | 3, "pd.Series[int]"), pd.Series, np.integer)
-        check(assert_type(3 | s, "pd.Series[int]"), pd.Series, np.integer)
-
-        check(assert_type(s ^ 3, "pd.Series[int]"), pd.Series, np.integer)
-        check(assert_type(3 ^ s, "pd.Series[int]"), pd.Series, np.integer)
-
         check(assert_type(s & [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
         check(assert_type([1, 2, 3, 4] & s, "pd.Series[bool]"), pd.Series, np.bool_)
-        check(assert_type(s & s2, "pd.Series[int]"), pd.Series, np.integer)
-        check(assert_type(s2 & s, "pd.Series[int]"), pd.Series, np.integer)
 
         check(assert_type(s | [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
         check(assert_type([1, 2, 3, 4] | s, "pd.Series[bool]"), pd.Series, np.bool_)
-        check(assert_type(s | s2, "pd.Series[int]"), pd.Series, np.integer)
-        check(assert_type(s2 | s, "pd.Series[int]"), pd.Series, np.integer)
 
         check(assert_type(s ^ [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
         check(assert_type([1, 2, 3, 4] ^ s, "pd.Series[bool]"), pd.Series, np.bool_)
-        check(assert_type(s ^ s2, "pd.Series[int]"), pd.Series, np.integer)
-        check(assert_type(s2 ^ s, "pd.Series[int]"), pd.Series, np.integer)
 
 
 def test_logical_operators() -> None:
     # GH 380
     df = pd.DataFrame({"a": [1, 2, 3], "b": [2, 3, 4]})
+
+    check(
+        assert_type((df["a"] >= 2) & (df["b"] >= 2), "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
+    check(
+        assert_type((df["a"] >= 2) | (df["b"] >= 2), "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
+    check(
+        assert_type((df["a"] >= 2) ^ (df["b"] >= 2), "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
+    check(assert_type((df["a"] >= 2) & True, "pd.Series[bool]"), pd.Series, np.bool_)
+
+    check(assert_type((df["a"] >= 2) | True, "pd.Series[bool]"), pd.Series, np.bool_)
+
+    check(assert_type((df["a"] >= 2) ^ True, "pd.Series[bool]"), pd.Series, np.bool_)
+
+    check(assert_type(True & (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
+
+    check(assert_type(True | (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
+
+    check(assert_type(True ^ (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
+
     with pytest_warns_bounded(
         FutureWarning, match="Logical Ops(and, or, xor) is deprecated", lower="2.1"
     ):
         check(
-            assert_type((df["a"] >= 2) & (df["b"] >= 2), "pd.Series[bool]"),
+            assert_type((df["a"] >= 2) ^ [True, False, True], "pd.Series[bool]"),
             pd.Series,
             np.bool_,
-        )
-        check(
-            assert_type((df["a"] >= 2) | (df["b"] >= 2), "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
-        check(
-            assert_type((df["a"] >= 2) ^ (df["b"] >= 2), "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
-        check(
-            assert_type((df["a"] >= 2) & True, "pd.Series[bool]"), pd.Series, np.bool_
         )
         check(
             assert_type((df["a"] >= 2) & [True, False, True], "pd.Series[bool]"),
@@ -1446,23 +1464,9 @@ def test_logical_operators() -> None:
             np.bool_,
         )
         check(
-            assert_type((df["a"] >= 2) | True, "pd.Series[bool]"), pd.Series, np.bool_
-        )
-        check(
             assert_type((df["a"] >= 2) | [True, False, True], "pd.Series[bool]"),
             pd.Series,
             np.bool_,
-        )
-        check(
-            assert_type((df["a"] >= 2) ^ True, "pd.Series[bool]"), pd.Series, np.bool_
-        )
-        check(
-            assert_type((df["a"] >= 2) ^ [True, False, True], "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
-        check(
-            assert_type(True & (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_
         )
         check(
             assert_type([True, False, True] & (df["a"] >= 2), "pd.Series[bool]"),
@@ -1470,15 +1474,9 @@ def test_logical_operators() -> None:
             np.bool_,
         )
         check(
-            assert_type(True | (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_
-        )
-        check(
             assert_type([True, False, True] | (df["a"] >= 2), "pd.Series[bool]"),
             pd.Series,
             np.bool_,
-        )
-        check(
-            assert_type(True ^ (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_
         )
         check(
             assert_type([True, False, True] ^ (df["a"] >= 2), "pd.Series[bool]"),

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1388,85 +1388,103 @@ def test_bitwise_operators() -> None:
     s2 = pd.Series([9, 10, 11, 12], dtype=int)
     # for issue #348 (bitwise operators on Series should support int)
     # The bitwise integers return platform-dependent numpy integers in the Series
-    check(assert_type(s & 3, "pd.Series[int]"), pd.Series, np.integer)
-    check(assert_type(3 & s, "pd.Series[int]"), pd.Series, np.integer)
+    with pytest_warns_bounded(
+        FutureWarning, match="Logical Ops(and, or, xor) is deprecated", lower="2.1"
+    ):
+        check(assert_type(s & 3, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(3 & s, "pd.Series[int]"), pd.Series, np.integer)
 
-    check(assert_type(s | 3, "pd.Series[int]"), pd.Series, np.integer)
-    check(assert_type(3 | s, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(s | 3, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(3 | s, "pd.Series[int]"), pd.Series, np.integer)
 
-    check(assert_type(s ^ 3, "pd.Series[int]"), pd.Series, np.integer)
-    check(assert_type(3 ^ s, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(s ^ 3, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(3 ^ s, "pd.Series[int]"), pd.Series, np.integer)
 
-    check(assert_type(s & [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
-    check(assert_type([1, 2, 3, 4] & s, "pd.Series[bool]"), pd.Series, np.bool_)
-    check(assert_type(s & s2, "pd.Series[int]"), pd.Series, np.integer)
-    check(assert_type(s2 & s, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(s & [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
+        check(assert_type([1, 2, 3, 4] & s, "pd.Series[bool]"), pd.Series, np.bool_)
+        check(assert_type(s & s2, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(s2 & s, "pd.Series[int]"), pd.Series, np.integer)
 
-    check(assert_type(s | [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
-    check(assert_type([1, 2, 3, 4] | s, "pd.Series[bool]"), pd.Series, np.bool_)
-    check(assert_type(s | s2, "pd.Series[int]"), pd.Series, np.integer)
-    check(assert_type(s2 | s, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(s | [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
+        check(assert_type([1, 2, 3, 4] | s, "pd.Series[bool]"), pd.Series, np.bool_)
+        check(assert_type(s | s2, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(s2 | s, "pd.Series[int]"), pd.Series, np.integer)
 
-    check(assert_type(s ^ [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
-    check(assert_type([1, 2, 3, 4] ^ s, "pd.Series[bool]"), pd.Series, np.bool_)
-    check(assert_type(s ^ s2, "pd.Series[int]"), pd.Series, np.integer)
-    check(assert_type(s2 ^ s, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(s ^ [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
+        check(assert_type([1, 2, 3, 4] ^ s, "pd.Series[bool]"), pd.Series, np.bool_)
+        check(assert_type(s ^ s2, "pd.Series[int]"), pd.Series, np.integer)
+        check(assert_type(s2 ^ s, "pd.Series[int]"), pd.Series, np.integer)
 
 
 def test_logical_operators() -> None:
     # GH 380
     df = pd.DataFrame({"a": [1, 2, 3], "b": [2, 3, 4]})
-    check(
-        assert_type((df["a"] >= 2) & (df["b"] >= 2), "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
-    check(
-        assert_type((df["a"] >= 2) | (df["b"] >= 2), "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
-    check(
-        assert_type((df["a"] >= 2) ^ (df["b"] >= 2), "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
-    check(assert_type((df["a"] >= 2) & True, "pd.Series[bool]"), pd.Series, np.bool_)
-    check(
-        assert_type((df["a"] >= 2) & [True, False, True], "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
-    check(assert_type((df["a"] >= 2) | True, "pd.Series[bool]"), pd.Series, np.bool_)
-    check(
-        assert_type((df["a"] >= 2) | [True, False, True], "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
-    check(assert_type((df["a"] >= 2) ^ True, "pd.Series[bool]"), pd.Series, np.bool_)
-    check(
-        assert_type((df["a"] >= 2) ^ [True, False, True], "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
-    check(assert_type(True & (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
-    check(
-        assert_type([True, False, True] & (df["a"] >= 2), "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
-    check(assert_type(True | (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
-    check(
-        assert_type([True, False, True] | (df["a"] >= 2), "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
-    check(assert_type(True ^ (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
-    check(
-        assert_type([True, False, True] ^ (df["a"] >= 2), "pd.Series[bool]"),
-        pd.Series,
-        np.bool_,
-    )
+    with pytest_warns_bounded(
+        FutureWarning, match="Logical Ops(and, or, xor) is deprecated", lower="2.1"
+    ):
+        check(
+            assert_type((df["a"] >= 2) & (df["b"] >= 2), "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
+        check(
+            assert_type((df["a"] >= 2) | (df["b"] >= 2), "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
+        check(
+            assert_type((df["a"] >= 2) ^ (df["b"] >= 2), "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
+        check(
+            assert_type((df["a"] >= 2) & True, "pd.Series[bool]"), pd.Series, np.bool_
+        )
+        check(
+            assert_type((df["a"] >= 2) & [True, False, True], "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
+        check(
+            assert_type((df["a"] >= 2) | True, "pd.Series[bool]"), pd.Series, np.bool_
+        )
+        check(
+            assert_type((df["a"] >= 2) | [True, False, True], "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
+        check(
+            assert_type((df["a"] >= 2) ^ True, "pd.Series[bool]"), pd.Series, np.bool_
+        )
+        check(
+            assert_type((df["a"] >= 2) ^ [True, False, True], "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
+        check(
+            assert_type(True & (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_
+        )
+        check(
+            assert_type([True, False, True] & (df["a"] >= 2), "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
+        check(
+            assert_type(True | (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_
+        )
+        check(
+            assert_type([True, False, True] | (df["a"] >= 2), "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
+        check(
+            assert_type(True ^ (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_
+        )
+        check(
+            assert_type([True, False, True] ^ (df["a"] >= 2), "pd.Series[bool]"),
+            pd.Series,
+            np.bool_,
+        )
 
 
 def test_AnyArrayLike_and_clip() -> None:


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes  #610 
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
