### PR TITLE
GH - 624: Added `dtype` arg to `read_sql`

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -77,6 +77,7 @@ class FulldatetimeDict(YearMonthDayDict, total=False):
 NpDtype: TypeAlias = str | np.dtype[np.generic] | type[str | complex | bool | object]
 Dtype: TypeAlias = ExtensionDtype | NpDtype
 DtypeArg: TypeAlias = Dtype | dict[Any, Dtype]
+DtypeBackend: TypeAlias = Literal["pyarrow", "numpy_nullable"]
 BooleanDtypeArg: TypeAlias = (
     # Builtin bool type and its string alias
     type[bool]  # noqa: Y030

--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -85,6 +85,7 @@ def read_sql(
     *,
     chunksize: int,
     dtype: DtypeArg | None = ...,
+    dtype_backend: None = ...,
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql(
@@ -97,6 +98,7 @@ def read_sql(
     columns: list[str] = ...,
     chunksize: None = ...,
     dtype: DtypeArg | None = ...,
+    dtype_backend: None = ...,
 ) -> DataFrame: ...
 
 class PandasSQL(PandasObject):

--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -16,8 +16,10 @@ import sqlalchemy.engine
 import sqlalchemy.sql.expression
 from typing_extensions import TypeAlias
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     DtypeArg,
+    DtypeBackend,
     npt,
 )
 
@@ -85,7 +87,7 @@ def read_sql(
     *,
     chunksize: int,
     dtype: DtypeArg | None = ...,
-    dtype_backend: None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql(
@@ -98,7 +100,7 @@ def read_sql(
     columns: list[str] = ...,
     chunksize: None = ...,
     dtype: DtypeArg | None = ...,
-    dtype_backend: None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...
 
 class PandasSQL(PandasObject):

--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -84,6 +84,7 @@ def read_sql(
     columns: list[str] = ...,
     *,
     chunksize: int,
+    dtype: DtypeArg | None = ...,
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql(
@@ -95,6 +96,7 @@ def read_sql(
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = ...,
     columns: list[str] = ...,
     chunksize: None = ...,
+    dtype: DtypeArg | None = ...,
 ) -> DataFrame: ...
 
 class PandasSQL(PandasObject):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1225,29 +1225,18 @@ def test_read_sql_dtype() -> None:
             ),
             pd.DataFrame,
         )
-        conn.close()
-
-
-def test_read_sql_dtype1() -> None:
-    with ensure_clean() as path:
-        conn2 = sqlite3.connect(path)
-        df = pd.DataFrame(
-            data=[[0, "10/11/12"], [1, "12/11/10"]],
-            columns=["int_column", "date_column"],
-        )
-        check(assert_type(df.to_sql("test_data", con=conn2), Union[int, None]), int)
         check(
             assert_type(
                 pd.read_sql(
                     "SELECT int_column, date_column FROM test_data",
-                    con=conn2,
+                    con=conn,
                     dtype={"int_column": int},
                 ),
                 pd.DataFrame,
             ),
             pd.DataFrame,
         )
-        conn2.close()
+        conn.close()
 
 
 def test_read_sql_dtypes2() -> None:
@@ -1263,3 +1252,26 @@ def test_read_sql_dtypes2() -> None:
             pd.DataFrame,
         )
         conn1.close()
+
+
+def test_read_sql_dtype_backend() -> None:
+    with ensure_clean() as path:
+        conn2 = sqlite3.connect(path)
+        check(assert_type(DF.to_sql("test", con=conn2), Union[int, None]), int)
+        check(
+            assert_type(
+                read_sql("select * from test", con=conn2, dtype_backend="pyarrow"),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        )
+        check(
+            assert_type(
+                read_sql(
+                    "select * from test", con=conn2, dtype_backend="numpy_nullable"
+                ),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        )
+        conn2.close()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1228,6 +1228,28 @@ def test_read_sql_dtype() -> None:
         conn.close()
 
 
+def test_read_sql_dtype1() -> None:
+    with ensure_clean() as path:
+        conn2 = sqlite3.connect(path)
+        df = pd.DataFrame(
+            data=[[0, "10/11/12"], [1, "12/11/10"]],
+            columns=["int_column", "date_column"],
+        )
+        check(assert_type(df.to_sql("test_data", con=conn2), Union[int, None]), int)
+        check(
+            assert_type(
+                pd.read_sql(
+                    "SELECT int_column, date_column FROM test_data",
+                    con=conn2,
+                    dtype={"int_column": int},
+                ),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        )
+        conn2.close()
+
+
 def test_read_sql_dtypes2() -> None:
     with ensure_clean() as path:
         conn1 = sqlite3.connect(path)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1256,6 +1256,10 @@ def test_read_sql_dtypes2() -> None:
         con = sqlite3.connect(path)
         check(assert_type(DF.to_sql("test", con=con), Union[int, None]), int)
         check(
-            assert_type(read_sql("select * from test", con=con, dtype={"int_column": float}), DataFrame), DataFrame
+            assert_type(
+                read_sql("select * from test", con=con, dtype={"int_column": float}),
+                DataFrame,
+            ),
+            DataFrame,
         )
         con.close()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1206,23 +1206,56 @@ def test_sqlalchemy_text() -> None:
             )
 
 
-def test_read_sql_dtype() -> None:
+# def test_read_sql_dtype() -> None:
+#     with ensure_clean() as path:
+#         conn = sqlite3.connect(path)
+#         df = pd.DataFrame(
+#             data=[[0, "10/11/12"], [1, "12/11/10"]],
+#             columns=["int_column", "date_column"],
+#         )
+#         check(assert_type(df.to_sql("test_data", con=conn), Union[int, None]), int)
+#         check(
+#             assert_type(
+#                 pd.read_sql(
+#                     "SELECT int_column, date_column FROM test_data",
+#                     con=conn,
+#                     dtype={"int_columb":float},
+#                     # dtype=None,
+#                 ),
+#                 pd.DataFrame,
+#             ),
+#             pd.DataFrame,
+#         )
+#         conn.close()
+
+
+# def test_read_sql_dtype1() -> None:
+#     with ensure_clean() as path:
+#         conn = sqlite3.connect(path)
+#         df = pd.DataFrame(
+#             data=[[0, "10/11/12"], [1, "12/11/10"]],
+#             columns=["int_column", "date_column"],
+#         )
+#         check(assert_type(df.to_sql("test_data", con=conn), Union[int, None]), int)
+#         check(
+#             assert_type(
+#                 pd.read_sql(
+#                     "SELECT int_column, date_column FROM test_data",
+#                     con=conn,
+#                     dtype={"int_columb":float},
+#                 ),
+#                 pd.DataFrame,
+#             ),
+#             pd.DataFrame,
+#         )
+#         conn.close()
+
+
+def test_read_sql_dtypes2() -> None:
     with ensure_clean() as path:
-        conn = sqlite3.connect(path)
-        df = pd.DataFrame(
-            data=[[0, "10/11/12"], [1, "12/11/10"]],
-            columns=["int_column", "date_column"],
-        )
-        check(assert_type(df.to_sql("test_data", con=conn), Union[int, None]), int)
+        con = sqlite3.connect(path)
+        check(assert_type(DF.to_sql("test", con=con), Union[int, None]), int)
         check(
-            assert_type(
-                pd.read_sql(
-                    "SELECT int_column, date_column FROM test_data",
-                    con=conn,
-                    dtype=None,
-                ),
-                pd.DataFrame,
-            ),
-            pd.DataFrame,
+            assert_type(read_sql("select * from test", con=con, dtype={"int_column": float}), DataFrame), DataFrame
         )
-        conn.close()
+        con.close()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1204,3 +1204,25 @@ def test_sqlalchemy_text() -> None:
                 assert_type(read_sql(sql_select, con=conn), DataFrame),
                 DataFrame,
             )
+
+
+def test_read_sql_dtype() -> None:
+    with ensure_clean() as path:
+        conn = sqlite3.connect(path)
+        df = pd.DataFrame(
+            data=[[0, "10/11/12"], [1, "12/11/10"]],
+            columns=["int_column", "date_column"],
+        )
+        check(assert_type(df.to_sql("test_data", con=conn), Union[int, None]), int)
+        check(
+            assert_type(
+                pd.read_sql(
+                    "SELECT int_column, date_column FROM test_data",
+                    con=conn,
+                    dtype=None,
+                ),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        )
+        conn.close()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1206,60 +1206,38 @@ def test_sqlalchemy_text() -> None:
             )
 
 
-# def test_read_sql_dtype() -> None:
-#     with ensure_clean() as path:
-#         conn = sqlite3.connect(path)
-#         df = pd.DataFrame(
-#             data=[[0, "10/11/12"], [1, "12/11/10"]],
-#             columns=["int_column", "date_column"],
-#         )
-#         check(assert_type(df.to_sql("test_data", con=conn), Union[int, None]), int)
-#         check(
-#             assert_type(
-#                 pd.read_sql(
-#                     "SELECT int_column, date_column FROM test_data",
-#                     con=conn,
-#                     dtype={"int_columb":float},
-#                     # dtype=None,
-#                 ),
-#                 pd.DataFrame,
-#             ),
-#             pd.DataFrame,
-#         )
-#         conn.close()
-
-
-# def test_read_sql_dtype1() -> None:
-#     with ensure_clean() as path:
-#         conn = sqlite3.connect(path)
-#         df = pd.DataFrame(
-#             data=[[0, "10/11/12"], [1, "12/11/10"]],
-#             columns=["int_column", "date_column"],
-#         )
-#         check(assert_type(df.to_sql("test_data", con=conn), Union[int, None]), int)
-#         check(
-#             assert_type(
-#                 pd.read_sql(
-#                     "SELECT int_column, date_column FROM test_data",
-#                     con=conn,
-#                     dtype={"int_columb":float},
-#                 ),
-#                 pd.DataFrame,
-#             ),
-#             pd.DataFrame,
-#         )
-#         conn.close()
+def test_read_sql_dtype() -> None:
+    with ensure_clean() as path:
+        conn = sqlite3.connect(path)
+        df = pd.DataFrame(
+            data=[[0, "10/11/12"], [1, "12/11/10"]],
+            columns=["int_column", "date_column"],
+        )
+        check(assert_type(df.to_sql("test_data", con=conn), Union[int, None]), int)
+        check(
+            assert_type(
+                pd.read_sql(
+                    "SELECT int_column, date_column FROM test_data",
+                    con=conn,
+                    dtype=None,
+                ),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        )
+        conn.close()
 
 
 def test_read_sql_dtypes2() -> None:
     with ensure_clean() as path:
-        con = sqlite3.connect(path)
-        check(assert_type(DF.to_sql("test", con=con), Union[int, None]), int)
+        conn1 = sqlite3.connect(path)
+        check(assert_type(DF.to_sql("test", con=conn1), Union[int, None]), int)
+
         check(
             assert_type(
-                read_sql("select * from test", con=con, dtype={"int_column": float}),
-                DataFrame,
+                read_sql("select * from test", con=conn1, dtype=int),
+                pd.DataFrame,
             ),
-            DataFrame,
+            pd.DataFrame,
         )
-        con.close()
+        conn1.close()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1236,22 +1236,16 @@ def test_read_sql_dtype() -> None:
             ),
             pd.DataFrame,
         )
-        conn.close()
-
-
-def test_read_sql_dtypes2() -> None:
-    with ensure_clean() as path:
-        conn1 = sqlite3.connect(path)
-        check(assert_type(DF.to_sql("test", con=conn1), Union[int, None]), int)
+        check(assert_type(DF.to_sql("test", con=conn), Union[int, None]), int)
 
         check(
             assert_type(
-                read_sql("select * from test", con=conn1, dtype=int),
+                read_sql("select * from test", con=conn, dtype=int),
                 pd.DataFrame,
             ),
             pd.DataFrame,
         )
-        conn1.close()
+        conn.close()
 
 
 def test_read_sql_dtype_backend() -> None:


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [ ] xref #624 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
