### PR TITLE
Broaden read csv param types

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -298,6 +298,16 @@ np_ndarray_str: TypeAlias = npt.NDArray[np.str_]
 
 IndexType: TypeAlias = slice | np_ndarray_anyint | Index | list[int] | Series[int]
 MaskType: TypeAlias = Series[bool] | np_ndarray_bool | list[bool]
+UsecolsArgType: TypeAlias = (
+    MutableSequence[str]
+    | tuple[str, ...]
+    | Sequence[int]
+    | Series
+    | Index
+    | np.ndarray
+    | Callable[[HashableT], bool]
+    | None
+)
 # Scratch types for generics
 S1 = TypeVar(
     "S1",

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -269,6 +269,9 @@ ListLikeExceptSeriesAndStr = TypeVar(
     "ListLikeExceptSeriesAndStr", MutableSequence, np.ndarray, tuple, "Index"
 )
 ListLikeU: TypeAlias = Sequence | np.ndarray | Series | Index
+ListLikeHashable: TypeAlias = (
+    MutableSequence[HashableT] | np.ndarray | tuple[HashableT, ...] | range
+)
 StrLike: TypeAlias = str | np.str_
 IndexIterScalar: TypeAlias = (
     str

--- a/pandas-stubs/io/clipboards.pyi
+++ b/pandas-stubs/io/clipboards.pyi
@@ -19,6 +19,7 @@ from pandas._typing import (
     CSVEngine,
     CSVQuoting,
     DtypeArg,
+    ListLikeHashable,
     StorageOptions,
     npt,
 )
@@ -31,7 +32,7 @@ def read_clipboard(
     *,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | Sequence[int]
@@ -94,7 +95,7 @@ def read_clipboard(
     *,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | Sequence[int]
@@ -157,7 +158,7 @@ def read_clipboard(
     *,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | Sequence[int]

--- a/pandas-stubs/io/clipboards.pyi
+++ b/pandas-stubs/io/clipboards.pyi
@@ -11,8 +11,6 @@ from typing import (
 )
 
 from pandas.core.frame import DataFrame
-from pandas.core.indexes.base import Index
-from pandas.core.series import Series
 
 from pandas._typing import (
     CompressionOptions,
@@ -21,7 +19,7 @@ from pandas._typing import (
     DtypeArg,
     ListLikeHashable,
     StorageOptions,
-    npt,
+    UsecolsArgType,
 )
 
 from pandas.io.parsers import TextFileReader
@@ -34,13 +32,7 @@ def read_clipboard(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: dict[int | str, Callable[[str], Any]] = ...,
@@ -97,13 +89,7 @@ def read_clipboard(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: dict[int | str, Callable[[str], Any]] = ...,
@@ -160,13 +146,7 @@ def read_clipboard(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: dict[int | str, Callable[[str], Any]] = ...,

--- a/pandas-stubs/io/clipboards.pyi
+++ b/pandas-stubs/io/clipboards.pyi
@@ -31,7 +31,7 @@ def read_clipboard(
     *,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] = ...,
+    names: list[str] | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | Sequence[int]
@@ -94,7 +94,7 @@ def read_clipboard(
     *,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] = ...,
+    names: list[str] | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | Sequence[int]
@@ -157,7 +157,7 @@ def read_clipboard(
     *,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] = ...,
+    names: list[str] | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | Sequence[int]

--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -22,6 +22,7 @@ from xlrd.book import Book
 from pandas._typing import (
     Dtype,
     FilePath,
+    ListLikeHashable,
     ReadBuffer,
     StorageOptions,
     WriteExcelBuffer,
@@ -40,7 +41,7 @@ def read_excel(
     sheet_name: list[int | str] | None,
     *,
     header: int | Sequence[int] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | Sequence[int] | None = ...,
     usecols: Sequence[int] | Sequence[str] | Callable[[str], bool] | None = ...,
     dtype: str | Dtype | Mapping[str, str | Dtype] | None = ...,
@@ -78,7 +79,7 @@ def read_excel(
     sheet_name: int | str = ...,
     *,
     header: int | Sequence[int] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | Sequence[int] | None = ...,
     usecols: Sequence[int] | Sequence[str] | Callable[[str], bool] | None = ...,
     dtype: str | Dtype | Mapping[str, str | Dtype] | None = ...,
@@ -155,7 +156,7 @@ class ExcelFile:
         self,
         sheet_name: list[int | str] | None,
         header: int | Sequence[int] | None = ...,
-        names: list[str] | None = ...,
+        names: ListLikeHashable | None = ...,
         index_col: int | Sequence[int] | None = ...,
         usecols: str
         | Sequence[int]
@@ -185,7 +186,7 @@ class ExcelFile:
         self,
         sheet_name: int | str,
         header: int | Sequence[int] | None = ...,
-        names: list[str] | None = ...,
+        names: ListLikeHashable | None = ...,
         index_col: int | Sequence[int] | None = ...,
         usecols: str
         | Sequence[int]

--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -25,6 +25,7 @@ from pandas._typing import (
     ListLikeHashable,
     ReadBuffer,
     StorageOptions,
+    UsecolsArgType,
     WriteExcelBuffer,
 )
 
@@ -43,7 +44,7 @@ def read_excel(
     header: int | Sequence[int] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | Sequence[int] | None = ...,
-    usecols: Sequence[int] | Sequence[str] | Callable[[str], bool] | None = ...,
+    usecols: str | UsecolsArgType = ...,
     dtype: str | Dtype | Mapping[str, str | Dtype] | None = ...,
     engine: Literal["xlrd", "openpyxl", "odf", "pyxlsb"] | None = ...,
     converters: Mapping[int | str, Callable[[object], object]] | None = ...,
@@ -81,7 +82,7 @@ def read_excel(
     header: int | Sequence[int] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | Sequence[int] | None = ...,
-    usecols: Sequence[int] | Sequence[str] | Callable[[str], bool] | None = ...,
+    usecols: str | UsecolsArgType = ...,
     dtype: str | Dtype | Mapping[str, str | Dtype] | None = ...,
     engine: Literal["xlrd", "openpyxl", "odf", "pyxlsb"] | None = ...,
     converters: Mapping[int | str, Callable[[object], object]] | None = ...,
@@ -158,11 +159,7 @@ class ExcelFile:
         header: int | Sequence[int] | None = ...,
         names: ListLikeHashable | None = ...,
         index_col: int | Sequence[int] | None = ...,
-        usecols: str
-        | Sequence[int]
-        | Sequence[str]
-        | Callable[[str], bool]
-        | None = ...,
+        usecols: str | UsecolsArgType = ...,
         converters: dict[int | str, Callable[[object], object]] | None = ...,
         true_values: Iterable[Hashable] | None = ...,
         false_values: Iterable[Hashable] | None = ...,
@@ -188,11 +185,7 @@ class ExcelFile:
         header: int | Sequence[int] | None = ...,
         names: ListLikeHashable | None = ...,
         index_col: int | Sequence[int] | None = ...,
-        usecols: str
-        | Sequence[int]
-        | Sequence[str]
-        | Callable[[str], bool]
-        | None = ...,
+        usecols: str | UsecolsArgType = ...,
         converters: dict[int | str, Callable[[object], object]] | None = ...,
         true_values: Iterable[Hashable] | None = ...,
         false_values: Iterable[Hashable] | None = ...,

--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -16,8 +16,6 @@ from typing import (
 )
 
 from pandas.core.frame import DataFrame
-from pandas.core.indexes.base import Index
-from pandas.core.series import Series
 from typing_extensions import Self
 
 from pandas._typing import (
@@ -29,7 +27,7 @@ from pandas._typing import (
     ListLikeHashable,
     ReadCsvBuffer,
     StorageOptions,
-    npt,
+    UsecolsArgType,
 )
 
 from pandas.io.common import IOHandles
@@ -43,14 +41,7 @@ def read_csv(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | tuple[str, ...]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: Mapping[int | str, Callable[[str], Any]]
@@ -109,14 +100,7 @@ def read_csv(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | tuple[str, ...]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: Mapping[int | str, Callable[[str], Any]]
@@ -175,14 +159,7 @@ def read_csv(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | tuple[str, ...]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: Mapping[int | str, Callable[[str], Any]]
@@ -241,14 +218,7 @@ def read_table(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | tuple[str, ...]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: Mapping[int | str, Callable[[str], Any]]
@@ -307,14 +277,7 @@ def read_table(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | tuple[str, ...]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: Mapping[int | str, Callable[[str], Any]]
@@ -373,14 +336,7 @@ def read_table(
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
-    usecols: list[str]
-    | tuple[str, ...]
-    | Sequence[int]
-    | Series
-    | Index
-    | npt.NDArray
-    | Callable[[str], bool]
-    | None = ...,
+    usecols: UsecolsArgType = ...,
     dtype: DtypeArg | defaultdict | None = ...,
     engine: CSVEngine | None = ...,
     converters: Mapping[int | str, Callable[[str], Any]]

--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -26,6 +26,7 @@ from pandas._typing import (
     CSVQuoting,
     DtypeArg,
     FilePath,
+    ListLikeHashable,
     ReadCsvBuffer,
     StorageOptions,
     npt,
@@ -40,7 +41,7 @@ def read_csv(
     sep: str | None = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | tuple[str, ...]
@@ -106,7 +107,7 @@ def read_csv(
     sep: str | None = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | tuple[str, ...]
@@ -172,7 +173,7 @@ def read_csv(
     sep: str | None = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | tuple[str, ...]
@@ -238,7 +239,7 @@ def read_table(
     sep: str | None = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | tuple[str, ...]
@@ -304,7 +305,7 @@ def read_table(
     sep: str | None = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | tuple[str, ...]
@@ -370,7 +371,7 @@ def read_table(
     sep: str | None = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
-    names: list[str] | None = ...,
+    names: ListLikeHashable | None = ...,
     index_col: int | str | Sequence[str | int] | Literal[False] | None = ...,
     usecols: list[str]
     | tuple[str, ...]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -12,6 +12,7 @@ from typing import (
     Generator,
     List,
     Literal,
+    Tuple,
     Union,
 )
 
@@ -206,6 +207,18 @@ def test_read_stata_iterator():
         check(assert_type(reader, StataReader), StataReader)
 
 
+def _true_if_b(s: str) -> bool:
+    return s == "b"
+
+
+def _true_if_greater_than_0(i: int) -> bool:
+    return i > 0
+
+
+def _true_if_first_param_is_head(t: Tuple[str, int]) -> bool:
+    return t[0] == "head"
+
+
 def test_clipboard():
     try:
         DF.to_clipboard()
@@ -228,6 +241,47 @@ def test_clipboard():
     check(
         assert_type(
             read_clipboard(names=(("first", 1), ("last", 2)), header=0), DataFrame
+        ),
+        DataFrame,
+    )
+    check(
+        assert_type(read_clipboard(usecols=None), DataFrame),
+        DataFrame,
+    )
+    check(
+        assert_type(read_clipboard(usecols=["a"]), DataFrame),
+        DataFrame,
+    )
+    check(
+        assert_type(read_clipboard(usecols=(0,)), DataFrame),
+        DataFrame,
+    )
+    check(
+        assert_type(read_clipboard(usecols=range(1)), DataFrame),
+        DataFrame,
+    )
+    check(
+        assert_type(read_clipboard(usecols=_true_if_b), DataFrame),
+        DataFrame,
+    )
+    check(
+        assert_type(
+            read_clipboard(
+                names=[1, 2], usecols=_true_if_greater_than_0, header=0, index_col=0
+            ),
+            DataFrame,
+        ),
+        DataFrame,
+    )
+    check(
+        assert_type(
+            read_clipboard(
+                names=(("head", 1), ("tail", 2)),
+                usecols=_true_if_first_param_is_head,
+                header=0,
+                index_col=0,
+            ),
+            DataFrame,
         ),
         DataFrame,
     )
@@ -501,6 +555,10 @@ def test_read_csv_iterator():
         tfr2.close()
 
 
+def _true_if_col1(s: str) -> bool:
+    return s == "col1"
+
+
 def test_types_read_csv() -> None:
     df = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
     csv_df: str = df.to_csv()
@@ -543,6 +601,21 @@ def test_types_read_csv() -> None:
                 ("last", 2),
             ),
             header=0,
+        )
+        df19: pd.DataFrame = pd.read_csv(path, usecols=None)
+        df20: pd.DataFrame = pd.read_csv(path, usecols=["col1"])
+        df21: pd.DataFrame = pd.read_csv(path, usecols=(0,))
+        df22: pd.DataFrame = pd.read_csv(path, usecols=range(1))
+        df23: pd.DataFrame = pd.read_csv(path, usecols=_true_if_col1)
+        df24: pd.DataFrame = pd.read_csv(
+            path, names=[1, 2], usecols=_true_if_greater_than_0, header=0, index_col=0
+        )
+        df25: pd.DataFrame = pd.read_csv(
+            path,
+            names=(("head", 1), ("tail", 2)),
+            usecols=_true_if_first_param_is_head,
+            header=0,
+            index_col=0,
         )
 
         tfr1: TextFileReader = pd.read_csv(path, nrows=2, iterator=True, chunksize=3)
@@ -594,6 +667,67 @@ def test_read_table():
                         ("last", 2),
                     ),
                     header=0,
+                ),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(path, usecols=None),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(path, usecols=["a"]),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(path, usecols=(0,)),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(path, usecols=range(1)),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(path, usecols=_true_if_b),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(
+                    path,
+                    names=[1, 2],
+                    usecols=_true_if_greater_than_0,
+                    header=0,
+                    index_col=0,
+                ),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(
+                    path,
+                    names=(("head", 1), ("tail", 2)),
+                    usecols=_true_if_first_param_is_head,
+                    header=0,
+                    index_col=0,
                 ),
                 DataFrame,
             ),
@@ -727,6 +861,52 @@ def test_read_excel() -> None:
         ),
         check(
             assert_type(pd.read_excel(path, names=range(1), header=0), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(pd.read_excel(path, usecols=None), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(pd.read_excel(path, usecols=["A"]), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(pd.read_excel(path, usecols=(0,)), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(pd.read_excel(path, usecols=range(1)), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(pd.read_excel(path, usecols=_true_if_b), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(
+                pd.read_excel(
+                    path,
+                    names=[1, 2],
+                    usecols=_true_if_greater_than_0,
+                    header=0,
+                    index_col=0,
+                ),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(
+                pd.read_excel(
+                    path,
+                    names=(("head", 1), ("tail", 2)),
+                    usecols=_true_if_first_param_is_head,
+                    header=0,
+                    index_col=0,
+                ),
+                pd.DataFrame,
+            ),
             pd.DataFrame,
         )
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -517,6 +517,20 @@ def test_types_read_csv() -> None:
         df12: pd.DataFrame = pd.read_csv(path, usecols=("col1",))
         df13: pd.DataFrame = pd.read_csv(path, usecols=pd.Series(data=["col1"]))
         df14: pd.DataFrame = pd.read_csv(path, converters=None)
+        df15: pd.DataFrame = pd.read_csv(path, names=("first", "second"), header=0)
+        df16: pd.DataFrame = pd.read_csv(path, names=range(2), header=0)
+        df17: pd.DataFrame = pd.read_csv(path, names=(1, "two"), header=0)
+        df18: pd.DataFrame = pd.read_csv(
+            path,
+            names=(
+                (
+                    "first",
+                    1,
+                ),
+                ("last", 2),
+            ),
+            header=0,
+        )
 
         tfr1: TextFileReader = pd.read_csv(path, nrows=2, iterator=True, chunksize=3)
         tfr1.close()
@@ -539,6 +553,37 @@ def test_read_table():
         check(assert_type(read_table(path, chunksize=None), DataFrame), DataFrame)
         check(
             assert_type(read_table(path, dtype=defaultdict(lambda: "f8")), DataFrame),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(path, names=("first", "second"), header=0), DataFrame
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(read_table(path, names=range(2), header=0), DataFrame),
+            DataFrame,
+        )
+        check(
+            assert_type(read_table(path, names=(1, "two"), header=0), DataFrame),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                read_table(
+                    path,
+                    names=(
+                        (
+                            "first",
+                            1,
+                        ),
+                        ("last", 2),
+                    ),
+                    header=0,
+                ),
+                DataFrame,
+            ),
             DataFrame,
         )
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -710,6 +710,25 @@ def test_read_excel() -> None:
             ),
             dict,
         )
+        check(
+            assert_type(pd.read_excel(path, names=("test",), header=0), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(pd.read_excel(path, names=(1,), header=0), pd.DataFrame),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(
+                pd.read_excel(path, names=(("higher", "lower"),), header=0),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        ),
+        check(
+            assert_type(pd.read_excel(path, names=range(1), header=0), pd.DataFrame),
+            pd.DataFrame,
+        )
 
 
 def test_read_excel_io_types() -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -909,6 +909,16 @@ def test_read_excel() -> None:
             ),
             pd.DataFrame,
         )
+        check(
+            assert_type(
+                pd.read_excel(
+                    path,
+                    usecols="A",
+                ),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        )
 
 
 def test_read_excel_io_types() -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -52,6 +52,7 @@ import sqlalchemy.orm.decl_api
 from typing_extensions import assert_type
 
 from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
     WINDOWS,
     check,
 )
@@ -285,6 +286,9 @@ def test_clipboard():
         ),
         DataFrame,
     )
+    if TYPE_CHECKING_INVALID_USAGE:
+        pd.read_clipboard(names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportGeneralTypeIssues]
+        pd.read_clipboard(usecols="abcd")  # type: ignore[arg-type] # pyright: ignore[reportGeneralTypeIssues]
 
 
 def test_clipboard_iterator():
@@ -618,6 +622,10 @@ def test_types_read_csv() -> None:
             index_col=0,
         )
 
+        if TYPE_CHECKING_INVALID_USAGE:
+            pd.read_csv(path, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportGeneralTypeIssues]
+            pd.read_csv(path, usecols="abcd")  # type: ignore[arg-type] # pyright: ignore[reportGeneralTypeIssues]
+
         tfr1: TextFileReader = pd.read_csv(path, nrows=2, iterator=True, chunksize=3)
         tfr1.close()
 
@@ -733,6 +741,9 @@ def test_read_table():
             ),
             DataFrame,
         )
+        if TYPE_CHECKING_INVALID_USAGE:
+            pd.read_table(path, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportGeneralTypeIssues]
+            pd.read_table(path, usecols="abcd")  # type: ignore[arg-type] # pyright: ignore[reportGeneralTypeIssues]
 
 
 def test_read_table_iterator():
@@ -919,6 +930,8 @@ def test_read_excel() -> None:
             ),
             pd.DataFrame,
         )
+        if TYPE_CHECKING_INVALID_USAGE:
+            pd.read_excel(path, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportGeneralTypeIssues]
 
 
 def test_read_excel_io_types() -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -219,6 +219,18 @@ def test_clipboard():
         DataFrame,
     )
     check(assert_type(read_clipboard(names=None), DataFrame), DataFrame)
+    check(
+        assert_type(read_clipboard(names=("first", "second"), header=0), DataFrame),
+        DataFrame,
+    )
+    check(assert_type(read_clipboard(names=range(2), header=0), DataFrame), DataFrame)
+    check(assert_type(read_clipboard(names=(1, "two"), header=0), DataFrame), DataFrame)
+    check(
+        assert_type(
+            read_clipboard(names=(("first", 1), ("last", 2)), header=0), DataFrame
+        ),
+        DataFrame,
+    )
 
 
 def test_clipboard_iterator():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -218,6 +218,7 @@ def test_clipboard():
         assert_type(read_clipboard(dtype=defaultdict(lambda: "f8")), DataFrame),
         DataFrame,
     )
+    check(assert_type(read_clipboard(names=None), DataFrame), DataFrame)
 
 
 def test_clipboard_iterator():


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [X] Closes #605, Closes #623
- [X] Tests added: Please use `assert_type()` to assert the type of any return value

Submitted as 1 PR for the 2 issues because the relevant code is so close that I thought it might be quicker to review together, plus trying to have both as separate PRs would likely result in merge conflicts if/when one was merged before the other. The commits addressing the two issues are separate though, so it would be easy for me to split into 2 separate PR if this is preferred.

As well as read_csv, modify read_table, read_clipboard, read_excel, which all have the relevant params (I searched for other functions but let me know if I missed any).

Closes #605 in a different way than suggested in that ticket, in order to allow broader types than just lists of string or ints, since list-likes are allowed here. Naming of the type alias UsecolsArgType was inspired by ColspaceArgType, happy to change if desired.

Please let me know if coverage of more different types for `names` and/or `usecols` is needed in the tests, or if there are stylistic details you would like me to change. There is a lot of repetition between the tests for the different functions that have these params - I'm happy to work on reducing it, but I thought it might mean restructuring some of the existing tests, so I didn't want to fiddle with it too much until I knew if it (and the actual functional change) was desired.

Passes tests (`poetry run poe test_all`) locally when the last commit before my changes is `7730abc` - the two commits after that (`6819e32` and `9c301b3`) result in test failures for me locally that seem unrelated to my change, and I get if I just run on `main` with no changes.
