### PR TITLE
GH: 624 - Added `dtype_backend` to all `read_*` functions

### DIFF
--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -29,6 +29,7 @@ from pandas._typing import (
     CSVQuoting,
     Dtype,
     DtypeArg,
+    DtypeBackend,
     FilePath,
     FileWriteMode,
     FillnaOptions,
@@ -373,6 +374,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         convert_string: _bool = ...,
         convert_integer: _bool = ...,
         convert_boolean: _bool = ...,
+        dtype_backend: DtypeBackend = ...,
     ) -> NDFrameT: ...
     def fillna(
         self,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1135,7 +1135,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         convert_string: _bool = ...,
         convert_integer: _bool = ...,
         convert_boolean: _bool = ...,
-        dtype_backend: DtypeBackend | NoDefault = ...,
+        dtype_backend: DtypeBackend = ...,
     ) -> Series[S1]: ...
     @overload
     def ffill(

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -74,10 +74,10 @@ from typing_extensions import (
     Never,
     TypeAlias,
 )
-from pandas._libs.lib import NoDefault
 import xarray as xr
 
 from pandas._libs.interval import Interval
+from pandas._libs.lib import NoDefault
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs import BaseOffset
 from pandas._typing import (
@@ -97,8 +97,8 @@ from pandas._typing import (
     CategoryDtypeArg,
     ComplexDtypeArg,
     CompressionOptions,
-    DtypeObj,
     DtypeBackend,
+    DtypeObj,
     FilePath,
     FillnaOptions,
     FloatDtypeArg,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -74,6 +74,7 @@ from typing_extensions import (
     Never,
     TypeAlias,
 )
+from pandas._libs.lib import NoDefault
 import xarray as xr
 
 from pandas._libs.interval import Interval
@@ -97,6 +98,7 @@ from pandas._typing import (
     ComplexDtypeArg,
     CompressionOptions,
     DtypeObj,
+    DtypeBackend,
     FilePath,
     FillnaOptions,
     FloatDtypeArg,
@@ -1133,6 +1135,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         convert_string: _bool = ...,
         convert_integer: _bool = ...,
         convert_boolean: _bool = ...,
+        dtype_backend: DtypeBackend | NoDefault = ...,
     ) -> Series[S1]: ...
     @overload
     def ffill(

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -77,7 +77,6 @@ from typing_extensions import (
 import xarray as xr
 
 from pandas._libs.interval import Interval
-from pandas._libs.lib import NoDefault
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs import BaseOffset
 from pandas._typing import (

--- a/pandas-stubs/core/tools/numeric.pyi
+++ b/pandas-stubs/core/tools/numeric.pyi
@@ -7,14 +7,13 @@ import numpy as np
 import pandas as pd
 from typing_extensions import TypeAlias
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     DtypeBackend,
     IgnoreRaiseCoerce,
     Scalar,
     npt,
 )
-
-from pandas._libs.lib import NoDefault
 
 _Downcast: TypeAlias = Literal["integer", "signed", "unsigned", "float"] | None
 

--- a/pandas-stubs/core/tools/numeric.pyi
+++ b/pandas-stubs/core/tools/numeric.pyi
@@ -8,10 +8,13 @@ import pandas as pd
 from typing_extensions import TypeAlias
 
 from pandas._typing import (
+    DtypeBackend,
     IgnoreRaiseCoerce,
     Scalar,
     npt,
 )
+
+from pandas._libs.lib import NoDefault
 
 _Downcast: TypeAlias = Literal["integer", "signed", "unsigned", "float"] | None
 
@@ -20,22 +23,26 @@ def to_numeric(
     arg: Scalar,
     errors: Literal["raise", "coerce"] = ...,
     downcast: _Downcast = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> float: ...
 @overload
 def to_numeric(
     arg: Scalar,
     errors: Literal["ignore"],
     downcast: _Downcast = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> Scalar: ...
 @overload
 def to_numeric(
     arg: list | tuple | np.ndarray,
     errors: IgnoreRaiseCoerce = ...,
     downcast: _Downcast = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> npt.NDArray: ...
 @overload
 def to_numeric(
     arg: pd.Series,
     errors: IgnoreRaiseCoerce = ...,
     downcast: _Downcast = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> pd.Series: ...

--- a/pandas-stubs/io/clipboards.pyi
+++ b/pandas-stubs/io/clipboards.pyi
@@ -17,12 +17,15 @@ from pandas._typing import (
     CSVEngine,
     CSVQuoting,
     DtypeArg,
+    DtypeBackend,
     ListLikeHashable,
     StorageOptions,
     UsecolsArgType,
 )
 
 from pandas.io.parsers import TextFileReader
+
+from pandas._libs.lib import NoDefault
 
 @overload
 def read_clipboard(
@@ -80,6 +83,7 @@ def read_clipboard(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> TextFileReader: ...
 @overload
 def read_clipboard(
@@ -137,6 +141,7 @@ def read_clipboard(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> TextFileReader: ...
 @overload
 def read_clipboard(
@@ -194,6 +199,7 @@ def read_clipboard(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...
 def to_clipboard(
     obj, excel: bool = ..., sep: str | None = ..., **kwargs: Any

--- a/pandas-stubs/io/clipboards.pyi
+++ b/pandas-stubs/io/clipboards.pyi
@@ -30,6 +30,7 @@ from pandas.io.parsers import TextFileReader
 def read_clipboard(
     sep: str | None = ...,
     *,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
@@ -82,12 +83,12 @@ def read_clipboard(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> TextFileReader: ...
 @overload
 def read_clipboard(
     sep: str | None = ...,
     *,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
@@ -140,12 +141,12 @@ def read_clipboard(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> TextFileReader: ...
 @overload
 def read_clipboard(
     sep: str | None = ...,
     *,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
@@ -198,7 +199,6 @@ def read_clipboard(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...
 def to_clipboard(
     obj, excel: bool = ..., sep: str | None = ..., **kwargs: Any

--- a/pandas-stubs/io/clipboards.pyi
+++ b/pandas-stubs/io/clipboards.pyi
@@ -12,6 +12,7 @@ from typing import (
 
 from pandas.core.frame import DataFrame
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     CompressionOptions,
     CSVEngine,
@@ -24,8 +25,6 @@ from pandas._typing import (
 )
 
 from pandas.io.parsers import TextFileReader
-
-from pandas._libs.lib import NoDefault
 
 @overload
 def read_clipboard(

--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -15,12 +15,14 @@ from typing import (
 from odf.opendocument import OpenDocument
 from openpyxl.workbook.workbook import Workbook
 from pandas.core.frame import DataFrame
+from pandas._libs.lib import NoDefault
 import pyxlsb.workbook
 from typing_extensions import Self
 from xlrd.book import Book
 
 from pandas._typing import (
     Dtype,
+    DtypeBackend,
     FilePath,
     ListLikeHashable,
     ReadBuffer,
@@ -66,6 +68,7 @@ def read_excel(
     comment: str | None = ...,
     skipfooter: int = ...,
     storage_options: StorageOptions = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> dict[int | str, DataFrame]: ...
 @overload
 def read_excel(
@@ -104,6 +107,7 @@ def read_excel(
     comment: str | None = ...,
     skipfooter: int = ...,
     storage_options: StorageOptions = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...
 
 class ExcelWriter:

--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -15,11 +15,11 @@ from typing import (
 from odf.opendocument import OpenDocument
 from openpyxl.workbook.workbook import Workbook
 from pandas.core.frame import DataFrame
-from pandas._libs.lib import NoDefault
 import pyxlsb.workbook
 from typing_extensions import Self
 from xlrd.book import Book
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     Dtype,
     DtypeBackend,

--- a/pandas-stubs/io/feather_format.pyi
+++ b/pandas-stubs/io/feather_format.pyi
@@ -1,15 +1,19 @@
 from pandas import DataFrame
 
 from pandas._typing import (
+    DtypeBackend,
     FilePath,
     HashableT,
     ReadBuffer,
     StorageOptions,
 )
 
+from pandas._libs.lib import NoDefault
+
 def read_feather(
     path: FilePath | ReadBuffer[bytes],
     columns: list[HashableT] | None = ...,
     use_threads: bool = ...,
     storage_options: StorageOptions = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...

--- a/pandas-stubs/io/feather_format.pyi
+++ b/pandas-stubs/io/feather_format.pyi
@@ -1,5 +1,6 @@
 from pandas import DataFrame
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     DtypeBackend,
     FilePath,
@@ -7,8 +8,6 @@ from pandas._typing import (
     ReadBuffer,
     StorageOptions,
 )
-
-from pandas._libs.lib import NoDefault
 
 def read_feather(
     path: FilePath | ReadBuffer[bytes],

--- a/pandas-stubs/io/html.pyi
+++ b/pandas-stubs/io/html.pyi
@@ -13,6 +13,7 @@ from typing import (
 from pandas.core.frame import DataFrame
 
 from pandas._typing import (
+    DtypeBackend,
     FilePath,
     HashableT1,
     HashableT2,
@@ -21,6 +22,8 @@ from pandas._typing import (
     HashableT5,
     ReadBuffer,
 )
+
+from pandas._libs.lib import NoDefault
 
 def read_html(
     io: FilePath | ReadBuffer[str],
@@ -49,4 +52,5 @@ def read_html(
     keep_default_na: bool = ...,
     displayed_only: bool = ...,
     extract_links: Literal["header", "footer", "body", "all"] | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> list[DataFrame]: ...

--- a/pandas-stubs/io/html.pyi
+++ b/pandas-stubs/io/html.pyi
@@ -12,6 +12,7 @@ from typing import (
 
 from pandas.core.frame import DataFrame
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     DtypeBackend,
     FilePath,
@@ -22,8 +23,6 @@ from pandas._typing import (
     HashableT5,
     ReadBuffer,
 )
-
-from pandas._libs.lib import NoDefault
 
 def read_html(
     io: FilePath | ReadBuffer[str],

--- a/pandas-stubs/io/json/_json.pyi
+++ b/pandas-stubs/io/json/_json.pyi
@@ -12,6 +12,7 @@ from pandas.core.series import Series
 from pandas._typing import (
     CompressionOptions,
     DtypeArg,
+    DtypeBackend,
     FilePath,
     HashableT,
     JsonFrameOrient,
@@ -20,6 +21,8 @@ from pandas._typing import (
     ReadBuffer,
     StorageOptions,
 )
+
+from pandas._libs.lib import NoDefault
 
 @overload
 def read_json(
@@ -43,6 +46,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> JsonReader[Series]: ...
 @overload
 def read_json(
@@ -66,6 +70,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> JsonReader[DataFrame]: ...
 @overload
 def read_json(
@@ -89,6 +94,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> Series: ...
 @overload
 def read_json(
@@ -112,6 +118,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...
 
 class JsonReader(abc.Iterator, Generic[NDFrameT]):

--- a/pandas-stubs/io/json/_json.pyi
+++ b/pandas-stubs/io/json/_json.pyi
@@ -9,6 +9,7 @@ from typing import (
 from pandas.core.frame import DataFrame
 from pandas.core.series import Series
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     CompressionOptions,
     DtypeArg,
@@ -21,8 +22,6 @@ from pandas._typing import (
     ReadBuffer,
     StorageOptions,
 )
-
-from pandas._libs.lib import NoDefault
 
 @overload
 def read_json(

--- a/pandas-stubs/io/orc.pyi
+++ b/pandas-stubs/io/orc.pyi
@@ -3,13 +3,17 @@ from typing import Any
 from pandas import DataFrame
 
 from pandas._typing import (
+    DtypeBackend,
     FilePath,
     HashableT,
     ReadBuffer,
 )
 
+from pandas._libs.lib import NoDefault
+
 def read_orc(
     path: FilePath | ReadBuffer[bytes],
     columns: list[HashableT] | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     **kwargs: Any,
 ) -> DataFrame: ...

--- a/pandas-stubs/io/orc.pyi
+++ b/pandas-stubs/io/orc.pyi
@@ -2,14 +2,13 @@ from typing import Any
 
 from pandas import DataFrame
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     DtypeBackend,
     FilePath,
     HashableT,
     ReadBuffer,
 )
-
-from pandas._libs.lib import NoDefault
 
 def read_orc(
     path: FilePath | ReadBuffer[bytes],

--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -23,6 +23,7 @@ from pandas._typing import (
     CSVEngine,
     CSVQuoting,
     DtypeArg,
+    DtypeBackend,
     FilePath,
     ListLikeHashable,
     ReadCsvBuffer,
@@ -32,6 +33,8 @@ from pandas._typing import (
 
 from pandas.io.common import IOHandles
 
+from pandas._libs.lib import NoDefault
+
 @overload
 def read_csv(
     filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
@@ -90,6 +93,7 @@ def read_csv(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> TextFileReader: ...
 @overload
 def read_csv(
@@ -149,6 +153,7 @@ def read_csv(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> TextFileReader: ...
 @overload
 def read_csv(
@@ -208,6 +213,7 @@ def read_csv(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...
 @overload
 def read_table(
@@ -395,6 +401,7 @@ def read_fwf(
     infer_nrows: int = ...,
     iterator: Literal[True],
     chunksize: int | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     **kwds: Any,
 ) -> TextFileReader: ...
 @overload
@@ -406,6 +413,7 @@ def read_fwf(
     infer_nrows: int = ...,
     iterator: bool = ...,
     chunksize: int,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     **kwds: Any,
 ) -> TextFileReader: ...
 @overload
@@ -417,6 +425,7 @@ def read_fwf(
     infer_nrows: int = ...,
     iterator: Literal[False] = ...,
     chunksize: None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     **kwds: Any,
 ) -> DataFrame: ...
 

--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -18,6 +18,7 @@ from typing import (
 from pandas.core.frame import DataFrame
 from typing_extensions import Self
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     CompressionOptions,
     CSVEngine,
@@ -32,8 +33,6 @@ from pandas._typing import (
 )
 
 from pandas.io.common import IOHandles
-
-from pandas._libs.lib import NoDefault
 
 @overload
 def read_csv(

--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -398,9 +398,9 @@ def read_fwf(
     colspecs: Sequence[tuple[int, int]] | Literal["infer"] | None = ...,
     widths: Sequence[int] | None = ...,
     infer_nrows: int = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     iterator: Literal[True],
     chunksize: int | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
     **kwds: Any,
 ) -> TextFileReader: ...
 @overload
@@ -410,9 +410,9 @@ def read_fwf(
     colspecs: Sequence[tuple[int, int]] | Literal["infer"] | None = ...,
     widths: Sequence[int] | None = ...,
     infer_nrows: int = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     iterator: bool = ...,
     chunksize: int,
-    dtype_backend: DtypeBackend | NoDefault = ...,
     **kwds: Any,
 ) -> TextFileReader: ...
 @overload
@@ -422,9 +422,9 @@ def read_fwf(
     colspecs: Sequence[tuple[int, int]] | Literal["infer"] | None = ...,
     widths: Sequence[int] | None = ...,
     infer_nrows: int = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
     iterator: Literal[False] = ...,
     chunksize: None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
     **kwds: Any,
 ) -> DataFrame: ...
 

--- a/pandas-stubs/io/spss.pyi
+++ b/pandas-stubs/io/spss.pyi
@@ -1,12 +1,16 @@
 from pandas.core.frame import DataFrame
 
 from pandas._typing import (
+    DtypeBackend,
     FilePath,
     HashableT,
 )
+
+from pandas._libs.lib import NoDefault
 
 def read_spss(
     path: FilePath,
     usecols: list[HashableT] | None = ...,
     convert_categoricals: bool = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...

--- a/pandas-stubs/io/spss.pyi
+++ b/pandas-stubs/io/spss.pyi
@@ -1,12 +1,11 @@
 from pandas.core.frame import DataFrame
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
     DtypeBackend,
     FilePath,
     HashableT,
 )
-
-from pandas._libs.lib import NoDefault
 
 def read_spss(
     path: FilePath,

--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -40,6 +40,7 @@ def read_sql_table(
     columns: list[str] | None = ...,
     *,
     chunksize: int,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql_table(
@@ -51,6 +52,7 @@ def read_sql_table(
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = ...,
     columns: list[str] | None = ...,
     chunksize: None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...
 @overload
 def read_sql_query(
@@ -63,6 +65,7 @@ def read_sql_query(
     *,
     chunksize: int,
     dtype: DtypeArg | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql_query(
@@ -74,6 +77,7 @@ def read_sql_query(
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = ...,
     chunksize: None = ...,
     dtype: DtypeArg | None = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...
 @overload
 def read_sql(

--- a/pandas-stubs/io/xml.pyi
+++ b/pandas-stubs/io/xml.pyi
@@ -2,19 +2,18 @@ from collections.abc import Sequence
 
 from pandas.core.frame import DataFrame
 
+from pandas._libs.lib import NoDefault
 from pandas._typing import (
-    DtypeBackend,
     CompressionOptions,
     ConvertersArg,
     DtypeArg,
+    DtypeBackend,
     FilePath,
     ParseDatesArg,
     ReadBuffer,
     StorageOptions,
     XMLParsers,
 )
-
-from pandas._libs.lib import NoDefault
 
 def read_xml(
     path_or_buffer: FilePath | ReadBuffer[bytes] | ReadBuffer[str],

--- a/pandas-stubs/io/xml.pyi
+++ b/pandas-stubs/io/xml.pyi
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from pandas.core.frame import DataFrame
 
 from pandas._typing import (
+    DtypeBackend,
     CompressionOptions,
     ConvertersArg,
     DtypeArg,
@@ -12,6 +13,8 @@ from pandas._typing import (
     StorageOptions,
     XMLParsers,
 )
+
+from pandas._libs.lib import NoDefault
 
 def read_xml(
     path_or_buffer: FilePath | ReadBuffer[bytes] | ReadBuffer[str],
@@ -31,4 +34,5 @@ def read_xml(
     iterparse: dict[str, list[str]] | None = ...,
     compression: CompressionOptions = ...,
     storage_options: StorageOptions = ...,
+    dtype_backend: DtypeBackend | NoDefault = ...,
 ) -> DataFrame: ...

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2597,3 +2597,9 @@ def test_suffix_prefix_index() -> None:
     check(
         assert_type(df.add_prefix("_col", axis="columns"), pd.DataFrame), pd.DataFrame
     )
+
+
+def test_convert_dtypes_dtype_backend() -> None:
+    df = pd.DataFrame({"A": [1, 2, 3, 4], "B": [3, 4, 5, 6]})
+    dfn = df.convert_dtypes(dtype_backend="numpy_nullable")
+    check(assert_type(dfn, pd.DataFrame), pd.DataFrame)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1336,16 +1336,17 @@ def test_all_read_dtype_backend() -> None:
         #     assert_type(read_spss(path, dtype_backend="pyarrow"), pd.DataFrame),
         #     pd.DataFrame,
         # )
-        path = Path(CWD, "data", "labelled-num.sav")
-        check(
-            assert_type(
-                read_spss(
-                    str(path), usecols=["VAR00002"], dtype_backend="numpy_nullable"
+        # path = Path(CWD, "data", "labelled-num.sav")
+        with ensure_clean() as path:
+            check(
+                assert_type(
+                    read_spss(
+                        path,dtype_backend="numpy_nullable"
+                    ),
+                    DataFrame,
                 ),
                 DataFrame,
-            ),
-            DataFrame,
-        )
+            )
 
         # check(
         #     assert_type(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1337,7 +1337,15 @@ def test_all_read_dtype_backend() -> None:
         #     pd.DataFrame,
         # )
         path = Path(CWD, "data", "labelled-num.sav")
-        check(assert_type(read_spss(str(path), usecols=["VAR00002"],dtype_backend="numpy_nullable"), DataFrame), DataFrame)
+        check(
+            assert_type(
+                read_spss(
+                    str(path), usecols=["VAR00002"], dtype_backend="numpy_nullable"
+                ),
+                DataFrame,
+            ),
+            DataFrame,
+        )
 
         # check(
         #     assert_type(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -16,6 +16,7 @@ from typing import (
     Union,
 )
 
+import numpy.typing as npt
 import numpy as np
 import pandas as pd
 from pandas import (
@@ -44,6 +45,7 @@ from pandas import (
     read_xml,
 )
 from pandas._testing import ensure_clean
+from pandas._libs.missing import NAType
 import pytest
 import sqlalchemy
 import sqlalchemy.ext.declarative
@@ -1269,3 +1271,63 @@ def test_read_sql_dtype_backend() -> None:
             pd.DataFrame,
         )
         conn2.close()
+
+
+def test_all_read_dtype_backend() -> None:
+    with ensure_clean() as path:
+        check(assert_type(DF.to_csv(path), None), type(None))
+        s1 = read_csv(path, iterator=True,dtype_backend="pyarrow")
+        check(assert_type(s1, TextFileReader), TextFileReader)
+        s1.close()
+
+        DF.to_string(path, index=False)
+        check(assert_type(read_fwf(path, dtype_backend="pyarrow"), DataFrame), DataFrame)
+
+    with ensure_clean() as path:
+        check(assert_type(DF.to_html(path), None), type(None))
+        check(assert_type(read_html(path, dtype_backend="numpy_nullable"), List[DataFrame]), list)
+
+        check(assert_type(DF.to_xml(path), None), type(None))
+        check(assert_type(read_xml(path, dtype_backend="pyarrow"), DataFrame), DataFrame)
+
+        check(assert_type(DF.to_json(path), None), type(None))
+        check(assert_type(read_json(path, dtype_backend="pyarrow"), DataFrame), DataFrame)
+
+    with ensure_clean() as path:
+        con = sqlite3.connect(path)
+        check(assert_type(DF.to_sql("test", con=con), Union[int, None]), int)
+        check(
+            assert_type(
+                read_sql_query("select * from test", con=con, index_col="index", dtype_backend="pyarrow"),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        con.close()
+
+        check(assert_type(DF.to_orc(path), None), type(None))
+        check(assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame), DataFrame)
+
+        check(assert_type(DF.to_feather(path), None), type(None))
+        check(assert_type(read_feather(path, dtype_backend="pyarrow"), DataFrame), DataFrame)
+
+        check(assert_type(read_spss(path, dtype_backend="pyarrow"), pd.DataFrame), pd.DataFrame)
+        path = Path(CWD, "data", "labelled-num.sav")
+        check(assert_type(read_spss(path, convert_categoricals=True, dtype_backend="pyarrow"), DataFrame), DataFrame)
+
+        check(assert_type(pd.to_numeric([1.0, 2.0, "blerg"], errors="ignore", dtype_backend="numpy_nullable"), npt.NDArray),np.ndarray,)
+
+        # con = sqlite3.connect(path)
+        #     check(assert_type(DF.to_sql("test", con=con), Union[int, None]))
+        #     assert_type(read_sql_table("test", con=con), DataFrame)
+
+    with ensure_clean(".xlsx") as path:
+        as_str: str = path
+        DF.to_excel(path)
+        check(assert_type(pd.read_excel(as_str, dtype_backend="pyarrow"), pd.DataFrame), pd.DataFrame)
+
+    try:
+        DF.to_clipboard()
+    except errors.PyperclipException:
+        pytest.skip("clipboard not available for testing")
+    check(assert_type(read_clipboard(iterator=True, dtype_backend="pyarrow"), TextFileReader), TextFileReader)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1272,8 +1272,7 @@ def test_read_sql_dtype_backend() -> None:
         conn2.close()
 
 
-@lxml_skip
-def test_all_read_dtype_backend() -> None:
+def test_all_read_without_lxml_dtype_backend() -> None:
     with ensure_clean() as path:
         check(assert_type(DF.to_csv(path), None), type(None))
         s1 = read_csv(path, iterator=True, dtype_backend="pyarrow")
@@ -1283,20 +1282,6 @@ def test_all_read_dtype_backend() -> None:
         DF.to_string(path, index=False)
         check(
             assert_type(read_fwf(path, dtype_backend="pyarrow"), DataFrame), DataFrame
-        )
-
-    with ensure_clean() as path:
-        check(assert_type(DF.to_html(path), None), type(None))
-        check(
-            assert_type(
-                read_html(path, dtype_backend="numpy_nullable"), List[DataFrame]
-            ),
-            list,
-        )
-
-        check(assert_type(DF.to_xml(path), None), type(None))
-        check(
-            assert_type(read_xml(path, dtype_backend="pyarrow"), DataFrame), DataFrame
         )
 
         check(assert_type(DF.to_json(path), None), type(None))
@@ -1322,11 +1307,11 @@ def test_all_read_dtype_backend() -> None:
         con.close()
 
         if not WINDOWS:
-                check(assert_type(DF.to_orc(path), None), type(None))
-                check(
-                    assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame),
-                    DataFrame,
-                )
+            check(assert_type(DF.to_orc(path), None), type(None))
+            check(
+                assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame),
+                DataFrame,
+            )
 
         check(assert_type(DF.to_feather(path), None), type(None))
         check(
@@ -1343,10 +1328,6 @@ def test_all_read_dtype_backend() -> None:
             ),
             np.ndarray,
         )
-
-        # con = sqlite3.connect(path)
-        #     check(assert_type(DF.to_sql("test", con=con), Union[int, None]))
-        #     assert_type(read_sql_table("test", con=con), DataFrame)
 
     with ensure_clean(".xlsx") as path:
         as_str: str = path
@@ -1366,3 +1347,30 @@ def test_all_read_dtype_backend() -> None:
         ),
         TextFileReader,
     )
+
+    if TYPE_CHECKING:
+        with ensure_clean() as path:
+            co1 = sqlite3.connect(path)
+            assert_type(DF.to_sql("test", con=co1), Union[int, None])
+            assert_type(
+                read_sql_table("test", con=co1, dtype_backend="numpy_nullable"),
+                DataFrame,
+            )
+            co1.close()
+
+
+@lxml_skip
+def test_read_with_lxml_dtype_backend() -> None:
+    with ensure_clean() as path:
+        check(assert_type(DF.to_html(path), None), type(None))
+        check(
+            assert_type(
+                read_html(path, dtype_backend="numpy_nullable"), List[DataFrame]
+            ),
+            list,
+        )
+
+        check(assert_type(DF.to_xml(path), None), type(None))
+        check(
+            assert_type(read_xml(path, dtype_backend="pyarrow"), DataFrame), DataFrame
+        )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -16,8 +16,8 @@ from typing import (
     Union,
 )
 
-import numpy.typing as npt
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from pandas import (
     DataFrame,
@@ -45,7 +45,6 @@ from pandas import (
     read_xml,
 )
 from pandas._testing import ensure_clean
-from pandas._libs.missing import NAType
 import pytest
 import sqlalchemy
 import sqlalchemy.ext.declarative
@@ -1276,29 +1275,45 @@ def test_read_sql_dtype_backend() -> None:
 def test_all_read_dtype_backend() -> None:
     with ensure_clean() as path:
         check(assert_type(DF.to_csv(path), None), type(None))
-        s1 = read_csv(path, iterator=True,dtype_backend="pyarrow")
+        s1 = read_csv(path, iterator=True, dtype_backend="pyarrow")
         check(assert_type(s1, TextFileReader), TextFileReader)
         s1.close()
 
         DF.to_string(path, index=False)
-        check(assert_type(read_fwf(path, dtype_backend="pyarrow"), DataFrame), DataFrame)
+        check(
+            assert_type(read_fwf(path, dtype_backend="pyarrow"), DataFrame), DataFrame
+        )
 
     with ensure_clean() as path:
         check(assert_type(DF.to_html(path), None), type(None))
-        check(assert_type(read_html(path, dtype_backend="numpy_nullable"), List[DataFrame]), list)
+        check(
+            assert_type(
+                read_html(path, dtype_backend="numpy_nullable"), List[DataFrame]
+            ),
+            list,
+        )
 
         check(assert_type(DF.to_xml(path), None), type(None))
-        check(assert_type(read_xml(path, dtype_backend="pyarrow"), DataFrame), DataFrame)
+        check(
+            assert_type(read_xml(path, dtype_backend="pyarrow"), DataFrame), DataFrame
+        )
 
         check(assert_type(DF.to_json(path), None), type(None))
-        check(assert_type(read_json(path, dtype_backend="pyarrow"), DataFrame), DataFrame)
+        check(
+            assert_type(read_json(path, dtype_backend="pyarrow"), DataFrame), DataFrame
+        )
 
     with ensure_clean() as path:
         con = sqlite3.connect(path)
         check(assert_type(DF.to_sql("test", con=con), Union[int, None]), int)
         check(
             assert_type(
-                read_sql_query("select * from test", con=con, index_col="index", dtype_backend="pyarrow"),
+                read_sql_query(
+                    "select * from test",
+                    con=con,
+                    index_col="index",
+                    dtype_backend="pyarrow",
+                ),
                 DataFrame,
             ),
             DataFrame,
@@ -1306,16 +1321,39 @@ def test_all_read_dtype_backend() -> None:
         con.close()
 
         check(assert_type(DF.to_orc(path), None), type(None))
-        check(assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame), DataFrame)
+        check(
+            assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame),
+            DataFrame,
+        )
 
         check(assert_type(DF.to_feather(path), None), type(None))
-        check(assert_type(read_feather(path, dtype_backend="pyarrow"), DataFrame), DataFrame)
+        check(
+            assert_type(read_feather(path, dtype_backend="pyarrow"), DataFrame),
+            DataFrame,
+        )
 
-        check(assert_type(read_spss(path, dtype_backend="pyarrow"), pd.DataFrame), pd.DataFrame)
+        check(
+            assert_type(read_spss(path, dtype_backend="pyarrow"), pd.DataFrame),
+            pd.DataFrame,
+        )
         path = Path(CWD, "data", "labelled-num.sav")
-        check(assert_type(read_spss(path, convert_categoricals=True, dtype_backend="pyarrow"), DataFrame), DataFrame)
+        check(
+            assert_type(
+                read_spss(path, convert_categoricals=True, dtype_backend="pyarrow"),
+                DataFrame,
+            ),
+            DataFrame,
+        )
 
-        check(assert_type(pd.to_numeric([1.0, 2.0, "blerg"], errors="ignore", dtype_backend="numpy_nullable"), npt.NDArray),np.ndarray,)
+        check(
+            assert_type(
+                pd.to_numeric(
+                    [1.0, 2.0, "blerg"], errors="ignore", dtype_backend="numpy_nullable"
+                ),
+                npt.NDArray,
+            ),
+            np.ndarray,
+        )
 
         # con = sqlite3.connect(path)
         #     check(assert_type(DF.to_sql("test", con=con), Union[int, None]))
@@ -1324,10 +1362,18 @@ def test_all_read_dtype_backend() -> None:
     with ensure_clean(".xlsx") as path:
         as_str: str = path
         DF.to_excel(path)
-        check(assert_type(pd.read_excel(as_str, dtype_backend="pyarrow"), pd.DataFrame), pd.DataFrame)
+        check(
+            assert_type(pd.read_excel(as_str, dtype_backend="pyarrow"), pd.DataFrame),
+            pd.DataFrame,
+        )
 
     try:
         DF.to_clipboard()
     except errors.PyperclipException:
         pytest.skip("clipboard not available for testing")
-    check(assert_type(read_clipboard(iterator=True, dtype_backend="pyarrow"), TextFileReader), TextFileReader)
+    check(
+        assert_type(
+            read_clipboard(iterator=True, dtype_backend="pyarrow"), TextFileReader
+        ),
+        TextFileReader,
+    )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1349,6 +1349,8 @@ def test_all_read_without_lxml_dtype_backend() -> None:
     )
 
     if TYPE_CHECKING:
+        # sqlite3 doesn't support read_table, which is required for this function
+        # Could only run in pytest if SQLAlchemy was installed
         with ensure_clean() as path:
             co1 = sqlite3.connect(path)
             assert_type(DF.to_sql("test", con=co1), Union[int, None])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -16,6 +16,7 @@ from typing import (
     Union,
 )
 
+# import lxml 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -1272,6 +1273,7 @@ def test_read_sql_dtype_backend() -> None:
         conn2.close()
 
 
+@lxml_skip
 def test_all_read_dtype_backend() -> None:
     with ensure_clean() as path:
         check(assert_type(DF.to_csv(path), None), type(None))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1332,28 +1332,6 @@ def test_all_read_dtype_backend() -> None:
             DataFrame,
         )
 
-        # check(
-        #     assert_type(read_spss(path, dtype_backend="pyarrow"), pd.DataFrame),
-        #     pd.DataFrame,
-        # )
-        # path = Path(CWD, "data", "labelled-num.sav")
-        with ensure_clean() as path:
-            check(
-                assert_type(
-                    read_spss(path, dtype_backend="numpy_nullable"),
-                    DataFrame,
-                ),
-                DataFrame,
-            )
-
-        # check(
-        #     assert_type(
-        #         read_spss(path, convert_categoricals=True, dtype_backend="pyarrow"),
-        #         DataFrame,
-        #     ),
-        #     DataFrame,
-        # )
-
         check(
             assert_type(
                 pd.to_numeric(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1321,11 +1321,12 @@ def test_all_read_dtype_backend() -> None:
         )
         con.close()
 
-        check(assert_type(DF.to_orc(path), None), type(None))
-        check(
-            assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame),
-            DataFrame,
-        )
+        if not WINDOWS:
+                check(assert_type(DF.to_orc(path), None), type(None))
+                check(
+                    assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame),
+                    DataFrame,
+                )
 
         check(assert_type(DF.to_feather(path), None), type(None))
         check(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1340,9 +1340,7 @@ def test_all_read_dtype_backend() -> None:
         with ensure_clean() as path:
             check(
                 assert_type(
-                    read_spss(
-                        path,dtype_backend="numpy_nullable"
-                    ),
+                    read_spss(path, dtype_backend="numpy_nullable"),
                     DataFrame,
                 ),
                 DataFrame,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1332,11 +1332,13 @@ def test_all_read_dtype_backend() -> None:
             DataFrame,
         )
 
-        check(
-            assert_type(read_spss(path, dtype_backend="pyarrow"), pd.DataFrame),
-            pd.DataFrame,
-        )
-        # path = Path(CWD, "data", "labelled-num.sav")
+        # check(
+        #     assert_type(read_spss(path, dtype_backend="pyarrow"), pd.DataFrame),
+        #     pd.DataFrame,
+        # )
+        path = Path(CWD, "data", "labelled-num.sav")
+        check(assert_type(read_spss(str(path), usecols=["VAR00002"],dtype_backend="numpy_nullable"), DataFrame), DataFrame)
+
         # check(
         #     assert_type(
         #         read_spss(path, convert_categoricals=True, dtype_backend="pyarrow"),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1336,14 +1336,14 @@ def test_all_read_dtype_backend() -> None:
             assert_type(read_spss(path, dtype_backend="pyarrow"), pd.DataFrame),
             pd.DataFrame,
         )
-        path = Path(CWD, "data", "labelled-num.sav")
-        check(
-            assert_type(
-                read_spss(path, convert_categoricals=True, dtype_backend="pyarrow"),
-                DataFrame,
-            ),
-            DataFrame,
-        )
+        # path = Path(CWD, "data", "labelled-num.sav")
+        # check(
+        #     assert_type(
+        #         read_spss(path, convert_categoricals=True, dtype_backend="pyarrow"),
+        #         DataFrame,
+        #     ),
+        #     DataFrame,
+        # )
 
         check(
             assert_type(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -16,7 +16,6 @@ from typing import (
     Union,
 )
 
-# import lxml 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1830,3 +1830,9 @@ def test_prefix_summix_axis() -> None:
     if TYPE_CHECKING_INVALID_USAGE:
         check(assert_type(s.add_prefix("_item", axis=1), pd.Series), pd.Series)  # type: ignore[arg-type] # pyright: ignore[reportGeneralTypeIssues]
         check(assert_type(s.add_suffix("_item", axis="columns"), pd.Series), pd.Series)  # type: ignore[arg-type] # pyright: ignore[reportGeneralTypeIssues]
+
+
+def test_convert_dtypes_dtype_backend() -> None:
+    s = pd.Series([1, 2, 3, 4])
+    s1 = s.convert_dtypes(dtype_backend="numpy_nullable")
+    check(assert_type(s1, pd.Series), pd.Series)


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [ ] Closes #624
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
