### PR TITLE
nightly fix for GH-657

### DIFF
--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -362,15 +362,20 @@ def test_is_object_dtype() -> None:
 
 
 def test_is_period_dtype() -> None:
-    check(assert_type(api.is_period_dtype(arr), bool), bool)
-    check(assert_type(api.is_period_dtype(nparr), bool), bool)
-    check(assert_type(api.is_period_dtype(dtylike), bool), bool)
-    check(
-        assert_type(api.is_period_dtype(dframe), bool),
-        bool,
-    )
-    check(assert_type(api.is_period_dtype(ind), bool), bool)
-    check(assert_type(api.is_period_dtype(ExtensionDtype), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="is_period_dtype is now deprecate and will be removed in a future version",
+        lower="2.0.99",
+    ):
+        check(assert_type(api.is_period_dtype(arr), bool), bool)
+        check(assert_type(api.is_period_dtype(nparr), bool), bool)
+        check(assert_type(api.is_period_dtype(dtylike), bool), bool)
+        check(
+            assert_type(api.is_period_dtype(dframe), bool),
+            bool,
+        )
+        check(assert_type(api.is_period_dtype(ind), bool), bool)
+        check(assert_type(api.is_period_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_re() -> None:
@@ -416,9 +421,14 @@ def test_is_signed_integer_dtype() -> None:
 
 
 def test_is_sparse() -> None:
-    check(assert_type(api.is_sparse(arr), bool), bool)
-    check(assert_type(api.is_sparse(nparr), bool), bool)
-    check(assert_type(api.is_sparse(dframe), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="is_sparse is now deprecated and will be removed in a future version",
+        lower="2.0.99",
+    ):
+        check(assert_type(api.is_sparse(arr), bool), bool)
+        check(assert_type(api.is_sparse(nparr), bool), bool)
+        check(assert_type(api.is_sparse(dframe), bool), bool)
 
 
 def test_is_string_dtype() -> None:

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -364,7 +364,7 @@ def test_is_object_dtype() -> None:
 def test_is_period_dtype() -> None:
     with pytest_warns_bounded(
         FutureWarning,
-        match="is_period_dtype is deprecated and will be removed in a future version. Use `isinstance(dtype, pd.PeriodDtype)` instead",
+        match="is_period_dtype is deprecated and will be removed in a future version",
         lower="2.0.00",
     ):
         check(assert_type(api.is_period_dtype(arr), bool), bool)
@@ -423,7 +423,7 @@ def test_is_signed_integer_dtype() -> None:
 def test_is_sparse() -> None:
     with pytest_warns_bounded(
         FutureWarning,
-        match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+        match="is_sparse is deprecated and will be removed in a future version",
         lower="2.0.00",
     ):
         check(assert_type(api.is_sparse(arr), bool), bool)

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -365,7 +365,7 @@ def test_is_period_dtype() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         match="is_period_dtype is deprecated and will be removed in a future version",
-        lower="2.0.00",
+        lower="2.0.99",
     ):
         check(assert_type(api.is_period_dtype(arr), bool), bool)
         check(assert_type(api.is_period_dtype(nparr), bool), bool)
@@ -424,7 +424,7 @@ def test_is_sparse() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         match="is_sparse is deprecated and will be removed in a future version",
-        lower="2.0.00",
+        lower="2.0.99",
     ):
         check(assert_type(api.is_sparse(arr), bool), bool)
         check(assert_type(api.is_sparse(nparr), bool), bool)

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -364,7 +364,7 @@ def test_is_object_dtype() -> None:
 def test_is_period_dtype() -> None:
     with pytest_warns_bounded(
         FutureWarning,
-        match="is_period_dtype is now deprecate and will be removed in a future version",
+        match="is_period_dtype is deprecated and will be removed in a future version. Use `isinstance(dtype, pd.PeriodDtype)` instead",
         lower="2.0.99",
     ):
         check(assert_type(api.is_period_dtype(arr), bool), bool)
@@ -423,7 +423,7 @@ def test_is_signed_integer_dtype() -> None:
 def test_is_sparse() -> None:
     with pytest_warns_bounded(
         FutureWarning,
-        match="is_sparse is now deprecated and will be removed in a future version",
+        match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
         lower="2.0.99",
     ):
         check(assert_type(api.is_sparse(arr), bool), bool)

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -365,7 +365,7 @@ def test_is_period_dtype() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         match="is_period_dtype is deprecated and will be removed in a future version. Use `isinstance(dtype, pd.PeriodDtype)` instead",
-        lower="2.0.99",
+        lower="2.0.00",
     ):
         check(assert_type(api.is_period_dtype(arr), bool), bool)
         check(assert_type(api.is_period_dtype(nparr), bool), bool)
@@ -424,7 +424,7 @@ def test_is_sparse() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-        lower="2.0.99",
+        lower="2.0.00",
     ):
         check(assert_type(api.is_sparse(arr), bool), bool)
         check(assert_type(api.is_sparse(nparr), bool), bool)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1100,7 +1100,7 @@ def test_types_to_feather() -> None:
     df = pd.DataFrame(data={"col1": [1, 1, 2], "col2": [3, 4, 5]})
     with pytest_warns_bounded(
         FutureWarning,
-        match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+        match="is_sparse is deprecated and will be removed in a future version",
         lower="2.0.00",
     ):
         with ensure_clean() as path:
