### PR TITLE
Add interchange to `pandas-stubs/api/__init__.pyi`

### DIFF
--- a/pandas-stubs/api/__init__.pyi
+++ b/pandas-stubs/api/__init__.pyi
@@ -1,5 +1,6 @@
 from pandas.api import (
     extensions as extensions,
     indexers as indexers,
+    interchange as interchange,
     types as types,
 )

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -470,3 +470,11 @@ def test_check_extension_dtypes() -> None:
     check_ext_dtype(pd.SparseDtype)
     check_ext_dtype(pd.Float32Dtype)
     check_ext_dtype(pd.Float64Dtype)
+
+
+def test_from_dataframe() -> None:
+    # GH 712
+    check(
+        assert_type(pd.api.interchange.from_dataframe(dframe), pd.DataFrame),
+        pd.DataFrame,
+    )


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #712  (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

It seems that tests need to be added, but not sure which folder should be added and may need some help
