### PR TITLE
fix nightly tests to work with 2.1 dev code

### DIFF
--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -8,7 +8,10 @@ from typing_extensions import assert_type
 
 from pandas._typing import DtypeObj
 
-from tests import check
+from tests import (
+    check,
+    pytest_warns_bounded,
+)
 
 nparr = np.array([1, 2, 3])
 arr = pd.Series([1, 2, 3])
@@ -52,12 +55,15 @@ def test_is_bool_dtype() -> None:
 
 
 def test_is_categorical_dtype() -> None:
-    check(assert_type(api.is_categorical_dtype(arr), bool), bool)
-    check(assert_type(api.is_categorical_dtype(nparr), bool), bool)
-    check(assert_type(api.is_categorical_dtype(dtylike), bool), bool)
-    check(assert_type(api.is_categorical_dtype(dframe), bool), bool)
-    check(assert_type(api.is_categorical_dtype(ind), bool), bool)
-    check(assert_type(api.is_categorical_dtype(ExtensionDtype), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning, "is_categorical_dtype is deprecated", lower="2.0.99"
+    ):
+        check(assert_type(api.is_categorical_dtype(arr), bool), bool)
+        check(assert_type(api.is_categorical_dtype(nparr), bool), bool)
+        check(assert_type(api.is_categorical_dtype(dtylike), bool), bool)
+        check(assert_type(api.is_categorical_dtype(dframe), bool), bool)
+        check(assert_type(api.is_categorical_dtype(ind), bool), bool)
+        check(assert_type(api.is_categorical_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_complex() -> None:
@@ -121,12 +127,15 @@ def test_is_datetime64_ns_dtype() -> None:
 
 
 def test_is_datetime64tz_dtype() -> None:
-    check(assert_type(api.is_datetime64tz_dtype(arr), bool), bool)
-    check(assert_type(api.is_datetime64tz_dtype(nparr), bool), bool)
-    check(assert_type(api.is_datetime64tz_dtype(dtylike), bool), bool)
-    check(assert_type(api.is_datetime64tz_dtype(dframe), bool), bool)
-    check(assert_type(api.is_datetime64tz_dtype(ind), bool), bool)
-    check(assert_type(api.is_datetime64tz_dtype(ExtensionDtype), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning, "is_datetime64tz_dtype is deprecated", lower="2.0.99"
+    ):
+        check(assert_type(api.is_datetime64tz_dtype(arr), bool), bool)
+        check(assert_type(api.is_datetime64tz_dtype(nparr), bool), bool)
+        check(assert_type(api.is_datetime64tz_dtype(dtylike), bool), bool)
+        check(assert_type(api.is_datetime64tz_dtype(dframe), bool), bool)
+        check(assert_type(api.is_datetime64tz_dtype(ind), bool), bool)
+        check(assert_type(api.is_datetime64tz_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_dict_like() -> None:
@@ -203,12 +212,15 @@ def test_is_hashable() -> None:
 
 
 def test_is_int64_dtype() -> None:
-    check(assert_type(api.is_int64_dtype(arr), bool), bool)
-    check(assert_type(api.is_int64_dtype(nparr), bool), bool)
-    check(assert_type(api.is_int64_dtype(dtylike), bool), bool)
-    check(assert_type(api.is_int64_dtype(dframe), bool), bool)
-    check(assert_type(api.is_int64_dtype(ind), bool), bool)
-    # check(assert_type(api.is_int64_dtype(ExtensionDtype), bool), bool) pandas GH 50923
+    with pytest_warns_bounded(
+        FutureWarning, "is_int64_dtype is deprecated", lower="2.0.99"
+    ):
+        check(assert_type(api.is_int64_dtype(arr), bool), bool)
+        check(assert_type(api.is_int64_dtype(nparr), bool), bool)
+        check(assert_type(api.is_int64_dtype(dtylike), bool), bool)
+        check(assert_type(api.is_int64_dtype(dframe), bool), bool)
+        check(assert_type(api.is_int64_dtype(ind), bool), bool)
+        # check(assert_type(api.is_int64_dtype(ExtensionDtype), bool), bool) pandas GH 50923
 
 
 def test_is_integer() -> None:
@@ -248,13 +260,16 @@ def test_is_interval() -> None:
 
 
 def test_is_interval_dtype() -> None:
-    check(assert_type(api.is_interval_dtype(obj), bool), bool)
-    check(assert_type(api.is_interval_dtype(nparr), bool), bool)
-    check(assert_type(api.is_interval_dtype(dtylike), bool), bool)
-    check(assert_type(api.is_interval_dtype(arr), bool), bool)
-    check(assert_type(api.is_interval_dtype(dframe), bool), bool)
-    check(assert_type(api.is_interval_dtype(ind), bool), bool)
-    check(assert_type(api.is_interval_dtype(ExtensionDtype), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning, "is_interval_dtype is deprecated", lower="2.0.99"
+    ):
+        check(assert_type(api.is_interval_dtype(obj), bool), bool)
+        check(assert_type(api.is_interval_dtype(nparr), bool), bool)
+        check(assert_type(api.is_interval_dtype(dtylike), bool), bool)
+        check(assert_type(api.is_interval_dtype(arr), bool), bool)
+        check(assert_type(api.is_interval_dtype(dframe), bool), bool)
+        check(assert_type(api.is_interval_dtype(ind), bool), bool)
+        check(assert_type(api.is_interval_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_iterator() -> None:
@@ -327,12 +342,15 @@ def test_is_object_dtype() -> None:
 
 
 def test_is_period_dtype() -> None:
-    check(assert_type(api.is_period_dtype(arr), bool), bool)
-    check(assert_type(api.is_period_dtype(nparr), bool), bool)
-    check(assert_type(api.is_period_dtype(dtylike), bool), bool)
-    check(assert_type(api.is_period_dtype(dframe), bool), bool)
-    check(assert_type(api.is_period_dtype(ind), bool), bool)
-    check(assert_type(api.is_period_dtype(ExtensionDtype), bool), bool)
+    with pytest_warns_bounded(
+        FutureWarning, "is_period_dtype is deprecated", lower="2.0.99"
+    ):
+        check(assert_type(api.is_period_dtype(arr), bool), bool)
+        check(assert_type(api.is_period_dtype(nparr), bool), bool)
+        check(assert_type(api.is_period_dtype(dtylike), bool), bool)
+        check(assert_type(api.is_period_dtype(dframe), bool), bool)
+        check(assert_type(api.is_period_dtype(ind), bool), bool)
+        check(assert_type(api.is_period_dtype(ExtensionDtype), bool), bool)
 
 
 def test_is_re() -> None:
@@ -378,9 +396,10 @@ def test_is_signed_integer_dtype() -> None:
 
 
 def test_is_sparse() -> None:
-    check(assert_type(api.is_sparse(arr), bool), bool)
-    check(assert_type(api.is_sparse(nparr), bool), bool)
-    check(assert_type(api.is_sparse(dframe), bool), bool)
+    with pytest_warns_bounded(FutureWarning, "is_sparse is deprecated", lower="2.0.99"):
+        check(assert_type(api.is_sparse(arr), bool), bool)
+        check(assert_type(api.is_sparse(nparr), bool), bool)
+        check(assert_type(api.is_sparse(dframe), bool), bool)
 
 
 def test_is_string_dtype() -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -474,37 +474,45 @@ def test_json_series():
         check(assert_type(s.to_json(path), None), type(None))
         check(assert_type(read_json(path, typ="series"), Series), Series)
     check(assert_type(DF.to_json(), str), str)
-    check(
-        assert_type(
-            read_json(s.to_json(orient=None), typ="series", orient=None), Series
-        ),
-        Series,
-    )
-    check(
-        assert_type(
-            read_json(s.to_json(orient="split"), typ="series", orient="split"), Series
-        ),
-        Series,
-    )
-    check(
-        assert_type(
-            read_json(s.to_json(orient="records"), typ="series", orient="records"),
+    with pytest_warns_bounded(
+        FutureWarning,
+        "Passing literal json to 'read_json' is deprecated ",
+        lower="2.0.99",
+    ):
+        check(
+            assert_type(
+                read_json(s.to_json(orient=None), typ="series", orient=None), Series
+            ),
             Series,
-        ),
-        Series,
-    )
-    check(
-        assert_type(
-            read_json(s.to_json(orient="index"), typ="series", orient="index"), Series
-        ),
-        Series,
-    )
-    check(
-        assert_type(
-            read_json(s.to_json(orient="table"), typ="series", orient="table"), Series
-        ),
-        Series,
-    )
+        )
+        check(
+            assert_type(
+                read_json(s.to_json(orient="split"), typ="series", orient="split"),
+                Series,
+            ),
+            Series,
+        )
+        check(
+            assert_type(
+                read_json(s.to_json(orient="records"), typ="series", orient="records"),
+                Series,
+            ),
+            Series,
+        )
+        check(
+            assert_type(
+                read_json(s.to_json(orient="index"), typ="series", orient="index"),
+                Series,
+            ),
+            Series,
+        )
+        check(
+            assert_type(
+                read_json(s.to_json(orient="table"), typ="series", orient="table"),
+                Series,
+            ),
+            Series,
+        )
 
 
 def test_json_chunk():
@@ -981,7 +989,12 @@ def test_read_excel_io_types() -> None:
             check(assert_type(pd.read_excel(as_file), pd.DataFrame), pd.DataFrame)
 
         as_bytes = as_path.read_bytes()
-        check(assert_type(pd.read_excel(as_bytes), pd.DataFrame), pd.DataFrame)
+        with pytest_warns_bounded(
+            FutureWarning,
+            "Passing bytes to 'read_excel' is deprecated",
+            lower="2.0.99",
+        ):
+            check(assert_type(pd.read_excel(as_bytes), pd.DataFrame), pd.DataFrame)
 
 
 def test_read_excel_basic():

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -20,7 +20,10 @@ from typing_extensions import assert_type
 
 from pandas._typing import Scalar
 
-from tests import check
+from tests import (
+    check,
+    pytest_warns_bounded,
+)
 
 DR = date_range("1999-1-1", periods=365, freq="D")
 DF_ = DataFrame(np.random.standard_normal((365, 1)), index=DR)
@@ -83,41 +86,52 @@ def test_filling() -> None:
 
 
 def test_fillna() -> None:
-    check(assert_type(DF.resample("m").fillna("pad"), DataFrame), DataFrame)
-    check(assert_type(DF.resample("m").fillna("backfill"), DataFrame), DataFrame)
-    check(assert_type(DF.resample("m").fillna("ffill"), DataFrame), DataFrame)
-    check(assert_type(DF.resample("m").fillna("bfill"), DataFrame), DataFrame)
-    check(
-        assert_type(DF.resample("m").fillna("nearest", limit=2), DataFrame), DataFrame
-    )
+    with pytest_warns_bounded(
+        FutureWarning,
+        "DatetimeIndexResampler.fillna is deprecated ",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.resample("m").fillna("pad"), DataFrame), DataFrame)
+        check(assert_type(DF.resample("m").fillna("backfill"), DataFrame), DataFrame)
+        check(assert_type(DF.resample("m").fillna("ffill"), DataFrame), DataFrame)
+        check(assert_type(DF.resample("m").fillna("bfill"), DataFrame), DataFrame)
+        check(
+            assert_type(DF.resample("m").fillna("nearest", limit=2), DataFrame),
+            DataFrame,
+        )
 
 
 def test_aggregate() -> None:
-    check(assert_type(DF.resample("m").aggregate(np.sum), _AggRetType), DataFrame)
-    check(assert_type(DF.resample("m").agg(np.sum), _AggRetType), DataFrame)
-    check(assert_type(DF.resample("m").apply(np.sum), _AggRetType), DataFrame)
-    check(
-        assert_type(DF.resample("m").aggregate([np.sum, np.mean]), _AggRetType),
-        DataFrame,
-    )
-    check(
-        assert_type(DF.resample("m").aggregate(["sum", np.mean]), _AggRetType),
-        DataFrame,
-    )
-    check(
-        assert_type(
-            DF.resample("m").aggregate({"col1": "sum", "col2": np.mean}),
-            _AggRetType,
-        ),
-        DataFrame,
-    )
-    check(
-        assert_type(
-            DF.resample("m").aggregate({"col1": ["sum", np.mean], "col2": np.mean}),
-            _AggRetType,
-        ),
-        DataFrame,
-    )
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.resample("m").aggregate(np.sum), _AggRetType), DataFrame)
+        check(assert_type(DF.resample("m").agg(np.sum), _AggRetType), DataFrame)
+        check(assert_type(DF.resample("m").apply(np.sum), _AggRetType), DataFrame)
+        check(
+            assert_type(DF.resample("m").aggregate([np.sum, np.mean]), _AggRetType),
+            DataFrame,
+        )
+        check(
+            assert_type(DF.resample("m").aggregate(["sum", np.mean]), _AggRetType),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                DF.resample("m").aggregate({"col1": "sum", "col2": np.mean}),
+                _AggRetType,
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                DF.resample("m").aggregate({"col1": ["sum", np.mean], "col2": np.mean}),
+                _AggRetType,
+            ),
+            DataFrame,
+        )
 
     def f(val: DataFrame) -> Series:
         return val.mean()
@@ -218,32 +232,42 @@ def test_filling_series() -> None:
 
 
 def test_fillna_series() -> None:
-    check(assert_type(S.resample("m").fillna("pad"), Series), Series)
-    check(assert_type(S.resample("m").fillna("backfill"), Series), Series)
-    check(assert_type(S.resample("m").fillna("ffill"), Series), Series)
-    check(assert_type(S.resample("m").fillna("bfill"), Series), Series)
-    check(assert_type(S.resample("m").fillna("nearest", limit=2), Series), Series)
+    with pytest_warns_bounded(
+        FutureWarning,
+        "DatetimeIndexResampler.fillna is deprecated ",
+        lower="2.0.99",
+    ):
+        check(assert_type(S.resample("m").fillna("pad"), Series), Series)
+        check(assert_type(S.resample("m").fillna("backfill"), Series), Series)
+        check(assert_type(S.resample("m").fillna("ffill"), Series), Series)
+        check(assert_type(S.resample("m").fillna("bfill"), Series), Series)
+        check(assert_type(S.resample("m").fillna("nearest", limit=2), Series), Series)
 
 
 def test_aggregate_series() -> None:
-    check(assert_type(S.resample("m").aggregate(np.sum), _AggRetType), Series)
-    check(assert_type(S.resample("m").agg(np.sum), _AggRetType), Series)
-    check(assert_type(S.resample("m").apply(np.sum), _AggRetType), Series)
-    check(
-        assert_type(S.resample("m").aggregate([np.sum, np.mean]), _AggRetType),
-        DataFrame,
-    )
-    check(
-        assert_type(S.resample("m").aggregate(["sum", np.mean]), _AggRetType),
-        DataFrame,
-    )
-    check(
-        assert_type(
-            S.resample("m").aggregate({"col1": "sum", "col2": np.mean}),
-            _AggRetType,
-        ),
-        DataFrame,
-    )
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(S.resample("m").aggregate(np.sum), _AggRetType), Series)
+        check(assert_type(S.resample("m").agg(np.sum), _AggRetType), Series)
+        check(assert_type(S.resample("m").apply(np.sum), _AggRetType), Series)
+        check(
+            assert_type(S.resample("m").aggregate([np.sum, np.mean]), _AggRetType),
+            DataFrame,
+        )
+        check(
+            assert_type(S.resample("m").aggregate(["sum", np.mean]), _AggRetType),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                S.resample("m").aggregate({"col1": "sum", "col2": np.mean}),
+                _AggRetType,
+            ),
+            DataFrame,
+        )
 
     def f(val: Series) -> float:
         return val.mean()
@@ -295,14 +319,19 @@ def test_aggregate_series_combinations() -> None:
     def s2scalar(val: Series) -> float:
         return float(val.mean())
 
-    check(S.resample("m").aggregate(np.sum), Series)
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(S.resample("m").aggregate(np.sum), Series)
+        check(S.resample("m").aggregate([np.mean]), DataFrame)
+        check(S.resample("m").aggregate(["sum", np.mean]), DataFrame)
+        check(S.resample("m").aggregate({"sum": np.sum}), DataFrame)
+        check(S.resample("m").aggregate({"sum": np.sum, "mean": np.mean}), DataFrame)
     check(S.resample("m").aggregate("sum"), Series)
     check(S.resample("m").aggregate(s2series), Series)
     check(S.resample("m").aggregate(s2scalar), Series)
-    check(S.resample("m").aggregate([np.mean]), DataFrame)
-    check(S.resample("m").aggregate(["sum", np.mean]), DataFrame)
-    check(S.resample("m").aggregate({"sum": np.sum}), DataFrame)
-    check(S.resample("m").aggregate({"sum": np.sum, "mean": np.mean}), DataFrame)
 
 
 def test_aggregate_frame_combinations() -> None:
@@ -315,21 +344,27 @@ def test_aggregate_frame_combinations() -> None:
     def df2scalar(val: DataFrame) -> float:
         return float(val.mean().mean())
 
-    check(DF.resample("m").aggregate(np.sum), DataFrame)
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(DF.resample("m").aggregate(np.sum), DataFrame)
+        check(DF.resample("m").aggregate([np.mean]), DataFrame)
+        check(DF.resample("m").aggregate(["sum", np.mean]), DataFrame)
+        check(DF.resample("m").aggregate({"col1": np.sum}), DataFrame)
+        check(DF.resample("m").aggregate({"col1": np.sum, "col2": np.mean}), DataFrame)
+        check(
+            DF.resample("m").aggregate({"col1": [np.sum], "col2": ["sum", np.mean]}),
+            DataFrame,
+        )
+        check(
+            DF.resample("m").aggregate({"col1": np.sum, "col2": ["sum", np.mean]}),
+            DataFrame,
+        )
+        check(DF.resample("m").aggregate({"col1": "sum", "col2": [np.mean]}), DataFrame)
+
     check(DF.resample("m").aggregate("sum"), DataFrame)
     check(DF.resample("m").aggregate(df2frame), DataFrame)
     check(DF.resample("m").aggregate(df2series), DataFrame)
     check(DF.resample("m").aggregate(df2scalar), DataFrame)
-    check(DF.resample("m").aggregate([np.mean]), DataFrame)
-    check(DF.resample("m").aggregate(["sum", np.mean]), DataFrame)
-    check(DF.resample("m").aggregate({"col1": np.sum}), DataFrame)
-    check(DF.resample("m").aggregate({"col1": np.sum, "col2": np.mean}), DataFrame)
-    check(
-        DF.resample("m").aggregate({"col1": [np.sum], "col2": ["sum", np.mean]}),
-        DataFrame,
-    )
-    check(
-        DF.resample("m").aggregate({"col1": np.sum, "col2": ["sum", np.mean]}),
-        DataFrame,
-    )
-    check(DF.resample("m").aggregate({"col1": "sum", "col2": [np.mean]}), DataFrame)

--- a/tests/test_styler.py
+++ b/tests/test_styler.py
@@ -22,7 +22,10 @@ from pandas._testing import ensure_clean
 import pytest
 from typing_extensions import assert_type
 
-from tests import check
+from tests import (
+    check,
+    pytest_warns_bounded,
+)
 
 from pandas.io.formats.style import Styler
 
@@ -70,14 +73,24 @@ def test_applymap() -> None:
     def g(o: object) -> str:
         return str(o)
 
-    check(assert_type(DF.style.applymap(g), Styler), Styler)
+    with pytest_warns_bounded(
+        FutureWarning,
+        "Styler.applymap has been deprecated. Use Styler.map instead",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.style.applymap(g), Styler), Styler)
 
 
 def test_applymap_index() -> None:
     def g(o: object) -> str:
         return str(o)
 
-    check(assert_type(DF.style.applymap_index(g), Styler), Styler)
+    with pytest_warns_bounded(
+        FutureWarning,
+        "Styler.applymap_index has been deprecated. Use Styler.map_index instead",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.style.applymap_index(g), Styler), Styler)
 
 
 def test_background_gradient() -> None:

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -14,7 +14,10 @@ from pandas.core.window import (
 )
 from typing_extensions import assert_type
 
-from tests import check
+from tests import (
+    check,
+    pytest_warns_bounded,
+)
 
 from pandas.tseries.frequencies import to_offset
 
@@ -94,19 +97,24 @@ def test_rolling_apply() -> None:
 
 
 def test_rolling_aggregate() -> None:
-    check(assert_type(DF.rolling(10).aggregate(np.mean), DataFrame), DataFrame)
-    check(
-        assert_type(DF.rolling(10).aggregate(["mean", np.mean]), DataFrame), DataFrame
-    )
-    check(
-        assert_type(
-            DF.rolling(10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
-        ),
-        DataFrame,
-    )
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.rolling(10).aggregate(np.mean), DataFrame), DataFrame)
+        check(
+            assert_type(DF.rolling(10).aggregate(["mean", np.mean]), DataFrame),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                DF.rolling(10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
+            ),
+            DataFrame,
+        )
     check(assert_type(DF.rolling(10).agg("sum"), DataFrame), DataFrame)
 