@@ -1346,7 +1346,7 @@ def test_types_to_parquet() -> None:
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             df.to_parquet(Path(path))

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1098,17 +1098,22 @@ def test_to_markdown() -> None:
 def test_types_to_feather() -> None:
     pytest.importorskip("pyarrow")
     df = pd.DataFrame(data={"col1": [1, 1, 2], "col2": [3, 4, 5]})
-    with ensure_clean() as path:
-        df.to_feather(path)
-        # kwargs for pyarrow.feather.write_feather added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
-        df.to_feather(path, compression="zstd", compression_level=3, chunksize=2)
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="As _is_sparse is now deprecated so to_feather now creates a warning",
+        lower="2.0.99",
+    ):
+        with ensure_clean() as path:
+            df.to_feather(path)
+            # kwargs for pyarrow.feather.write_feather added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
+            df.to_feather(path, compression="zstd", compression_level=3, chunksize=2)
 
-        # to_feather has been able to accept a buffer since pandas 1.0.0
-        # See https://pandas.pydata.org/docs/whatsnew/v1.0.0.html
-        # Docstring and type were updated in 1.2.0.
-        # https://github.com/pandas-dev/pandas/pull/35408
-        with open(path, mode="wb") as file:
-            df.to_feather(file)
+            # to_feather has been able to accept a buffer since pandas 1.0.0
+            # See https://pandas.pydata.org/docs/whatsnew/v1.0.0.html
+            # Docstring and type were updated in 1.2.0.
+            # https://github.com/pandas-dev/pandas/pull/35408
+            with open(path, mode="wb") as file:
+                df.to_feather(file)
 
 
 # compare() method added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
@@ -1339,9 +1344,14 @@ def test_types_to_parquet() -> None:
         allows_duplicate_labels=False
     )
     with ensure_clean() as path:
-        df.to_parquet(Path(path))
-    # to_parquet() returns bytes when no path given since 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html
-    b: bytes = df.to_parquet()
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            lower="2.0.99",
+        ):
+            df.to_parquet(Path(path))
+        # to_parquet() returns bytes when no path given since 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html
+        b: bytes = df.to_parquet()
 
 
 def test_types_to_latex() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1347,7 +1347,7 @@ def test_types_to_parquet() -> None:
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             df.to_parquet(Path(path))
         # to_parquet() returns bytes when no path given since 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1100,7 +1100,7 @@ def test_types_to_feather() -> None:
     df = pd.DataFrame(data={"col1": [1, 1, 2], "col2": [3, 4, 5]})
     with pytest_warns_bounded(
         FutureWarning,
-        match="As _is_sparse is now deprecated so to_feather now creates a warning",
+        match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
         lower="2.0.99",
     ):
         with ensure_clean() as path:
