### PR TITLE
add support for `np.recarray` in `pd.factorize`

### DIFF
--- a/pandas-stubs/core/algorithms.pyi
+++ b/pandas-stubs/core/algorithms.pyi
@@ -42,7 +42,7 @@ def unique(values: np.ndarray | list) -> np.ndarray: ...
 def unique(values: ExtensionArray) -> ExtensionArray: ...
 @overload
 def factorize(
-    values: Sequence,
+    values: Sequence | np.recarray,
     sort: bool = ...,
     use_na_sentinel: bool = ...,
     size_hint: int | None = ...,

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -756,6 +756,10 @@ def test_factorize() -> None:
     check(assert_type(codes, np.ndarray), np.ndarray)
     check(assert_type(uniques, np.ndarray), np.ndarray)
 
+    codes, uniques = pd.factorize(np.recarray((1,), dtype=[("x", int)]))
+    check(assert_type(codes, np.ndarray), np.ndarray)
+    check(assert_type(uniques, np.ndarray), np.ndarray)
+
     codes, cat_uniques = pd.factorize(pd.Categorical(["b", "b", "a", "c", "b"]))
     check(assert_type(codes, np.ndarray), np.ndarray)
     check(assert_type(cat_uniques, pd.Categorical), pd.Categorical)


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

Needed to pass `df.to_records` which returns an `np.recarray` directly to `pd.factorize`

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
