### PR TITLE
dtype argument of read_json()

### DIFF
--- a/pandas-stubs/io/json/_json.pyi
+++ b/pandas-stubs/io/json/_json.pyi
@@ -1,4 +1,5 @@
 from collections import abc
+from collections.abc import Mapping
 from types import TracebackType
 from typing import (
     Generic,
@@ -29,7 +30,7 @@ def read_json(
     *,
     orient: JsonSeriesOrient | None = ...,
     typ: Literal["series"],
-    dtype: bool | dict[HashableT, DtypeArg] | None = ...,
+    dtype: bool | Mapping[HashableT, DtypeArg] | None = ...,
     convert_axes: bool | None = ...,
     convert_dates: bool | list[str] = ...,
     keep_default_dates: bool = ...,
@@ -53,7 +54,7 @@ def read_json(
     *,
     orient: JsonFrameOrient | None = ...,
     typ: Literal["frame"] = ...,
-    dtype: bool | dict[HashableT, DtypeArg] | None = ...,
+    dtype: bool | Mapping[HashableT, DtypeArg] | None = ...,
     convert_axes: bool | None = ...,
     convert_dates: bool | list[str] = ...,
     keep_default_dates: bool = ...,
@@ -77,7 +78,7 @@ def read_json(
     *,
     orient: JsonSeriesOrient | None = ...,
     typ: Literal["series"],
-    dtype: bool | dict[HashableT, DtypeArg] | None = ...,
+    dtype: bool | Mapping[HashableT, DtypeArg] | None = ...,
     convert_axes: bool | None = ...,
     convert_dates: bool | list[str] = ...,
     keep_default_dates: bool = ...,
@@ -101,7 +102,7 @@ def read_json(
     *,
     orient: JsonFrameOrient | None = ...,
     typ: Literal["frame"] = ...,
-    dtype: bool | dict[HashableT, DtypeArg] | None = ...,
+    dtype: bool | Mapping[HashableT, DtypeArg] | None = ...,
     convert_axes: bool | None = ...,
     convert_dates: bool | list[str] = ...,
     keep_default_dates: bool = ...,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1299,6 +1299,9 @@ def test_all_read_without_lxml_dtype_backend() -> None:
         check(
             assert_type(read_json(path, dtype_backend="pyarrow"), DataFrame), DataFrame
         )
+        check(
+            assert_type(read_json(path, dtype={"MatchID": str}), DataFrame), DataFrame
+        )
 
     with ensure_clean() as path:
         con = sqlite3.connect(path)


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #700  
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
