### PR TITLE
Remove cap on python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ packages = [
 "Documentation" = "https://pandas.pydata.org/pandas-docs/stable"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8"
 types-pytz = ">= 2022.1.1"
 
 [tool.poetry.dev-dependencies]
@@ -49,7 +49,7 @@ pre-commit = ">=2.19.0"
 black = ">=22.12.0"
 isort = ">=5.10.1"
 openpyxl = ">=3.0.10"
-tables = { version = ">=3.7.0" }
+tables = { version = ">=3.7.0" , python = "<4"}  # 3.8.0 depends on blosc2 which caps python to <4
 lxml = { version = ">=4.7.1,<4.9.0", python = "<3.11" }
 pyreadstat = ">=1.2.0"
 xlrd = ">=2.0.1"


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [ ] Closes #625 (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
