### PR TITLE
Fix inplace overload for DataFrame.interpolate

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1708,7 +1708,7 @@ class DataFrame(NDFrame, OpsMixin):
         limit_direction: Literal["forward", "backward", "both"] = ...,
         limit_area: Literal["inside", "outside"] | None = ...,
         downcast: Literal["infer"] | None = ...,
-        inplace: Literal[False],
+        inplace: Literal[False] = ...,
         **kwargs,
     ) -> DataFrame: ...
     @overload

--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -210,7 +210,6 @@ class DataFrameGroupBy(GroupBy, Generic[ByT]):
     def cumsum(self, axis: Axis = ..., **kwargs) -> DataFrame: ...
     def describe(self, **kwargs) -> DataFrame: ...
     def ffill(self, limit: int | None = ...) -> DataFrame: ...
-    @overload
     def fillna(
         self,
         value,
@@ -218,30 +217,8 @@ class DataFrameGroupBy(GroupBy, Generic[ByT]):
         axis: Axis = ...,
         limit: int | None = ...,
         downcast: dict | None = ...,
-        *,
-        inplace: Literal[True],
-    ) -> None: ...
-    @overload
-    def fillna(
-        self,
-        value,
-        method: str | None = ...,
-        axis: Axis = ...,
-        limit: int | None = ...,
-        downcast: dict | None = ...,
-        *,
-        inplace: Literal[False],
+        inplace: Literal[False] = ...,
     ) -> DataFrame: ...
-    @overload
-    def fillna(
-        self,
-        value,
-        method: str | None = ...,
-        axis: Axis = ...,
-        inplace: bool = ...,
-        limit: int | None = ...,
-        downcast: dict | None = ...,
-    ) -> DataFrame | None: ...
     def first(self, **kwargs) -> DataFrame: ...
     def head(self, n: int = ...) -> DataFrame: ...
     def hist(

--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -215,9 +215,9 @@ class DataFrameGroupBy(GroupBy, Generic[ByT]):
         value,
         method: str | None = ...,
         axis: Axis = ...,
+        inplace: Literal[False] = ...,
         limit: int | None = ...,
         downcast: dict | None = ...,
-        inplace: Literal[False] = ...,
     ) -> DataFrame: ...
     def first(self, **kwargs) -> DataFrame: ...
     def head(self, n: int = ...) -> DataFrame: ...

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2695,3 +2695,23 @@ def test_to_json_mode() -> None:
     check(assert_type(result4, str), str)
     if TYPE_CHECKING_INVALID_USAGE:
         result3 = df.to_json(orient="records", lines=False, mode="a")  # type: ignore[call-overload] # pyright: ignore[reportGeneralTypeIssues]
+
+
+def test_interpolate_inplace() -> None:
+    # GH 691
+    df = pd.DataFrame({"a": range(3)})
+    check(assert_type(df.interpolate(method="linear"), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.interpolate(method="linear", inplace=False), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(assert_type(df.interpolate(method="linear", inplace=True), None), type(None))
+
+
+def test_groupby_fillna_inplace() -> None:
+    # GH 691
+    groupby = pd.DataFrame({"a": range(3), "b": range(3)}).groupby("a")
+    check(assert_type(groupby.fillna(0), pd.DataFrame), pd.DataFrame)
+    check(assert_type(groupby.fillna(0, inplace=False), pd.DataFrame), pd.DataFrame)
+    if TYPE_CHECKING_INVALID_USAGE:
+        groupby.fillna(0, inplace=True)  # type: ignore[arg-type] # pyright: ignore[reportGeneralTypeIssues]


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #691 (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
