### PR TITLE
upgrade SQLAlchemy and pyright

### DIFF
--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -13,6 +13,7 @@ from typing import (
 from pandas.core.base import PandasObject
 from pandas.core.frame import DataFrame
 import sqlalchemy.engine
+from sqlalchemy.orm import FromStatement
 import sqlalchemy.sql.expression
 from typing_extensions import TypeAlias
 
@@ -26,7 +27,11 @@ from pandas._typing import (
 _SQLConnection: TypeAlias = str | sqlalchemy.engine.Connectable | sqlite3.Connection
 
 _SQLStatement: TypeAlias = (
-    str | sqlalchemy.sql.expression.Selectable | sqlalchemy.sql.expression.TextClause
+    str
+    | sqlalchemy.sql.expression.Selectable
+    | sqlalchemy.sql.expression.TextClause
+    | sqlalchemy.sql.Select
+    | FromStatement
 )
 
 @overload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ types-pytz = ">= 2022.1.1"
 mypy = "1.2.0"
 pyarrow = ">=10.0.1"
 pytest = ">=7.1.2"
-pyright = ">= 1.1.305"
+pyright = ">= 1.1.306"
 poethepoet = ">=0.16.5"
 loguru = ">=0.6.0"
 pandas = "2.0.1"
@@ -60,7 +60,7 @@ xarray = ">=22.6.0"
 tabulate = ">=0.8.10"
 jinja2 = "^3.1"
 scipy = ">=1.9.1"
-SQLAlchemy = "<=1.4.45"
+SQLAlchemy = ">=2.0.12"
 types-python-dateutil = ">=2.8.19"
 
 [build-system]
@@ -195,6 +195,7 @@ reportUnusedVariable = false
 reportPrivateUsage = false
 # enable optional checks
 reportMissingModuleSource = true
+useLibraryCodeForTypes = false
 
 [tool.codespell]
 ignore-words-list = "indext, mose, sav, ser"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1095,6 +1095,7 @@ def test_read_sql_via_sqlalchemy_connection():
                 assert_type(read_sql("select * from test", con=conn), DataFrame),
                 DataFrame,
             )
+        engine.dispose()
 
 
 def test_read_sql_via_sqlalchemy_engine():
@@ -1107,6 +1108,7 @@ def test_read_sql_via_sqlalchemy_engine():
             assert_type(read_sql("select * from test", con=engine), DataFrame),
             DataFrame,
         )
+        engine.dispose()
 
 
 def test_read_sql_generator():
@@ -1218,6 +1220,7 @@ def test_sqlalchemy_text() -> None:
                 assert_type(read_sql(sql_select, con=conn), DataFrame),
                 DataFrame,
             )
+        engine.dispose()
 
 
 def test_read_sql_dtype() -> None:


### PR DESCRIPTION
Based on https://github.com/pandas-dev/pandas/issues/50558#issuecomment-1537477148, we could upgrade SqlAlchemy to 2.0.  Doing that revealed an issue in those tests and some of the typing.

Also bumped pyright to 1.1.306, but the default value for `useLibraryCodeForTypes` changed in that version, so added that in `pyproject.toml`.  Without that, some of the plotting tests fail because `matplotlib` doesn't have typing yet.
