### PR TITLE
CI: ignore warnings from pandas-nightly

### DIFF
--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -49,8 +49,14 @@ def stubtest(allowlist: str, check_missing: bool, nightly: bool) -> None:
 
 
 def pytest(nightly: bool) -> None:
-    steps = [_step.nightly] if nightly else []
-    run_job(steps + [_step.pytest])
+    setup_steps = []
+    pytest_step = _step.pytest
+    if nightly:
+        pytest_step = dataclasses.replace(
+            _step.pytest, run=partial(_step.pytest.run, flags=())
+        )
+        setup_steps = [_step.nightly]
+    run_job(setup_steps + [pytest_step])
 
 
 def mypy_src(mypy_nightly: bool) -> None:

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 import subprocess
 import sys

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -13,8 +13,8 @@ def pyright_src():
     subprocess.run(cmd, check=True)
 
 
-def pytest():
-    cmd = ["pytest", "--cache-clear", "-Werror"]
+def pytest(flags: tuple[str, ...] = ("-Werror",)):
+    cmd = ["pytest", "--cache-clear", *flags]
     subprocess.run(cmd, check=True)
 
 

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -8,10 +8,7 @@ from typing_extensions import assert_type
 
 from pandas._typing import DtypeObj
 
-from tests import (
-    check,
-    pytest_warns_bounded,
-)
+from tests import check
 
 nparr = np.array([1, 2, 3])
 arr = pd.Series([1, 2, 3])
