### PR TITLE
Allow Timedelta for `Series.rolling` and `DataFrame.rolling`

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1955,7 +1955,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def rolling(
         self,
-        window: int | str | Timedelta | BaseOffset | BaseIndexer,
+        window: int | str | _dt.timedelta | BaseOffset | BaseIndexer,
         min_periods: int | None = ...,
         center: _bool = ...,
         on: Hashable | None = ...,
@@ -1969,7 +1969,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def rolling(
         self,
-        window: int | str | Timedelta | BaseOffset | BaseIndexer,
+        window: int | str | _dt.timedelta | BaseOffset | BaseIndexer,
         min_periods: int | None = ...,
         center: _bool = ...,
         on: Hashable | None = ...,

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1955,7 +1955,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def rolling(
         self,
-        window: int | str | BaseOffset | BaseIndexer,
+        window: int | str | Timedelta | BaseOffset | BaseIndexer,
         min_periods: int | None = ...,
         center: _bool = ...,
         on: Hashable | None = ...,
@@ -1969,7 +1969,7 @@ class DataFrame(NDFrame, OpsMixin):
     @overload
     def rolling(
         self,
-        window: int | str | BaseOffset | BaseIndexer,
+        window: int | str | Timedelta | BaseOffset | BaseIndexer,
         min_periods: int | None = ...,
         center: _bool = ...,
         on: Hashable | None = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1834,7 +1834,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def rolling(
         self,
-        window: int | _str | BaseOffset | BaseIndexer,
+        window: int | _str | Timedelta | BaseOffset | BaseIndexer,
         min_periods: int | None = ...,
         center: _bool = ...,
         on: _str | None = ...,
@@ -1848,7 +1848,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def rolling(
         self,
-        window: int | _str | BaseOffset | BaseIndexer,
+        window: int | _str | Timedelta | BaseOffset | BaseIndexer,
         min_periods: int | None = ...,
         center: _bool = ...,
         on: _str | None = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1834,7 +1834,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def rolling(
         self,
-        window: int | _str | Timedelta | BaseOffset | BaseIndexer,
+        window: int | _str | timedelta | BaseOffset | BaseIndexer,
         min_periods: int | None = ...,
         center: _bool = ...,
         on: _str | None = ...,
@@ -1848,7 +1848,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def rolling(
         self,
-        window: int | _str | Timedelta | BaseOffset | BaseIndexer,
+        window: int | _str | timedelta | BaseOffset | BaseIndexer,
         min_periods: int | None = ...,
         center: _bool = ...,
         on: _str | None = ...,

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 import numpy as np
 import pandas as pd
 from pandas import (
@@ -69,6 +71,10 @@ def test_rolling_datetime_index() -> None:
         Rolling,
         Series,
     )
+
+    dttd = dt.timedelta(days=1)
+    check(assert_type(DF_DTI.rolling(dttd), "Rolling[DataFrame]"), Rolling, DataFrame)
+    check(assert_type(S_DTI.rolling(dttd), "Rolling[Series]"), Rolling, Series)
 
 
 def test_rolling_apply() -> None:

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -52,25 +52,22 @@ def test_rolling_basic_math() -> None:
 
 def test_rolling_datetime_index() -> None:
     offset_1d = to_offset("1D")
-    td = Timedelta("1D")
     assert offset_1d is not None
 
     check(assert_type(DF_DTI.rolling("1D"), "Rolling[DataFrame]"), Rolling, DataFrame)
     check(
         assert_type(DF_DTI.rolling(offset_1d), "Rolling[DataFrame]"), Rolling, DataFrame
     )
-    check(assert_type(DF_DTI.rolling(td), "Rolling[DataFrame]"), Rolling, DataFrame)
     check(assert_type(S_DTI.rolling("1D"), "Rolling[Series]"), Rolling, Series)
     check(
         assert_type(S_DTI.rolling(offset_1d), "Rolling[Series]"),
         Rolling,
         Series,
     )
-    check(
-        assert_type(S_DTI.rolling(td), "Rolling[Series]"),
-        Rolling,
-        Series,
-    )
+
+    td = Timedelta("1D")
+    check(assert_type(DF_DTI.rolling(td), "Rolling[DataFrame]"), Rolling, DataFrame)
+    check(assert_type(S_DTI.rolling(td), "Rolling[Series]"), Rolling, Series)
 
     dttd = dt.timedelta(days=1)
     check(assert_type(DF_DTI.rolling(dttd), "Rolling[DataFrame]"), Rolling, DataFrame)

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -3,6 +3,7 @@ import pandas as pd
 from pandas import (
     DataFrame,
     Series,
+    Timedelta,
     date_range,
 )
 from pandas.core.window import (
@@ -49,15 +50,22 @@ def test_rolling_basic_math() -> None:
 
 def test_rolling_datetime_index() -> None:
     offset_1d = to_offset("1D")
+    td = Timedelta("1D")
     assert offset_1d is not None
 
     check(assert_type(DF_DTI.rolling("1D"), "Rolling[DataFrame]"), Rolling, DataFrame)
     check(
         assert_type(DF_DTI.rolling(offset_1d), "Rolling[DataFrame]"), Rolling, DataFrame
     )
+    check(assert_type(DF_DTI.rolling(td), "Rolling[DataFrame]"), Rolling, DataFrame)
     check(assert_type(S_DTI.rolling("1D"), "Rolling[Series]"), Rolling, Series)
     check(
         assert_type(S_DTI.rolling(offset_1d), "Rolling[Series]"),
+        Rolling,
+        Series,
+    )
+    check(
+        assert_type(S_DTI.rolling(td), "Rolling[Series]"),
         Rolling,
         Series,
     )


### PR DESCRIPTION
- [x] Closes #704 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