-    check(assert_type(DF.rolling(10).aggregate(np.mean), DataFrame), DataFrame)
     check(assert_type(DF.rolling(10).aggregate("mean"), DataFrame), DataFrame)
 
     def _mean(df: DataFrame) -> Series:
@@ -114,23 +122,29 @@ def test_rolling_aggregate() -> None:
 
     check(assert_type(DF.rolling(10).aggregate(_mean), DataFrame), DataFrame)
 
-    check(assert_type(DF.rolling(10).aggregate([np.mean]), DataFrame), DataFrame)
-    check(
-        assert_type(DF.rolling(10).aggregate([np.mean, "mean"]), DataFrame), DataFrame
-    )
-    check(
-        assert_type(
-            DF.rolling(10).aggregate({"col1": np.mean, "col2": "mean"}), DataFrame
-        ),
-        DataFrame,
-    )
-    check(
-        assert_type(
-            DF.rolling(10).aggregate({"col1": [np.mean, "mean"], "col2": "mean"}),
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.rolling(10).aggregate([np.mean]), DataFrame), DataFrame)
+        check(
+            assert_type(DF.rolling(10).aggregate([np.mean, "mean"]), DataFrame),
             DataFrame,
-        ),
-        DataFrame,
-    )
+        )
+        check(
+            assert_type(
+                DF.rolling(10).aggregate({"col1": np.mean, "col2": "mean"}), DataFrame
+            ),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                DF.rolling(10).aggregate({"col1": [np.mean, "mean"], "col2": "mean"}),
+                DataFrame,
+            ),
+            DataFrame,
+        )
 
     # func: np.ufunc | Callable | str | list[Callable | str, np.ufunc] | dict[Hashable, Callable | str | np.ufunc| list[Callable | str]]
     check(assert_type(DF.rolling(10).agg("sum"), DataFrame), DataFrame)
