### PR TITLE
updated the lower bound PR 611

### DIFF
--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1409,7 +1409,7 @@ def test_bitwise_operators() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         match="Logical ops (and, or, xor) between Pandas objects and",
-        lower="2.1",
+        lower="2.0.99",
     ):
         check(assert_type(s & [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
         check(assert_type([1, 2, 3, 4] & s, "pd.Series[bool]"), pd.Series, np.bool_)
@@ -1455,7 +1455,7 @@ def test_logical_operators() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         match="Logical ops (and, or, xor) between Pandas objects and",
-        lower="2.1",
+        lower="2.0.99",
     ):
         check(
             assert_type((df["a"] >= 2) ^ [True, False, True], "pd.Series[bool]"),


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
