### PR TITLE
corrected the message for PR 611

### DIFF
--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1407,7 +1407,9 @@ def test_bitwise_operators() -> None:
     check(assert_type(s2 ^ s, "pd.Series[int]"), pd.Series, np.integer)
 
     with pytest_warns_bounded(
-        FutureWarning, match="Logical Ops(and, or, xor) is deprecated", lower="2.1"
+        FutureWarning,
+        match="Logical Ops(and, or, xor) between Pandas objects is deprecated",
+        lower="2.1",
     ):
         check(assert_type(s & [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
         check(assert_type([1, 2, 3, 4] & s, "pd.Series[bool]"), pd.Series, np.bool_)
@@ -1451,7 +1453,9 @@ def test_logical_operators() -> None:
     check(assert_type(True ^ (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
 
     with pytest_warns_bounded(
-        FutureWarning, match="Logical Ops(and, or, xor) is deprecated", lower="2.1"
+        FutureWarning,
+        match="Logical Ops(and, or, xor) between Pandas objects is deprecated",
+        lower="2.1",
     ):
         check(
             assert_type((df["a"] >= 2) ^ [True, False, True], "pd.Series[bool]"),


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