@@ -171,7 +185,6 @@ def test_rolling_apply_series() -> None:
 
 
 def test_rolling_aggregate_series() -> None:
-    check(assert_type(S.rolling(10).aggregate(np.mean), Series), Series)
     check(assert_type(S.rolling(10).aggregate("mean"), Series), Series)
 
     def _mean(s: Series) -> float:
@@ -179,15 +192,27 @@ def test_rolling_aggregate_series() -> None:
 
     check(assert_type(S.rolling(10).aggregate(_mean), Series), Series)
 
-    check(assert_type(S.rolling(10).aggregate([np.mean]), DataFrame), DataFrame)
-    check(assert_type(S.rolling(10).aggregate([np.mean, "mean"]), DataFrame), DataFrame)
-    check(
-        assert_type(
-            S.rolling(10).aggregate({"col1": np.mean, "col2": "mean", "col3": _mean}),
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function mean .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(S.rolling(10).aggregate(np.mean), Series), Series)
+
+        check(assert_type(S.rolling(10).aggregate([np.mean]), DataFrame), DataFrame)
+        check(
+            assert_type(S.rolling(10).aggregate([np.mean, "mean"]), DataFrame),
             DataFrame,
-        ),
-        DataFrame,
-    )
+        )
+        check(
+            assert_type(
+                S.rolling(10).aggregate(
+                    {"col1": np.mean, "col2": "mean", "col3": _mean}
+                ),
+                DataFrame,
+            ),
+            DataFrame,
+        )
     check(assert_type(S.rolling(10).agg("sum"), Series), Series)
 
 