@@ -1346,7 +1346,7 @@ def test_types_to_parquet() -> None:
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             df.to_parquet(Path(path))

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1101,7 +1101,7 @@ def test_types_to_feather() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         match="is_sparse is deprecated and will be removed in a future version",
-        lower="2.0.00",
+        lower="2.0.99",
     ):
         with ensure_clean() as path:
             df.to_feather(path)
@@ -1347,7 +1347,7 @@ def test_types_to_parquet() -> None:
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             df.to_parquet(Path(path))
         # to_parquet() returns bytes when no path given since 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1101,7 +1101,7 @@ def test_types_to_feather() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-        lower="2.0.99",
+        lower="2.0.00",
     ):
         with ensure_clean() as path:
             df.to_feather(path)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -83,7 +83,7 @@ def test_orc():
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             check(assert_type(DF.to_orc(path), None), type(None))
@@ -96,7 +96,7 @@ def test_orc_path():
         pathlib_path = Path(path)
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             check(assert_type(DF.to_orc(pathlib_path), None), type(None))
@@ -109,7 +109,7 @@ def test_orc_buffer():
         file_w = open(path, "wb")
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             check(assert_type(DF.to_orc(file_w), None), type(None))
@@ -125,7 +125,7 @@ def test_orc_columns():
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             check(assert_type(DF.to_orc(path, index=False), None), type(None))
@@ -136,7 +136,7 @@ def test_orc_columns():
 def test_orc_bytes():
     with pytest_warns_bounded(
         FutureWarning,
-        match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+        match="is_sparse is deprecated and will be removed in a future version",
         lower="2.0.00",
     ):
         check(assert_type(DF.to_orc(index=False), bytes), bytes)
@@ -534,7 +534,7 @@ def test_parquet():
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             check(assert_type(DF.to_parquet(path), None), type(None))
@@ -546,7 +546,7 @@ def test_parquet_options():
     with ensure_clean(".parquet") as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             check(
@@ -560,7 +560,7 @@ def test_feather():
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             check(assert_type(DF.to_feather(path), None), type(None))
@@ -569,7 +569,7 @@ def test_feather():
     bio = io.BytesIO()
     with pytest_warns_bounded(
         FutureWarning,
-        match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+        match="is_sparse is deprecated and will be removed in a future version",
         lower="2.0.00",
     ):
         check(assert_type(DF.to_feather(bio), None), type(None))
@@ -1372,7 +1372,7 @@ def test_all_read_without_lxml_dtype_backend() -> None:
         if not WINDOWS:
             with pytest_warns_bounded(
                 FutureWarning,
-                match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+                match="is_sparse is deprecated and will be removed in a future version",
                 lower="2.0.00",
             ):
                 check(assert_type(DF.to_orc(path), None), type(None))
@@ -1382,7 +1382,7 @@ def test_all_read_without_lxml_dtype_backend() -> None:
             )
         with pytest_warns_bounded(
             FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
+            match="is_sparse is deprecated and will be removed in a future version",
             lower="2.0.00",
         ):
             check(assert_type(DF.to_feather(path), None), type(None))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -83,7 +83,7 @@ def test_orc():
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_orc now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             check(assert_type(DF.to_orc(path), None), type(None))
@@ -96,7 +96,7 @@ def test_orc_path():
         pathlib_path = Path(path)
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             check(assert_type(DF.to_orc(pathlib_path), None), type(None))
@@ -109,7 +109,7 @@ def test_orc_buffer():
         file_w = open(path, "wb")
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             check(assert_type(DF.to_orc(file_w), None), type(None))
@@ -125,7 +125,7 @@ def test_orc_columns():
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             check(assert_type(DF.to_orc(path, index=False), None), type(None))
@@ -136,7 +136,7 @@ def test_orc_columns():
 def test_orc_bytes():
     with pytest_warns_bounded(
         FutureWarning,
-        match="As _is_sparse is now deprecated so to_feather now creates a warning",
+        match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
         lower="2.0.99",
     ):
         check(assert_type(DF.to_orc(index=False), bytes), bytes)
