### PR TITLE
updated message for PR 611

### DIFF
--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1408,7 +1408,7 @@ def test_bitwise_operators() -> None:
 
     with pytest_warns_bounded(
         FutureWarning,
-        match="Logical ops (and, or, xor) between Pandas objects and",
+        match=r"Logical ops \(and, or, xor\) between Pandas objects and",
         lower="2.0.99",
     ):
         check(assert_type(s & [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
@@ -1454,7 +1454,7 @@ def test_logical_operators() -> None:
 
     with pytest_warns_bounded(
         FutureWarning,
-        match="Logical ops (and, or, xor) between Pandas objects and",
+        match=r"Logical ops \(and, or, xor\) between Pandas objects and",
         lower="2.0.99",
     ):
         check(


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
