### PR TITLE
Fix pandas-nightly

### DIFF
--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -8,7 +8,10 @@ from typing_extensions import assert_type
 
 from pandas._typing import DtypeObj
 
-from tests import check
+from tests import (
+    check,
+    pytest_warns_bounded,
+)
 
 nparr = np.array([1, 2, 3])
 arr = pd.Series([1, 2, 3])
@@ -52,15 +55,20 @@ def test_is_bool_dtype() -> None:
 
 
 def test_is_categorical_dtype() -> None:
-    check(assert_type(api.is_categorical_dtype(arr), bool), bool)
-    check(assert_type(api.is_categorical_dtype(nparr), bool), bool)
-    check(assert_type(api.is_categorical_dtype(dtylike), bool), bool)
-    check(
-        assert_type(api.is_categorical_dtype(dframe), bool),
-        bool,
-    )
-    check(assert_type(api.is_categorical_dtype(ind), bool), bool)
-    check(assert_type(api.is_categorical_dtype(ExtensionDtype), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="is_categorical_dtype is deprecated and will be removed in a future version",
+        lower="2.0.99",
+    ):
+        check(assert_type(api.is_categorical_dtype(arr), bool), bool)
+        check(assert_type(api.is_categorical_dtype(nparr), bool), bool)
+        check(assert_type(api.is_categorical_dtype(dtylike), bool), bool)
+        check(
+            assert_type(api.is_categorical_dtype(dframe), bool),
+            bool,
+        )
+        check(assert_type(api.is_categorical_dtype(ind), bool), bool)
+        check(assert_type(api.is_categorical_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_complex() -> None:
@@ -124,15 +132,20 @@ def test_is_datetime64_ns_dtype() -> None:
 
 
 def test_is_datetime64tz_dtype() -> None:
-    check(assert_type(api.is_datetime64tz_dtype(arr), bool), bool)
-    check(assert_type(api.is_datetime64tz_dtype(nparr), bool), bool)
-    check(assert_type(api.is_datetime64tz_dtype(dtylike), bool), bool)
-    check(
-        assert_type(api.is_datetime64tz_dtype(dframe), bool),
-        bool,
-    )
-    check(assert_type(api.is_datetime64tz_dtype(ind), bool), bool)
-    check(assert_type(api.is_datetime64tz_dtype(ExtensionDtype), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="is_datetime64tz_dtype is deprecated and will be removed in a future version",
+        lower="2.0.99",
+    ):
+        check(assert_type(api.is_datetime64tz_dtype(arr), bool), bool)
+        check(assert_type(api.is_datetime64tz_dtype(nparr), bool), bool)
+        check(assert_type(api.is_datetime64tz_dtype(dtylike), bool), bool)
+        check(
+            assert_type(api.is_datetime64tz_dtype(dframe), bool),
+            bool,
+        )
+        check(assert_type(api.is_datetime64tz_dtype(ind), bool), bool)
+        check(assert_type(api.is_datetime64tz_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_dict_like() -> None:
@@ -209,15 +222,20 @@ def test_is_hashable() -> None:
 
 
 def test_is_int64_dtype() -> None:
-    check(assert_type(api.is_int64_dtype(arr), bool), bool)
-    check(assert_type(api.is_int64_dtype(nparr), bool), bool)
-    check(assert_type(api.is_int64_dtype(dtylike), bool), bool)
-    check(
-        assert_type(api.is_int64_dtype(dframe), bool),
-        bool,
-    )
-    check(assert_type(api.is_int64_dtype(ind), bool), bool)
-    # check(assert_type(api.is_int64_dtype(ExtensionDtype), bool), bool) pandas GH 50923
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="is_int64_dtype is deprecated and will be removed in a future version",
+        lower="2.0.99",
+    ):
+        check(assert_type(api.is_int64_dtype(arr), bool), bool)
+        check(assert_type(api.is_int64_dtype(nparr), bool), bool)
+        check(assert_type(api.is_int64_dtype(dtylike), bool), bool)
+        check(
+            assert_type(api.is_int64_dtype(dframe), bool),
+            bool,
+        )
+        check(assert_type(api.is_int64_dtype(ind), bool), bool)
+        # check(assert_type(api.is_int64_dtype(ExtensionDtype), bool), bool) pandas GH 50923
 
 
 def test_is_integer() -> None:
@@ -257,16 +275,21 @@ def test_is_interval() -> None:
 
 
 def test_is_interval_dtype() -> None:
-    check(assert_type(api.is_interval_dtype(obj), bool), bool)
-    check(assert_type(api.is_interval_dtype(nparr), bool), bool)
-    check(assert_type(api.is_interval_dtype(dtylike), bool), bool)
-    check(assert_type(api.is_interval_dtype(arr), bool), bool)
-    check(
-        assert_type(api.is_interval_dtype(dframe), bool),
-        bool,
-    )
-    check(assert_type(api.is_interval_dtype(ind), bool), bool)
-    check(assert_type(api.is_interval_dtype(ExtensionDtype), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="is_interval_dtype is deprecated and will be removed in a future version",
+        lower="2.0.99",
+    ):
+        check(assert_type(api.is_interval_dtype(obj), bool), bool)
+        check(assert_type(api.is_interval_dtype(nparr), bool), bool)
+        check(assert_type(api.is_interval_dtype(dtylike), bool), bool)
+        check(assert_type(api.is_interval_dtype(arr), bool), bool)
+        check(
+            assert_type(api.is_interval_dtype(dframe), bool),
+            bool,
+        )
+        check(assert_type(api.is_interval_dtype(ind), bool), bool)
+        check(assert_type(api.is_interval_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_iterator() -> None:

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -22,7 +22,10 @@ from pandas._libs import NaTType
 from pandas._libs.missing import NAType
 from pandas._typing import Scalar
 
-from tests import check
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    check,
+)
 
 from pandas.tseries.offsets import (
     BusinessDay,
@@ -54,10 +57,8 @@ def test_period_dtype() -> None:
     check(
         assert_type(pd.PeriodDtype(freq=BusinessDay()), pd.PeriodDtype), pd.PeriodDtype
     )
-    check(
-        assert_type(pd.PeriodDtype(freq=CustomBusinessDay()), pd.PeriodDtype),
-        pd.PeriodDtype,
-    )
+    if TYPE_CHECKING_INVALID_USAGE:
+        pd.PeriodDtype(freq=CustomBusinessDay())  # TODO(raises on 2.1)
     check(
         assert_type(p_dt.freq, pd.tseries.offsets.BaseOffset),
         pd.tseries.offsets.DateOffset,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -450,7 +450,12 @@ def test_types_apply() -> None:
     def makeseries(x: float) -> pd.Series:
         return pd.Series([x, 2 * x])
 
-    check(assert_type(s.apply(makeseries), pd.DataFrame), pd.DataFrame)
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="Returning a DataFrame from Series.apply when the supplied functionreturns a Series is deprecated",
+        lower="2.0.99",
+    ):
+        check(assert_type(s.apply(makeseries), pd.DataFrame), pd.DataFrame)
 
     # GH 293
 

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -22,6 +22,8 @@ from pandas._libs import NaTType
 from pandas._libs.tslibs import BaseOffset
 from pandas._libs.tslibs.offsets import DateOffset
 
+from tests import pytest_warns_bounded
+
 if TYPE_CHECKING:
     from pandas._typing import FulldatetimeDict
 else:
@@ -361,7 +363,13 @@ def test_series_dt_accessors() -> None:
     check(assert_type(s0.dt.freq, Optional[str]), str)
     check(assert_type(s0.dt.isocalendar(), pd.DataFrame), pd.DataFrame)
     check(assert_type(s0.dt.to_period("D"), "PeriodSeries"), pd.Series, pd.Period)
-    check(assert_type(s0.dt.to_pydatetime(), np.ndarray), np.ndarray, dt.datetime)
+
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="The behavior of DatetimeProperties.to_pydatetime is deprecated",
+        lower="2.0.99",
+    ):
+        check(assert_type(s0.dt.to_pydatetime(), np.ndarray), np.ndarray, dt.datetime)
     s0_local = s0.dt.tz_localize("UTC")
     check(
         assert_type(s0_local, "TimestampSeries"),


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #640 (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

There is still a TypeError on nightly xref https://github.com/pandas-dev/pandas/issues/52790 (will mark as invalid - there is no warning but it will raise in 2.1: I think we should reflect that in our annotations)