@@ -231,16 +256,22 @@ def test_expanding_apply() -> None:
 
 
 def test_expanding_aggregate() -> None:
-    check(assert_type(DF.expanding(10).aggregate(np.mean), DataFrame), DataFrame)
-    check(
-        assert_type(DF.expanding(10).aggregate(["mean", np.mean]), DataFrame), DataFrame
-    )
-    check(
-        assert_type(
-            DF.expanding(10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
-        ),
-        DataFrame,
-    )
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.expanding(10).aggregate(np.mean), DataFrame), DataFrame)
+        check(
+            assert_type(DF.expanding(10).aggregate(["mean", np.mean]), DataFrame),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                DF.expanding(10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
+            ),
+            DataFrame,
+        )
     check(assert_type(DF.expanding(10).agg("sum"), DataFrame), DataFrame)
 
 
@@ -279,16 +310,22 @@ def test_expanding_apply_series() -> None:
 
 
 def test_expanding_aggregate_series() -> None:
-    check(assert_type(S.expanding(10).aggregate(np.mean), Series), Series)
-    check(
-        assert_type(S.expanding(10).aggregate(["mean", np.mean]), DataFrame), DataFrame
-    )
-    check(
-        assert_type(
-            S.expanding(10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
-        ),
-        DataFrame,
-    )
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(S.expanding(10).aggregate(np.mean), Series), Series)
+        check(
+            assert_type(S.expanding(10).aggregate(["mean", np.mean]), DataFrame),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                S.expanding(10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
+            ),
+            DataFrame,
+        )
     check(assert_type(S.expanding(10).agg("sum"), Series), Series)
 
 