@@ -534,7 +534,7 @@ def test_parquet():
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_parquet now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             check(assert_type(DF.to_parquet(path), None), type(None))
@@ -546,7 +546,7 @@ def test_parquet_options():
     with ensure_clean(".parquet") as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_parquet now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             check(
@@ -560,7 +560,7 @@ def test_feather():
     with ensure_clean() as path:
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             check(assert_type(DF.to_feather(path), None), type(None))
@@ -569,7 +569,7 @@ def test_feather():
     bio = io.BytesIO()
     with pytest_warns_bounded(
         FutureWarning,
-        match="As _is_sparse is now deprecated so to_feather now creates a warning",
+        match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
         lower="2.0.99",
     ):
         check(assert_type(DF.to_feather(bio), None), type(None))
@@ -1372,7 +1372,7 @@ def test_all_read_without_lxml_dtype_backend() -> None:
         if not WINDOWS:
             with pytest_warns_bounded(
                 FutureWarning,
-                match="As _is_sparse is now deprecated so to_feather now creates a warning",
+                match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
                 lower="2.0.99",
             ):
                 check(assert_type(DF.to_orc(path), None), type(None))
@@ -1382,7 +1382,7 @@ def test_all_read_without_lxml_dtype_backend() -> None:
             )
         with pytest_warns_bounded(
             FutureWarning,
-            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
             lower="2.0.99",
         ):
             check(assert_type(DF.to_feather(path), None), type(None))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -69,7 +69,10 @@ from pandas.io.sas.sas7bdat import SAS7BDATReader
 from pandas.io.sas.sas_xport import XportReader
 from pandas.io.stata import StataReader
 
-from . import lxml_skip
+from . import (
+    lxml_skip,
+    pytest_warns_bounded,
+)
 
 DF = DataFrame({"a": [1, 2, 3], "b": [0.0, 0.0, 0.0]})
 CWD = os.path.split(os.path.abspath(__file__))[0]
@@ -78,7 +81,12 @@ CWD = os.path.split(os.path.abspath(__file__))[0]
 @pytest.mark.skipif(WINDOWS, reason="ORC not available on windows")
 def test_orc():
     with ensure_clean() as path:
-        check(assert_type(DF.to_orc(path), None), type(None))
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_orc now creates a warning",
+            lower="2.0.99",
+        ):
+            check(assert_type(DF.to_orc(path), None), type(None))
         check(assert_type(read_orc(path), DataFrame), DataFrame)
 
 
@@ -86,7 +94,12 @@ def test_orc():
 def test_orc_path():
     with ensure_clean() as path:
         pathlib_path = Path(path)
-        check(assert_type(DF.to_orc(pathlib_path), None), type(None))
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            lower="2.0.99",
+        ):
+            check(assert_type(DF.to_orc(pathlib_path), None), type(None))
         check(assert_type(read_orc(pathlib_path), DataFrame), DataFrame)
 
 
@@ -94,7 +107,12 @@ def test_orc_path():
 def test_orc_buffer():
     with ensure_clean() as path:
         file_w = open(path, "wb")
-        check(assert_type(DF.to_orc(file_w), None), type(None))
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            lower="2.0.99",
+        ):
+            check(assert_type(DF.to_orc(file_w), None), type(None))
         file_w.close()
 
         file_r = open(path, "rb")
@@ -105,13 +123,23 @@ def test_orc_buffer():
 @pytest.mark.skipif(WINDOWS, reason="ORC not available on windows")
 def test_orc_columns():
     with ensure_clean() as path:
-        check(assert_type(DF.to_orc(path, index=False), None), type(None))
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            lower="2.0.99",
+        ):
+            check(assert_type(DF.to_orc(path, index=False), None), type(None))
         check(assert_type(read_orc(path, columns=["a"]), DataFrame), DataFrame)
 
 
 @pytest.mark.skipif(WINDOWS, reason="ORC not available on windows")
 def test_orc_bytes():
