### PR TITLE
GH-676 : Corrected `DtypeArg` for accepting strings

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -76,7 +76,7 @@ class FulldatetimeDict(YearMonthDayDict, total=False):
 # dtypes
 NpDtype: TypeAlias = str | np.dtype[np.generic] | type[str | complex | bool | object]
 Dtype: TypeAlias = ExtensionDtype | NpDtype
-DtypeArg: TypeAlias = Dtype | dict[Any, Dtype]
+DtypeArg: TypeAlias = Dtype | Mapping[Any, Dtype]
 DtypeBackend: TypeAlias = Literal["pyarrow", "numpy_nullable"]
 BooleanDtypeArg: TypeAlias = (
     # Builtin bool type and its string alias

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1390,7 +1390,7 @@ def test_read_with_lxml_dtype_backend() -> None:
         )
 
 
-def test_read_sql_str_dtype() -> None:
+def test_read_sql_dict_str_value_dtype() -> None:
     with ensure_clean() as path:
         con = sqlite3.connect(path)
         check(assert_type(DF.to_sql("test", con), Union[int, None]), int)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1388,3 +1388,31 @@ def test_read_with_lxml_dtype_backend() -> None:
         check(
             assert_type(read_xml(path, dtype_backend="pyarrow"), DataFrame), DataFrame
         )
+
+
+def test_read_sql_str_dtype() -> None:
+    with ensure_clean() as path:
+        con = sqlite3.connect(path)
+        check(assert_type(DF.to_sql("test", con), Union[int, None]), int)
+        check(
+            assert_type(
+                read_sql_query(
+                    "select * from test",
+                    con=con,
+                    index_col="index",
+                    dtype="int",
+                ),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+        con.close()
+
+        if TYPE_CHECKING:
+            # sqlite3 doesn't support read_table, which is required for this function
+            # Could only run in pytest if SQLAlchemy was installed
+            with ensure_clean() as path:
+                co1 = sqlite3.connect(path)
+                assert_type(DF.to_sql("test", con=co1), Union[int, None])
+                assert_type(read_sql_table("test", con=co1, dtype="int"), DataFrame)
+                co1.close()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1407,12 +1407,3 @@ def test_read_sql_str_dtype() -> None:
             DataFrame,
         )
         con.close()
-
-        if TYPE_CHECKING:
-            # sqlite3 doesn't support read_table, which is required for this function
-            # Could only run in pytest if SQLAlchemy was installed
-            with ensure_clean() as path:
-                co1 = sqlite3.connect(path)
-                assert_type(DF.to_sql("test", con=co1), Union[int, None])
-                assert_type(read_sql_table("test", con=co1, dtype="int"), DataFrame)
-                co1.close()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1391,6 +1391,7 @@ def test_read_with_lxml_dtype_backend() -> None:
 
 
 def test_read_sql_dict_str_value_dtype() -> None:
+    # GH 676
     with ensure_clean() as path:
         con = sqlite3.connect(path)
         check(assert_type(DF.to_sql("test", con), Union[int, None]), int)
@@ -1400,7 +1401,7 @@ def test_read_sql_dict_str_value_dtype() -> None:
                     "select * from test",
                     con=con,
                     index_col="index",
-                    dtype="int",
+                    dtype={"a": "int"},
                 ),
                 DataFrame,
             ),


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #676 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
