### PR TITLE
Argument 1 to "apply" of "Series" has incompatible type "Callable[[Any], Union[int, NAType]]"

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -851,7 +851,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def apply(
         self,
-        func: Callable[..., Scalar | Sequence | set | Mapping | None],
+        func: Callable[..., Scalar | Sequence | set | Mapping | NAType | None],
         convertDType: _bool = ...,
         args: tuple = ...,
         **kwds,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -35,6 +35,7 @@ from typing_extensions import (
 )
 import xarray as xr
 
+from pandas._libs.missing import NAType
 from pandas._libs.tslibs.timedeltas import Timedelta
 from pandas._libs.tslibs.timestamps import Timestamp
 from pandas._typing import (
@@ -469,6 +470,8 @@ def test_types_apply() -> None:
 
     ss = s.astype(str)
     check(assert_type(ss.apply(get_depth), pd.Series), pd.Series, np.int64)
+
+    check(assert_type(s.apply(lambda x: pd.NA), pd.Series), pd.Series, NAType)
 
 
 def test_types_element_wise_arithmetic() -> None:


### PR DESCRIPTION
<!--
Two CI tests are using not yet released versions of pandas ("nightly") and mypy ("mypy_nightly"). It is okay if they fail.
-->

- [x] Closes #681 (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