-    check(assert_type(DF.to_orc(index=False), bytes), bytes)
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="As _is_sparse is now deprecated so to_feather now creates a warning",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.to_orc(index=False), bytes), bytes)
 
 
 @lxml_skip
@@ -504,27 +532,47 @@ def test_json_chunk():
 
 def test_parquet():
     with ensure_clean() as path:
-        check(assert_type(DF.to_parquet(path), None), type(None))
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_parquet now creates a warning",
+            lower="2.0.99",
+        ):
+            check(assert_type(DF.to_parquet(path), None), type(None))
+            check(assert_type(DF.to_parquet(), bytes), bytes)
         check(assert_type(read_parquet(path), DataFrame), DataFrame)
-    check(assert_type(DF.to_parquet(), bytes), bytes)
 
 
 def test_parquet_options():
     with ensure_clean(".parquet") as path:
-        check(
-            assert_type(DF.to_parquet(path, compression=None, index=True), None),
-            type(None),
-        )
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_parquet now creates a warning",
+            lower="2.0.99",
+        ):
+            check(
+                assert_type(DF.to_parquet(path, compression=None, index=True), None),
+                type(None),
+            )
         check(assert_type(read_parquet(path), DataFrame), DataFrame)
 
 
 def test_feather():
     with ensure_clean() as path:
-        check(assert_type(DF.to_feather(path), None), type(None))
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            lower="2.0.99",
+        ):
+            check(assert_type(DF.to_feather(path), None), type(None))
         check(assert_type(read_feather(path), DataFrame), DataFrame)
         check(assert_type(read_feather(path, columns=["a"]), DataFrame), DataFrame)
     bio = io.BytesIO()
-    check(assert_type(DF.to_feather(bio), None), type(None))
+    with pytest_warns_bounded(
+        FutureWarning,
+        match="As _is_sparse is now deprecated so to_feather now creates a warning",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.to_feather(bio), None), type(None))
     bio.seek(0)
     check(assert_type(read_feather(bio), DataFrame), DataFrame)
 
@@ -1322,13 +1370,22 @@ def test_all_read_without_lxml_dtype_backend() -> None:
         con.close()
 
         if not WINDOWS:
-            check(assert_type(DF.to_orc(path), None), type(None))
+            with pytest_warns_bounded(
+                FutureWarning,
+                match="As _is_sparse is now deprecated so to_feather now creates a warning",
+                lower="2.0.99",
+            ):
+                check(assert_type(DF.to_orc(path), None), type(None))
             check(
                 assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame),
                 DataFrame,
             )