@@ -302,16 +339,22 @@ def test_ewm_basic_math() -> None:
 
 
 def test_ewm_aggregate() -> None:
-    check(assert_type(DF.ewm(span=10).aggregate(np.mean), DataFrame), DataFrame)
-    check(
-        assert_type(DF.ewm(span=10).aggregate(["mean", np.mean]), DataFrame), DataFrame
-    )
-    check(
-        assert_type(
-            DF.ewm(span=10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
-        ),
-        DataFrame,
-    )
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(DF.ewm(span=10).aggregate(np.mean), DataFrame), DataFrame)
+        check(
+            assert_type(DF.ewm(span=10).aggregate(["mean", np.mean]), DataFrame),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                DF.ewm(span=10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
+            ),
+            DataFrame,
+        )
     check(assert_type(DF.ewm(span=10).agg("sum"), DataFrame), DataFrame)
 
 
@@ -325,16 +368,22 @@ def test_ewm_basic_math_series() -> None:
 
 
 def test_ewm_aggregate_series() -> None:
-    check(assert_type(S.ewm(span=10).aggregate(np.mean), Series), Series)
-    check(
-        assert_type(S.ewm(span=10).aggregate(["mean", np.mean]), DataFrame), DataFrame
-    )
-    check(
-        assert_type(
-            S.ewm(span=10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
-        ),
-        DataFrame,
-    )
+    with pytest_warns_bounded(
+        FutureWarning,
+        r"The provided callable <function (sum|mean) .*> is currently using ",
+        lower="2.0.99",
+    ):
+        check(assert_type(S.ewm(span=10).aggregate(np.mean), Series), Series)
+        check(
+            assert_type(S.ewm(span=10).aggregate(["mean", np.mean]), DataFrame),
+            DataFrame,
+        )
+        check(
+            assert_type(
+                S.ewm(span=10).aggregate({"col1": "mean", "col2": np.mean}), DataFrame
+            ),
+            DataFrame,
+        )
     check(assert_type(S.ewm(span=10).agg("sum"), Series), Series)
 
 


### PR DESCRIPTION

- [x] Closes #740 

Added a number of `pytest_warns_bounded()` to catch warnings.  Discovered a few errors in the pandas dev code which are reported as issues there.

