### PR TITLE
gh:552 - Corrected Series.mean return type

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -283,6 +283,8 @@ IndexIterScalar: TypeAlias = (
     | float
     | Timestamp
     | Timedelta
+    | np.integer
+    | np.float_
 )
 Scalar: TypeAlias = IndexIterScalar | complex
 ScalarT = TypeVar("ScalarT", bound=Scalar)

--- a/pandas-stubs/core/resample.pyi
+++ b/pandas-stubs/core/resample.pyi
@@ -88,8 +88,7 @@ class Resampler(BaseGroupBy, Generic[NDFrameT]):
         func: Callable[..., DataFrame]
         | tuple[Callable[..., DataFrame], str]
         | Callable[..., Series]
-        | tuple[Callable[..., Series], str]
-        | Callable[[DataFrame], np.float64],
+        | tuple[Callable[..., Series], str],
         *args,
         **kwargs,
     ) -> DataFrame: ...

--- a/pandas-stubs/core/resample.pyi
+++ b/pandas-stubs/core/resample.pyi
@@ -41,7 +41,10 @@ _FrameGroupByFuncArgs: TypeAlias = (
 )
 
 _SeriesGroupByFunc: TypeAlias = (
-    Callable[[Series], Scalar] | Callable[[Series], Series] | np.ufunc
+    Callable[[Series], Scalar]
+    | Callable[[Series], Series]
+    | Callable[[Series], np.float64]
+    | np.ufunc
 )
 _SeriesGroupByFuncTypes: TypeAlias = (
     _SeriesGroupByFunc | str | list[_SeriesGroupByFunc | str]
@@ -85,7 +88,8 @@ class Resampler(BaseGroupBy, Generic[NDFrameT]):
         func: Callable[..., DataFrame]
         | tuple[Callable[..., DataFrame], str]
         | Callable[..., Series]
-        | tuple[Callable[..., Series], str],
+        | tuple[Callable[..., Series], str]
+        | Callable[[DataFrame], np.float64],
         *args,
         **kwargs,
     ) -> DataFrame: ...