-
-        check(assert_type(DF.to_feather(path), None), type(None))
+        with pytest_warns_bounded(
+            FutureWarning,
+            match="As _is_sparse is now deprecated so to_feather now creates a warning",
+            lower="2.0.99",
+        ):
+            check(assert_type(DF.to_feather(path), None), type(None))
         check(
             assert_type(read_feather(path, dtype_backend="pyarrow"), DataFrame),
             DataFrame,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -84,7 +84,7 @@ def test_orc():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             check(assert_type(DF.to_orc(path), None), type(None))
         check(assert_type(read_orc(path), DataFrame), DataFrame)
@@ -97,7 +97,7 @@ def test_orc_path():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             check(assert_type(DF.to_orc(pathlib_path), None), type(None))
         check(assert_type(read_orc(pathlib_path), DataFrame), DataFrame)
@@ -110,7 +110,7 @@ def test_orc_buffer():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             check(assert_type(DF.to_orc(file_w), None), type(None))
         file_w.close()
@@ -126,7 +126,7 @@ def test_orc_columns():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             check(assert_type(DF.to_orc(path, index=False), None), type(None))
         check(assert_type(read_orc(path, columns=["a"]), DataFrame), DataFrame)
@@ -137,7 +137,7 @@ def test_orc_bytes():
     with pytest_warns_bounded(
         FutureWarning,
         match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-        lower="2.0.99",
+        lower="2.0.00",
     ):
         check(assert_type(DF.to_orc(index=False), bytes), bytes)
 
@@ -535,7 +535,7 @@ def test_parquet():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             check(assert_type(DF.to_parquet(path), None), type(None))
             check(assert_type(DF.to_parquet(), bytes), bytes)
@@ -547,7 +547,7 @@ def test_parquet_options():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             check(
                 assert_type(DF.to_parquet(path, compression=None, index=True), None),
@@ -561,7 +561,7 @@ def test_feather():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             check(assert_type(DF.to_feather(path), None), type(None))
         check(assert_type(read_feather(path), DataFrame), DataFrame)
@@ -570,7 +570,7 @@ def test_feather():
     with pytest_warns_bounded(
         FutureWarning,
         match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-        lower="2.0.99",
+        lower="2.0.00",
     ):
         check(assert_type(DF.to_feather(bio), None), type(None))
     bio.seek(0)
@@ -1373,7 +1373,7 @@ def test_all_read_without_lxml_dtype_backend() -> None:
             with pytest_warns_bounded(
                 FutureWarning,
                 match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-                lower="2.0.99",
+                lower="2.0.00",
             ):
                 check(assert_type(DF.to_orc(path), None), type(None))
             check(
@@ -1383,7 +1383,7 @@ def test_all_read_without_lxml_dtype_backend() -> None:
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version. Check `isinstance(dtype, pd.SparseDtype)` instead.",
-            lower="2.0.99",
+            lower="2.0.00",
         ):
             check(assert_type(DF.to_feather(path), None), type(None))
         check(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -84,7 +84,7 @@ def test_orc():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             check(assert_type(DF.to_orc(path), None), type(None))
         check(assert_type(read_orc(path), DataFrame), DataFrame)
@@ -97,7 +97,7 @@ def test_orc_path():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             check(assert_type(DF.to_orc(pathlib_path), None), type(None))
         check(assert_type(read_orc(pathlib_path), DataFrame), DataFrame)
@@ -110,7 +110,7 @@ def test_orc_buffer():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             check(assert_type(DF.to_orc(file_w), None), type(None))
         file_w.close()
@@ -126,7 +126,7 @@ def test_orc_columns():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             check(assert_type(DF.to_orc(path, index=False), None), type(None))
         check(assert_type(read_orc(path, columns=["a"]), DataFrame), DataFrame)
@@ -137,7 +137,7 @@ def test_orc_bytes():
     with pytest_warns_bounded(
         FutureWarning,
         match="is_sparse is deprecated and will be removed in a future version",
-        lower="2.0.00",
+        lower="2.0.99",
     ):
         check(assert_type(DF.to_orc(index=False), bytes), bytes)
 
@@ -535,7 +535,7 @@ def test_parquet():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             check(assert_type(DF.to_parquet(path), None), type(None))
             check(assert_type(DF.to_parquet(), bytes), bytes)
@@ -547,7 +547,7 @@ def test_parquet_options():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             check(
                 assert_type(DF.to_parquet(path, compression=None, index=True), None),
@@ -561,7 +561,7 @@ def test_feather():
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             check(assert_type(DF.to_feather(path), None), type(None))
         check(assert_type(read_feather(path), DataFrame), DataFrame)
@@ -1373,7 +1373,7 @@ def test_all_read_without_lxml_dtype_backend() -> None:
             with pytest_warns_bounded(
                 FutureWarning,
                 match="is_sparse is deprecated and will be removed in a future version",
-                lower="2.0.00",
+                lower="2.0.99",
             ):
                 check(assert_type(DF.to_orc(path), None), type(None))
             check(
@@ -1383,7 +1383,7 @@ def test_all_read_without_lxml_dtype_backend() -> None:
         with pytest_warns_bounded(
             FutureWarning,
             match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.00",
+            lower="2.0.99",
         ):
             check(assert_type(DF.to_feather(path), None), type(None))
         check(


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #657
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