@@ -55,20 +52,12 @@ def test_is_bool_dtype() -> None:
 
 
 def test_is_categorical_dtype() -> None:
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_categorical_dtype is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
-        check(assert_type(api.is_categorical_dtype(arr), bool), bool)
-        check(assert_type(api.is_categorical_dtype(nparr), bool), bool)
-        check(assert_type(api.is_categorical_dtype(dtylike), bool), bool)
-        check(
-            assert_type(api.is_categorical_dtype(dframe), bool),
-            bool,
-        )
-        check(assert_type(api.is_categorical_dtype(ind), bool), bool)
-        check(assert_type(api.is_categorical_dtype(ExtensionDtype), bool), bool)
+    check(assert_type(api.is_categorical_dtype(arr), bool), bool)
+    check(assert_type(api.is_categorical_dtype(nparr), bool), bool)
+    check(assert_type(api.is_categorical_dtype(dtylike), bool), bool)
+    check(assert_type(api.is_categorical_dtype(dframe), bool), bool)
+    check(assert_type(api.is_categorical_dtype(ind), bool), bool)
+    check(assert_type(api.is_categorical_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_complex() -> None:
@@ -132,20 +121,12 @@ def test_is_datetime64_ns_dtype() -> None:
 
 
 def test_is_datetime64tz_dtype() -> None:
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_datetime64tz_dtype is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
-        check(assert_type(api.is_datetime64tz_dtype(arr), bool), bool)
-        check(assert_type(api.is_datetime64tz_dtype(nparr), bool), bool)
-        check(assert_type(api.is_datetime64tz_dtype(dtylike), bool), bool)
-        check(
-            assert_type(api.is_datetime64tz_dtype(dframe), bool),
-            bool,
-        )
-        check(assert_type(api.is_datetime64tz_dtype(ind), bool), bool)
-        check(assert_type(api.is_datetime64tz_dtype(ExtensionDtype), bool), bool)
+    check(assert_type(api.is_datetime64tz_dtype(arr), bool), bool)
+    check(assert_type(api.is_datetime64tz_dtype(nparr), bool), bool)
+    check(assert_type(api.is_datetime64tz_dtype(dtylike), bool), bool)
+    check(assert_type(api.is_datetime64tz_dtype(dframe), bool), bool)
+    check(assert_type(api.is_datetime64tz_dtype(ind), bool), bool)
+    check(assert_type(api.is_datetime64tz_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_dict_like() -> None:
@@ -222,20 +203,12 @@ def test_is_hashable() -> None:
 
 
 def test_is_int64_dtype() -> None:
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_int64_dtype is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
-        check(assert_type(api.is_int64_dtype(arr), bool), bool)
-        check(assert_type(api.is_int64_dtype(nparr), bool), bool)
-        check(assert_type(api.is_int64_dtype(dtylike), bool), bool)
-        check(
-            assert_type(api.is_int64_dtype(dframe), bool),
-            bool,
-        )
-        check(assert_type(api.is_int64_dtype(ind), bool), bool)
-        # check(assert_type(api.is_int64_dtype(ExtensionDtype), bool), bool) pandas GH 50923
+    check(assert_type(api.is_int64_dtype(arr), bool), bool)
+    check(assert_type(api.is_int64_dtype(nparr), bool), bool)
+    check(assert_type(api.is_int64_dtype(dtylike), bool), bool)
+    check(assert_type(api.is_int64_dtype(dframe), bool), bool)
+    check(assert_type(api.is_int64_dtype(ind), bool), bool)
+    # check(assert_type(api.is_int64_dtype(ExtensionDtype), bool), bool) pandas GH 50923
 
 
 def test_is_integer() -> None:
@@ -275,21 +248,13 @@ def test_is_interval() -> None:
 
 
 def test_is_interval_dtype() -> None:
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_interval_dtype is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
-        check(assert_type(api.is_interval_dtype(obj), bool), bool)
-        check(assert_type(api.is_interval_dtype(nparr), bool), bool)
-        check(assert_type(api.is_interval_dtype(dtylike), bool), bool)
-        check(assert_type(api.is_interval_dtype(arr), bool), bool)
-        check(
-            assert_type(api.is_interval_dtype(dframe), bool),
-            bool,
-        )
-        check(assert_type(api.is_interval_dtype(ind), bool), bool)
-        check(assert_type(api.is_interval_dtype(ExtensionDtype), bool), bool)
+    check(assert_type(api.is_interval_dtype(obj), bool), bool)
+    check(assert_type(api.is_interval_dtype(nparr), bool), bool)
+    check(assert_type(api.is_interval_dtype(dtylike), bool), bool)
+    check(assert_type(api.is_interval_dtype(arr), bool), bool)
+    check(assert_type(api.is_interval_dtype(dframe), bool), bool)
+    check(assert_type(api.is_interval_dtype(ind), bool), bool)
+    check(assert_type(api.is_interval_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_iterator() -> None:
@@ -362,20 +327,12 @@ def test_is_object_dtype() -> None:
 
 
 def test_is_period_dtype() -> None:
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_period_dtype is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
-        check(assert_type(api.is_period_dtype(arr), bool), bool)
-        check(assert_type(api.is_period_dtype(nparr), bool), bool)
-        check(assert_type(api.is_period_dtype(dtylike), bool), bool)
-        check(
-            assert_type(api.is_period_dtype(dframe), bool),
-            bool,
-        )
-        check(assert_type(api.is_period_dtype(ind), bool), bool)
-        check(assert_type(api.is_period_dtype(ExtensionDtype), bool), bool)
+    check(assert_type(api.is_period_dtype(arr), bool), bool)
+    check(assert_type(api.is_period_dtype(nparr), bool), bool)
+    check(assert_type(api.is_period_dtype(dtylike), bool), bool)
+    check(assert_type(api.is_period_dtype(dframe), bool), bool)
+    check(assert_type(api.is_period_dtype(ind), bool), bool)
+    check(assert_type(api.is_period_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_re() -> None:
@@ -421,14 +378,9 @@ def test_is_signed_integer_dtype() -> None:
 
 
 def test_is_sparse() -> None:
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_sparse is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
-        check(assert_type(api.is_sparse(arr), bool), bool)
-        check(assert_type(api.is_sparse(nparr), bool), bool)
-        check(assert_type(api.is_sparse(dframe), bool), bool)
+    check(assert_type(api.is_sparse(arr), bool), bool)
+    check(assert_type(api.is_sparse(nparr), bool), bool)
+    check(assert_type(api.is_sparse(dframe), bool), bool)
 
 
 def test_is_string_dtype() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -43,7 +43,6 @@ from tests import (
     PD_LTE_20,
     TYPE_CHECKING_INVALID_USAGE,
     check,
-    pytest_warns_bounded,
 )
 
 from pandas.io.formats.style import Styler
@@ -727,17 +726,12 @@ def test_types_apply() -> None:
 
 def test_types_applymap() -> None:
     df = pd.DataFrame(data={"col1": [2, 1], "col2": [3, 4]})
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="DataFrame.applymap has been deprecated. Use DataFrame.map instead.",
-        lower="2.0.99",
-    ):
-        df.applymap(lambda x: x**2)
-        df.applymap(np.exp)
-        df.applymap(str)
-        # na_action parameter was added in 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html
-        df.applymap(np.exp, na_action="ignore")
-        df.applymap(str, na_action=None)
+    df.applymap(lambda x: x**2)
+    df.applymap(np.exp)
+    df.applymap(str)
+    # na_action parameter was added in 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html
+    df.applymap(np.exp, na_action="ignore")
+    df.applymap(str, na_action=None)
 
 
 def test_types_element_wise_arithmetic() -> None:
@@ -881,12 +875,7 @@ def test_types_groupby() -> None:
     df4: pd.DataFrame = df.groupby(by=["col1", "col2"]).count()
     df5: pd.DataFrame = df.groupby(by=["col1", "col2"]).filter(lambda x: x["col1"] > 0)
     df6: pd.DataFrame = df.groupby(by=["col1", "col2"]).nunique()
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated",
-        lower="2.0.99",
-    ):
-        df7: pd.DataFrame = df.groupby(by="col1").apply(sum)
+    df7: pd.DataFrame = df.groupby(by="col1").apply(sum)
     df8: pd.DataFrame = df.groupby("col1").transform("sum")
     s1: pd.Series = df.set_index("col1")["col2"]
     s2: pd.Series = s1.groupby("col1").transform("sum")
@@ -1098,22 +1087,17 @@ def test_to_markdown() -> None:
 def test_types_to_feather() -> None:
     pytest.importorskip("pyarrow")
     df = pd.DataFrame(data={"col1": [1, 1, 2], "col2": [3, 4, 5]})
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_sparse is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
-        with ensure_clean() as path:
-            df.to_feather(path)
-            # kwargs for pyarrow.feather.write_feather added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
-            df.to_feather(path, compression="zstd", compression_level=3, chunksize=2)
+    with ensure_clean() as path:
+        df.to_feather(path)
+        # kwargs for pyarrow.feather.write_feather added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
+        df.to_feather(path, compression="zstd", compression_level=3, chunksize=2)
 
-            # to_feather has been able to accept a buffer since pandas 1.0.0
-            # See https://pandas.pydata.org/docs/whatsnew/v1.0.0.html
-            # Docstring and type were updated in 1.2.0.
-            # https://github.com/pandas-dev/pandas/pull/35408
-            with open(path, mode="wb") as file:
-                df.to_feather(file)
+        # to_feather has been able to accept a buffer since pandas 1.0.0
+        # See https://pandas.pydata.org/docs/whatsnew/v1.0.0.html
+        # Docstring and type were updated in 1.2.0.
+        # https://github.com/pandas-dev/pandas/pull/35408
+        with open(path, mode="wb") as file:
+            df.to_feather(file)
 
 
 # compare() method added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
@@ -1344,12 +1328,7 @@ def test_types_to_parquet() -> None:
         allows_duplicate_labels=False
     )
     with ensure_clean() as path:
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
-            df.to_parquet(Path(path))
+        df.to_parquet(Path(path))
         # to_parquet() returns bytes when no path given since 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html
         b: bytes = df.to_parquet()
 
@@ -1475,19 +1454,14 @@ def test_types_regressions() -> None:
 
     # https://github.com/microsoft/python-type-stubs/issues/115
     df = pd.DataFrame({"A": [1, 2, 3], "B": [5, 6, 7]})
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="The 'closed' keyword in DatetimeIndex construction is deprecated",
-        lower="2.0.99",
-    ):
-        pd.DatetimeIndex(
-            data=df["A"],
-            tz=None,
-            normalize=False,
-            closed=None,
-            ambiguous="NaT",
-            copy=True,
-        )
+    pd.DatetimeIndex(
+        data=df["A"],
+        tz=None,
+        normalize=False,
+        closed=None,
+        ambiguous="NaT",
+        copy=True,
+    )
 
 
 def test_read_csv() -> None:
@@ -2053,41 +2027,32 @@ def test_groupby_apply() -> None:
     def sum_mean(x: pd.DataFrame) -> float:
         return x.sum().mean()
 
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated",
-        lower="2.0.99",
-    ):
-        check(assert_type(df.groupby("col1").apply(sum_mean), pd.Series), pd.Series)
+    check(assert_type(df.groupby("col1").apply(sum_mean), pd.Series), pd.Series)
 
-        lfunc: Callable[[pd.DataFrame], float] = lambda x: x.sum().mean()
-        check(
-            assert_type(df.groupby("col1").apply(lfunc), pd.Series),
-            pd.Series,
-        )
+    lfunc: Callable[[pd.DataFrame], float] = lambda x: x.sum().mean()
+    check(assert_type(df.groupby("col1").apply(lfunc), pd.Series), pd.Series)
 
-        def sum_to_list(x: pd.DataFrame) -> list:
-            return x.sum().tolist()
+    def sum_to_list(x: pd.DataFrame) -> list:
+        return x.sum().tolist()
 
-        check(assert_type(df.groupby("col1").apply(sum_to_list), pd.Series), pd.Series)
+    check(assert_type(df.groupby("col1").apply(sum_to_list), pd.Series), pd.Series)
 
-        def sum_to_series(x: pd.DataFrame) -> pd.Series:
-            return x.sum()
+    def sum_to_series(x: pd.DataFrame) -> pd.Series:
+        return x.sum()
 
-        check(
-            assert_type(df.groupby("col1").apply(sum_to_series), pd.DataFrame),
-            pd.DataFrame,
-        )
+    check(
+        assert_type(df.groupby("col1").apply(sum_to_series), pd.DataFrame), pd.DataFrame
+    )
 
-        def sample_to_df(x: pd.DataFrame) -> pd.DataFrame:
-            return x.sample()
+    def sample_to_df(x: pd.DataFrame) -> pd.DataFrame:
+        return x.sample()
 
-        check(
-            assert_type(
-                df.groupby("col1", group_keys=False).apply(sample_to_df), pd.DataFrame
-            ),
-            pd.DataFrame,
-        )
+    check(
+        assert_type(
+            df.groupby("col1", group_keys=False).apply(sample_to_df), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
 
 
 def test_resample() -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -69,10 +69,7 @@ from pandas.io.sas.sas7bdat import SAS7BDATReader
 from pandas.io.sas.sas_xport import XportReader
 from pandas.io.stata import StataReader
 
-from . import (
-    lxml_skip,
-    pytest_warns_bounded,
-)
+from . import lxml_skip
 
 DF = DataFrame({"a": [1, 2, 3], "b": [0.0, 0.0, 0.0]})
 CWD = os.path.split(os.path.abspath(__file__))[0]
@@ -81,12 +78,7 @@ CWD = os.path.split(os.path.abspath(__file__))[0]
 @pytest.mark.skipif(WINDOWS, reason="ORC not available on windows")
 def test_orc():
     with ensure_clean() as path:
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
-            check(assert_type(DF.to_orc(path), None), type(None))
+        check(assert_type(DF.to_orc(path), None), type(None))
         check(assert_type(read_orc(path), DataFrame), DataFrame)
 
 
@@ -94,52 +86,30 @@ def test_orc():
 def test_orc_path():
     with ensure_clean() as path:
         pathlib_path = Path(path)
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
-            check(assert_type(DF.to_orc(pathlib_path), None), type(None))
+        check(assert_type(DF.to_orc(pathlib_path), None), type(None))
         check(assert_type(read_orc(pathlib_path), DataFrame), DataFrame)
 
 
 @pytest.mark.skipif(WINDOWS, reason="ORC not available on windows")
 def test_orc_buffer():
     with ensure_clean() as path:
-        file_w = open(path, "wb")
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
+        with open(path, "wb") as file_w:
             check(assert_type(DF.to_orc(file_w), None), type(None))
-        file_w.close()
 
-        file_r = open(path, "rb")
-        check(assert_type(read_orc(file_r), DataFrame), DataFrame)
-        file_r.close()
+        with open(path, "rb") as file_r:
+            check(assert_type(read_orc(file_r), DataFrame), DataFrame)
 
 
 @pytest.mark.skipif(WINDOWS, reason="ORC not available on windows")
 def test_orc_columns():
     with ensure_clean() as path:
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
-            check(assert_type(DF.to_orc(path, index=False), None), type(None))
+        check(assert_type(DF.to_orc(path, index=False), None), type(None))
         check(assert_type(read_orc(path, columns=["a"]), DataFrame), DataFrame)
 
 
 @pytest.mark.skipif(WINDOWS, reason="ORC not available on windows")
 def test_orc_bytes():
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_sparse is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
-        check(assert_type(DF.to_orc(index=False), bytes), bytes)
+    check(assert_type(DF.to_orc(index=False), bytes), bytes)
 
 
 @lxml_skip
@@ -532,49 +502,29 @@ def test_json_chunk():
 
 def test_parquet():
     with ensure_clean() as path:
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
-            check(assert_type(DF.to_parquet(path), None), type(None))
-            check(assert_type(DF.to_parquet(), bytes), bytes)
+        check(assert_type(DF.to_parquet(path), None), type(None))
+        check(assert_type(DF.to_parquet(), bytes), bytes)
         check(assert_type(read_parquet(path), DataFrame), DataFrame)
 
 
 def test_parquet_options():
     with ensure_clean(".parquet") as path:
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
-            check(
-                assert_type(DF.to_parquet(path, compression=None, index=True), None),
-                type(None),
-            )
+        check(
+            assert_type(DF.to_parquet(path, compression=None, index=True), None),
+            type(None),
+        )
         check(assert_type(read_parquet(path), DataFrame), DataFrame)
 
 
 def test_feather():
     with ensure_clean() as path:
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
-            check(assert_type(DF.to_feather(path), None), type(None))
+        check(assert_type(DF.to_feather(path), None), type(None))
         check(assert_type(read_feather(path), DataFrame), DataFrame)
         check(assert_type(read_feather(path, columns=["a"]), DataFrame), DataFrame)
-    bio = io.BytesIO()
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="is_sparse is deprecated and will be removed in a future version",
-        lower="2.0.99",
-    ):
+    with io.BytesIO() as bio:
         check(assert_type(DF.to_feather(bio), None), type(None))
-    bio.seek(0)
-    check(assert_type(read_feather(bio), DataFrame), DataFrame)
+        bio.seek(0)
+        check(assert_type(read_feather(bio), DataFrame), DataFrame)
 
 
 def test_read_csv():
@@ -1370,22 +1320,12 @@ def test_all_read_without_lxml_dtype_backend() -> None:
         con.close()
 
         if not WINDOWS:
-            with pytest_warns_bounded(
-                FutureWarning,
-                match="is_sparse is deprecated and will be removed in a future version",
-                lower="2.0.99",
-            ):
-                check(assert_type(DF.to_orc(path), None), type(None))
+            check(assert_type(DF.to_orc(path), None), type(None))
             check(
                 assert_type(read_orc(path, dtype_backend="numpy_nullable"), DataFrame),
                 DataFrame,
             )
-        with pytest_warns_bounded(
-            FutureWarning,
-            match="is_sparse is deprecated and will be removed in a future version",
-            lower="2.0.99",
-        ):
-            check(assert_type(DF.to_feather(path), None), type(None))
+        check(assert_type(DF.to_feather(path), None), type(None))
         check(
             assert_type(read_feather(path, dtype_backend="pyarrow"), DataFrame),
             DataFrame,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -45,7 +45,6 @@ from tests import (
     PD_LTE_20,
     TYPE_CHECKING_INVALID_USAGE,
     check,
-    pytest_warns_bounded,
 )
 from tests.extension.decimal.array import DecimalDtype
 
@@ -450,12 +449,7 @@ def test_types_apply() -> None:
     def makeseries(x: float) -> pd.Series:
         return pd.Series([x, 2 * x])
 
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="Returning a DataFrame from Series.apply when the supplied functionreturns a Series is deprecated",
-        lower="2.0.99",
-    ):
-        check(assert_type(s.apply(makeseries), pd.DataFrame), pd.DataFrame)
+    check(assert_type(s.apply(makeseries), pd.DataFrame), pd.DataFrame)
 
     # GH 293
 
@@ -1390,19 +1384,14 @@ def test_bitwise_operators() -> None:
     check(assert_type(s ^ s2, "pd.Series[int]"), pd.Series, np.integer)
     check(assert_type(s2 ^ s, "pd.Series[int]"), pd.Series, np.integer)
 
-    with pytest_warns_bounded(
-        FutureWarning,
-        match=r"Logical ops \(and, or, xor\) between Pandas objects and",
-        lower="2.0.99",
-    ):
-        check(assert_type(s & [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
-        check(assert_type([1, 2, 3, 4] & s, "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type(s & [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type([1, 2, 3, 4] & s, "pd.Series[bool]"), pd.Series, np.bool_)
 
-        check(assert_type(s | [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
-        check(assert_type([1, 2, 3, 4] | s, "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type(s | [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type([1, 2, 3, 4] | s, "pd.Series[bool]"), pd.Series, np.bool_)
 
-        check(assert_type(s ^ [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
-        check(assert_type([1, 2, 3, 4] ^ s, "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type(s ^ [1, 2, 3, 4], "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type([1, 2, 3, 4] ^ s, "pd.Series[bool]"), pd.Series, np.bool_)
 
 
 def test_logical_operators() -> None:
@@ -1436,41 +1425,36 @@ def test_logical_operators() -> None:
 
     check(assert_type(True ^ (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
 
-    with pytest_warns_bounded(
-        FutureWarning,
-        match=r"Logical ops \(and, or, xor\) between Pandas objects and",
-        lower="2.0.99",
-    ):
-        check(
-            assert_type((df["a"] >= 2) ^ [True, False, True], "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
-        check(
-            assert_type((df["a"] >= 2) & [True, False, True], "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
-        check(
-            assert_type((df["a"] >= 2) | [True, False, True], "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
-        check(
-            assert_type([True, False, True] & (df["a"] >= 2), "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
-        check(
-            assert_type([True, False, True] | (df["a"] >= 2), "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
-        check(
-            assert_type([True, False, True] ^ (df["a"] >= 2), "pd.Series[bool]"),
-            pd.Series,
-            np.bool_,
-        )
+    check(
+        assert_type((df["a"] >= 2) ^ [True, False, True], "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
+    check(
+        assert_type((df["a"] >= 2) & [True, False, True], "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
+    check(
+        assert_type((df["a"] >= 2) | [True, False, True], "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
+    check(
+        assert_type([True, False, True] & (df["a"] >= 2), "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
+    check(
+        assert_type([True, False, True] | (df["a"] >= 2), "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
+    check(
+        assert_type([True, False, True] ^ (df["a"] >= 2), "pd.Series[bool]"),
+        pd.Series,
+        np.bool_,
+    )
 
 
 def test_AnyArrayLike_and_clip() -> None:

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -22,8 +22,6 @@ from pandas._libs import NaTType
 from pandas._libs.tslibs import BaseOffset
 from pandas._libs.tslibs.offsets import DateOffset
 
-from tests import pytest_warns_bounded
-
 if TYPE_CHECKING:
     from pandas._typing import FulldatetimeDict
 else:
@@ -364,12 +362,7 @@ def test_series_dt_accessors() -> None:
     check(assert_type(s0.dt.isocalendar(), pd.DataFrame), pd.DataFrame)
     check(assert_type(s0.dt.to_period("D"), "PeriodSeries"), pd.Series, pd.Period)
 
-    with pytest_warns_bounded(
-        FutureWarning,
-        match="The behavior of DatetimeProperties.to_pydatetime is deprecated",
-        lower="2.0.99",
-    ):
-        check(assert_type(s0.dt.to_pydatetime(), np.ndarray), np.ndarray, dt.datetime)
+    check(assert_type(s0.dt.to_pydatetime(), np.ndarray), np.ndarray, dt.datetime)
     s0_local = s0.dt.tz_localize("UTC")
     check(
         assert_type(s0_local, "TimestampSeries"),


### PR DESCRIPTION
closes #666

`pytest_warns_bounded` becomes unused with this PR