--- a/pandas-stubs/core/resample.pyi
+++ b/pandas-stubs/core/resample.pyi
@@ -41,10 +41,7 @@ _FrameGroupByFuncArgs: TypeAlias = (
 )
 
 _SeriesGroupByFunc: TypeAlias = (
-    Callable[[Series], Scalar]
-    | Callable[[Series], Series]
-    | Callable[[Series], np.float64]
-    | np.ufunc
+    Callable[[Series], Scalar] | Callable[[Series], Series] | np.ufunc
 )
 _SeriesGroupByFuncTypes: TypeAlias = (
     _SeriesGroupByFunc | str | list[_SeriesGroupByFunc | str]

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1609,7 +1609,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         level: None = ...,
         numeric_only: _bool = ...,
         **kwargs,
-    ) -> float: ...
+    ) -> np.float64: ...
     def median(
         self,
         axis: AxisIndex | None = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2042,12 +2042,12 @@ def test_groupby_apply() -> None:
     # GH 167
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
 
-    def sum_mean(x: pd.DataFrame) -> float:
+    def sum_mean(x: pd.DataFrame) -> np.float64:
         return x.sum().mean()
 
     check(assert_type(df.groupby("col1").apply(sum_mean), pd.Series), pd.Series)
 
-    lfunc: Callable[[pd.DataFrame], float] = lambda x: x.sum().mean()
+    lfunc: Callable[[pd.DataFrame], np.float64] = lambda x: x.sum().mean()
     check(
         assert_type(df.groupby("col1").apply(lfunc), pd.Series),
         pd.Series,

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -158,10 +158,10 @@ def test_pipe() -> None:
 
     check(assert_type(DF.resample("m").pipe(g), DataFrame), DataFrame)
 
-    def h(val: DataFrame) -> float:
+    def h(val: DataFrame) -> np.float64:
         return val.mean().mean()
 
-    check(assert_type(DF.resample("m").pipe(h), Series), Series)
+    check(assert_type(DF.resample("m").pipe(h), DataFrame), Series)
 
 
 def test_transform() -> None:
@@ -248,10 +248,10 @@ def test_aggregate_series() -> None:
         DataFrame,
     )
 
-    def f(val: Series) -> float:
+    def f(val: Series) -> np.float64:
         return val.mean()
 
-    check(assert_type(S.resample("m").aggregate(f), _AggRetType), Series)
+    check(assert_type(S.resample("m").aggregate(f), _AggRetType), pd.Series)
 
 
 def test_asfreq_series() -> None:

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -161,7 +161,7 @@ def test_pipe() -> None:
     def h(val: DataFrame) -> np.float64:
         return val.mean().mean()
 
-    check(assert_type(DF.resample("m").pipe(h), DataFrame), Series)
+    check(assert_type(DF.resample("m").pipe(h), Series), Series)
 
 
 def test_transform() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -311,9 +311,12 @@ def test_types_rank() -> None:
 def test_types_mean() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     check(assert_type(s.mean(), np.float64), np.float64)
-    s1 = s.groupby(level=0)
-    check(assert_type(s1.mean(skipna=False), pd.Series), np.float64)
-    check(assert_type(s1.mean(numeric_only=False), pd.Series), np.float64)
+    # s1 = s.groupby(level=0)
+    check(assert_type(s.groupby(level=0).mean(skipna=False), pd.Series), np.float64)
+    # check(assert_type(s1.mean(skipna=False), pd.Series), np.float64)
+    check(
+        assert_type(s.groupby(level=0).mean(numeric_only=False), pd.Series), np.float64
+    )
 
 
 def test_types_median() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -311,12 +311,9 @@ def test_types_rank() -> None:
 def test_types_mean() -> None:
     s = pd.Series([1, 2, 3, np.nan])
     check(assert_type(s.mean(), np.float64), np.float64)
-    # s1 = s.groupby(level=0)
-    check(assert_type(s.groupby(level=0).mean(skipna=False), pd.Series), np.float64)
-    # check(assert_type(s1.mean(skipna=False), pd.Series), np.float64)
-    check(
-        assert_type(s.groupby(level=0).mean(numeric_only=False), pd.Series), np.float64
-    )
+    s1: pd.Series = s.groupby(level=0).mean()
+    f2: np.float64 = s.mean(skipna=False)
+    f3: np.float64 = s.mean(numeric_only=False)
 
 
 def test_types_median() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -310,10 +310,10 @@ def test_types_rank() -> None:
 
 def test_types_mean() -> None:
     s = pd.Series([1, 2, 3, np.nan])
-    f1: float = s.mean()
-    s1: pd.Series = s.groupby(level=0).mean()
-    f2: float = s.mean(skipna=False)
-    f3: float = s.mean(numeric_only=False)
+    check(assert_type(s.mean(), np.float64), np.float64)
+    s1 = s.groupby(level=0)
+    check(assert_type(s1.mean(skipna=False), pd.Series), np.float64)
+    check(assert_type(s1.mean(numeric_only=False), pd.Series), np.float64)
 
 
 def test_types_median() -> None:

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -148,7 +148,7 @@ def test_rolling_basic_math_series() -> None:
 def test_rolling_apply_series() -> None:
     check(assert_type(S.rolling(10).apply(np.mean), Series), Series)
 
-    def _mean(df: Series) -> float:
+    def _mean(df: Series) -> np.float64:
         return df.mean()
 
     check(assert_type(S.rolling(10).apply(_mean), Series), Series)
@@ -163,7 +163,7 @@ def test_rolling_aggregate_series() -> None:
     check(assert_type(S.rolling(10).aggregate(np.mean), Series), Series)
     check(assert_type(S.rolling(10).aggregate("mean"), Series), Series)
 
-    def _mean(s: Series) -> float:
+    def _mean(s: Series) -> np.float64:
         return s.mean()
 
     check(assert_type(S.rolling(10).aggregate(_mean), Series), Series)
@@ -256,7 +256,7 @@ def test_expanding_basic_math_series() -> None:
 def test_expanding_apply_series() -> None:
     check(assert_type(S.expanding(10).apply(np.mean), Series), Series)
 
-    def _mean(df: Series) -> float:
+    def _mean(df: Series) -> np.float64:
         return df.mean()
 
     check(assert_type(S.expanding(10).apply(_mean), Series), Series)


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #552
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
