### PR TITLE
added pyarrow/numpy dtype literals and allowed `str` | `DtypeObj` as input for `Series.astype`

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -78,6 +78,17 @@ NpDtype: TypeAlias = str | np.dtype[np.generic] | type[str | complex | bool | ob
 Dtype: TypeAlias = ExtensionDtype | NpDtype
 DtypeArg: TypeAlias = Dtype | Mapping[Any, Dtype]
 DtypeBackend: TypeAlias = Literal["pyarrow", "numpy_nullable"]
+
+# NOTE: we want to catch all the possible dtypes from np.sctypeDict
+# timedelta64
+# M
+# m8
+# M8
+# object_
+# object0
+# m
+# datetime64
+
 BooleanDtypeArg: TypeAlias = (
     # Builtin bool type and its string alias
     type[bool]  # noqa: Y030
@@ -88,7 +99,7 @@ BooleanDtypeArg: TypeAlias = (
     # Numpy bool type
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool_
     | type[np.bool_]
-    | Literal["?", "bool8", "bool_"]
+    | Literal["?", "b1", "bool8", "bool_"]
     # PyArrow boolean type and its string alias
     | Literal["bool[pyarrow]", "boolean[pyarrow]"]
 )
@@ -102,73 +113,56 @@ IntDtypeArg: TypeAlias = (
     | pd.Int32Dtype
     | pd.Int64Dtype
     | Literal["Int8", "Int16", "Int32", "Int64"]
+    # Numpy signed integer types and their string aliases
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.byte
+    | type[np.byte]
+    | Literal["b", "i1", "int8", "byte"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.short
+    | type[np.short]
+    | Literal["h", "i2", "int16", "short"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.intc
+    | type[np.intc]
+    | Literal["i", "i4", "int32", "intc"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.int_
+    | type[np.int_]
+    | Literal["l", "i8", "int64", "int0", "int_", "long"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.longlong
+    | type[np.longlong]
+    | Literal["q", "longlong"]  # NOTE: int128 not assigned
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.intp
+    | type[np.intp]  # signed pointer (=`intptr_t`, platform dependent)
+    | Literal["p", "intp"]
+    # PyArrow integer types and their string aliases
+    | Literal["int8[pyarrow]", "int16[pyarrow]", "int32[pyarrow]", "int64[pyarrow]"]
+)
+UIntDtypeArg: TypeAlias = (
     # Pandas nullable unsigned integer types and their string aliases
-    | pd.UInt8Dtype
+    pd.UInt8Dtype  # noqa: Y030
     | pd.UInt16Dtype
     | pd.UInt32Dtype
     | pd.UInt64Dtype
     | Literal["UInt8", "UInt16", "UInt32", "UInt64"]
-    # Numpy signed integer types and their string aliases
-    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.byte
-    | type[np.byte]
-    | Literal["b", "int8", "byte"]
-    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.short
-    | type[np.short]
-    | Literal["h", "int16", "short"]
-    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.intc
-    | type[np.intc]
-    | Literal["i", "int32", "intc"]
-    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.int_
-    | type[np.int_]
-    | Literal["l", "int64", "int_", "intp", "long"]
-    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.longlong
-    | type[np.longlong]
-    | Literal["q", "longlong"]  # NOTE: int128 not assigned
     # Numpy unsigned integer types and their string aliases
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.ubyte
     | type[np.ubyte]
-    | Literal["B", "uint8", "ubyte"]
+    | Literal["B", "u1", "uint8", "ubyte"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.ushort
     | type[np.ushort]
-    | Literal["H", "uint16", "ushort"]
+    | Literal["H", "u2", "uint16", "ushort"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.uintc
     | type[np.uintc]
-    | Literal["I", "uint32", "uintc"]
+    | Literal["I", "u4", "uint32", "uintc"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.uint
     | type[np.uint]
-    | Literal["L", "uint64", "uint", "uintp"]
+    | Literal["L", "u8", "uint", "ulong", "uint64", "uint0"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.ulonglong
     | type[np.ulonglong]
     | Literal["Q", "ulonglong"]  # NOTE: uint128 not assigned
-    # PyArrow integer types and their string aliases
-    | Literal["int8[pyarrow]", "int16[pyarrow]", "int32[pyarrow]", "int64[pyarrow]"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.uintp
+    | type[np.uintp]  # unsigned pointer (=`uintptr_t`, platform dependent)
+    | Literal["P", "uintp"]
     # PyArrow unsigned integer types and their string aliases
     | Literal["uint8[pyarrow]", "uint16[pyarrow]", "uint32[pyarrow]", "uint64[pyarrow]"]
-)
-StrDtypeArg: TypeAlias = (
-    # Builtin str type and its string alias
-    type[str]  # noqa: Y030
-    | Literal["str"]
-    # Pandas nullable string type and its string alias
-    | pd.StringDtype
-    | Literal["string"]
-    # Numpy string type and its string alias
-    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.str_
-    | type[np.str_]
-    | Literal["U", "str_", "unicode"]
-    # PyArrow string type and its string alias
-    | Literal["string[pyarrow]"]
-)
-BytesDtypeArg: TypeAlias = (
-    # Builtin bytes type and its string alias
-    type[bytes]  # noqa: Y030
-    | Literal["bytes"]
-    # Numpy bytes type and its string alias
-    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bytes_
-    | type[np.bytes_]
-    | Literal["S", "bytes_", "string_"]
-    # PyArrow binary type and its string alias
-    | Literal["binary[pyarrow]"]
 )
 FloatDtypeArg: TypeAlias = (
     # Builtin float type and its string alias
@@ -182,16 +176,16 @@ FloatDtypeArg: TypeAlias = (
     # NOTE: Alias np.float16 only on Linux x86_64, use np.half instead
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.half
     | type[np.half]
-    | Literal["e", "float16", "half"]
+    | Literal["e", "f2", "<f2", "float16", "half"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.single
     | type[np.single]
-    | Literal["f", "float32", "single"]
+    | Literal["f", "f4", "float32", "single"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.double
     | type[np.double]
-    | Literal["d", "float64", "double", "float_"]
+    | Literal["d", "f8", "float64", "double", "float_"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.longdouble
     | type[np.longdouble]
-    | Literal["g", "float128", "longdouble", "longfloat"]
+    | Literal["g", "f16", "float128", "longdouble", "longfloat"]
     # PyArrow floating point types and their string aliases
     | Literal[
         "float[pyarrow]",
@@ -208,14 +202,14 @@ ComplexDtypeArg: TypeAlias = (
     # Numpy complex types and their aliases
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.csingle
     | type[np.csingle]
-    | Literal["F", "complex64", "csingle", "singlecomplex"]
+    | Literal["F", "c8", "complex64", "csingle", "singlecomplex"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.cdouble
     | type[np.cdouble]
-    | Literal["D", "complex128", "cdouble", "cfloat", "complex_"]
+    | Literal["D", "c16", "complex128", "cdouble", "cfloat", "complex_"]
     #  https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.clongdouble
     # NOTE: Alias np.complex256 only on Linux x86_64, use np.clongdouble instead
     | type[np.clongdouble]
-    | Literal["G", "complex256", "clongdouble", "clongfloat", "longcomplex"]
+    | Literal["G", "c32", "complex256", "clongdouble", "clongfloat", "longcomplex"]
 )
 # Refer to https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units
 TimedeltaDtypeArg: TypeAlias = Literal[
@@ -234,6 +228,21 @@ TimedeltaDtypeArg: TypeAlias = Literal[
     "timedelta64[fs]",
     "timedelta64[as]",
     # numpy type codes
+    "m8[Y]",
+    "m8[M]",
+    "m8[W]",
+    "m8[D]",
+    "m8[h]",
+    "m8[m]",
+    "m8[s]",
+    "m8[ms]",
+    "m8[us]",
+    "m8[μs]",
+    "m8[ns]",
+    "m8[ps]",
+    "m8[fs]",
+    "m8[as]",
+    # little endian
     "<m8[Y]",
     "<m8[M]",
     "<m8[W]",
@@ -270,6 +279,21 @@ TimestampDtypeArg: TypeAlias = Literal[
     "datetime64[fs]",
     "datetime64[as]",
     # numpy type codes
+    "M8[Y]",
+    "M8[M]",
+    "M8[W]",
+    "M8[D]",
+    "M8[h]",
+    "M8[m]",
+    "M8[s]",
+    "M8[ms]",
+    "M8[us]",
+    "M8[μs]",
+    "M8[ns]",
+    "M8[ps]",
+    "M8[fs]",
+    "M8[as]",
+    # little endian
     "<M8[Y]",
     "<M8[M]",
     "<M8[W]",
@@ -292,6 +316,32 @@ TimestampDtypeArg: TypeAlias = Literal[
     "timestamp[us][pyarrow]",
     "timestamp[ns][pyarrow]",
 ]
+
+StrDtypeArg: TypeAlias = (
+    # Builtin str type and its string alias
+    type[str]  # noqa: Y030
+    | Literal["str"]
+    # Pandas nullable string type and its string alias
+    | pd.StringDtype
+    | Literal["string"]
+    # Numpy string type and its string alias
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.str_
+    | type[np.str_]
+    | Literal["U", "str_", "str0", "unicode", "unicode_"]
+    # PyArrow string type and its string alias
+    | Literal["string[pyarrow]"]
+)
+BytesDtypeArg: TypeAlias = (
+    # Builtin bytes type and its string alias
+    type[bytes]  # noqa: Y030
+    | Literal["bytes"]
+    # Numpy bytes type and its string alias
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bytes_
+    | type[np.bytes_]
+    | Literal["S", "a", "bytes_", "bytes0", "string_"]
+    # PyArrow binary type and its string alias
+    | Literal["binary[pyarrow]"]
+)
 CategoryDtypeArg: TypeAlias = CategoricalDtype | Literal["category"]
 
 ObjectDtypeArg: TypeAlias = (
@@ -303,12 +353,21 @@ ObjectDtypeArg: TypeAlias = (
     | type[np.object_]
     | Literal["O"]  # NOTE: "object_" not assigned
 )
+
+VoidDtypeArg: TypeAlias = (
+    # Numpy void type and its string alias
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.void
+    type[np.void]
+    | Literal["V", "void", "void0"]
+)
+
 # DtypeArg specifies all allowable dtypes in a functions its dtype argument
 DtypeObj: TypeAlias = np.dtype[np.generic] | ExtensionDtype
 
 AstypeArg: TypeAlias = (
     BooleanDtypeArg
     | IntDtypeArg
+    | UIntDtypeArg
     | StrDtypeArg
     | BytesDtypeArg
     | FloatDtypeArg
@@ -317,6 +376,7 @@ AstypeArg: TypeAlias = (
     | TimestampDtypeArg
     | CategoryDtypeArg
     | ObjectDtypeArg
+    | VoidDtypeArg
     | DtypeObj
 )
 

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -86,7 +86,11 @@ BooleanDtypeArg: TypeAlias = (
     | pd.BooleanDtype
     | Literal["boolean"]
     # Numpy bool type
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool_
     | type[np.bool_]
+    | Literal["?", "bool8", "bool_"]
+    # PyArrow boolean type and its string alias
+    | Literal["bool[pyarrow]", "boolean[pyarrow]"]
 )
 IntDtypeArg: TypeAlias = (
     # Builtin integer type and its string alias
@@ -98,22 +102,48 @@ IntDtypeArg: TypeAlias = (
     | pd.Int32Dtype
     | pd.Int64Dtype
     | Literal["Int8", "Int16", "Int32", "Int64"]
+    # Pandas nullable unsigned integer types and their string aliases
+    | pd.UInt8Dtype
+    | pd.UInt16Dtype
+    | pd.UInt32Dtype
+    | pd.UInt64Dtype
+    | Literal["UInt8", "UInt16", "UInt32", "UInt64"]
     # Numpy signed integer types and their string aliases
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.byte
     | type[np.byte]
-    | type[np.int8]
+    | Literal["b", "int8", "byte"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.short
     | type[np.int16]
-    | type[np.int32]
-    | type[np.int64]
-    | type[np.intp]
-    | Literal["byte", "int8", "int16", "int32", "int64", "intp"]
+    | Literal["h", "int16", "short"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.intc
+    | type[np.intc]
+    | Literal["i", "int32", "intc"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.int_
+    | type[np.int_]
+    | Literal["l", "int64", "int_", "intp", "long"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.longlong
+    | type[np.longlong]
+    | Literal["q", "longlong"]  # NOTE: int128 not assigned
     # Numpy unsigned integer types and their string aliases
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.ubyte
     | type[np.ubyte]
-    | type[np.uint8]
-    | type[np.uint16]
-    | type[np.uint32]
-    | type[np.uint64]
-    | type[np.uintp]
-    | Literal["ubyte", "uint8", "uint16", "uint32", "uint64", "uintp"]
+    | Literal["B", "uint8", "ubyte"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.ushort
+    | type[np.ushort]
+    | Literal["H", "uint16", "ushort"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.uintc
+    | type[np.uintc]
+    | Literal["I", "uint32", "uintc"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.uint
+    | type[np.uint]
+    | Literal["L", "uint64", "uint", "uintp"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.ulonglong
+    | type[np.ulonglong]
+    | Literal["Q", "ulonglong"]  # NOTE: uint128 not assigned
+    # PyArrow integer types and their string aliases
+    | Literal["int8[pyarrow]", "int16[pyarrow]", "int32[pyarrow]", "int64[pyarrow]"]
+    # PyArrow unsigned integer types and their string aliases
+    | Literal["uint8[pyarrow]", "uint16[pyarrow]", "uint32[pyarrow]", "uint64[pyarrow]"]
 )
 StrDtypeArg: TypeAlias = (
     # Builtin str type and its string alias
@@ -122,30 +152,59 @@ StrDtypeArg: TypeAlias = (
     # Pandas nullable string type and its string alias
     | pd.StringDtype
     | Literal["string"]
+    # PyArrow string type and its string alias
+    | Literal["string[pyarrow]"]
 )
 BytesDtypeArg: TypeAlias = type[bytes]
 FloatDtypeArg: TypeAlias = (
     # Builtin float type and its string alias
     type[float]  # noqa: Y030
-    | Literal["float"]
+    | Literal[
+        "float",
+        "float",
+    ]
     # Pandas nullable float types and their string aliases
     | pd.Float32Dtype
     | pd.Float64Dtype
     | Literal["Float32", "Float64"]
     # Numpy float types and their string aliases
-    | type[np.float16]
-    | type[np.float32]
-    | type[np.float64]
-    | Literal["float16", "float32", "float64"]
+    # NOTE: Alias np.float16 only on Linux x86_64, use np.half instead
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.half
+    | type[np.half]
+    | Literal["e", "float16", "half"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.single
+    | type[np.single]
+    | Literal["f", "float32", "single"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.double
+    | type[np.double]
+    | Literal["d", "float64", "double", "float_"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.longdouble
+    | type[np.longdouble]
+    | Literal["g", "float128", "longdouble", "longfloat"]
+    # PyArrow floating point types and their string aliases
+    | Literal[
+        "float[pyarrow]",
+        "double[pyarrow]",
+        "float16[pyarrow]",
+        "float32[pyarrow]",
+        "float64[pyarrow]",
+    ]
 )
 ComplexDtypeArg: TypeAlias = (
     # Builtin complex type and its string alias
     type[complex]  # noqa: Y030
     | Literal["complex"]
     # Numpy complex types and their aliases
-    | type[np.complex64]
-    | type[np.complex128]
-    | Literal["complex64", "complex128"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.csingle
+    | type[np.csingle]
+    | Literal["F", "complex64", "singlecomplex"]
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.cdouble
+    | type[np.cdouble]
+    | Literal["D", "complex128", "cdouble", "cfloat", "complex_"]
+    #  https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.clongdouble
+    # NOTE: Alias np.complex256 only on Linux x86_64, use np.clongdouble instead
+    | type[np.clongdouble]
+    | Literal["G", "complex256", "clongdouble", "clongfloat", "longcomplex"]
 )
 # Refer to https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units
 TimedeltaDtypeArg: TypeAlias = Literal[
@@ -163,6 +222,11 @@ TimedeltaDtypeArg: TypeAlias = Literal[
     "timedelta64[ps]",
     "timedelta64[fs]",
     "timedelta64[as]",
+    # PyArrow duration type and its string alias
+    "duration[s][pyarrow]",
+    "duration[ms][pyarrow]",
+    "duration[us][pyarrow]",
+    "duration[ns][pyarrow]",
 ]
 TimestampDtypeArg: TypeAlias = Literal[
     "datetime64[Y]",
@@ -179,8 +243,18 @@ TimestampDtypeArg: TypeAlias = Literal[
     "datetime64[ps]",
     "datetime64[fs]",
     "datetime64[as]",
+    # PyArrow timestamp type and its string alias
+    "date32[pyarrow]",
+    "date64[pyarrow]",
+    "timestamp[s][pyarrow]",
+    "timestamp[ms][pyarrow]",
+    "timestamp[us][pyarrow]",
+    "timestamp[ns][pyarrow]",
 ]
 CategoryDtypeArg: TypeAlias = CategoricalDtype | Literal["category"]
+
+# DtypeArg specifies all allowable dtypes in a functions its dtype argument
+DtypeObj: TypeAlias = np.dtype[np.generic] | ExtensionDtype
 
 AstypeArg: TypeAlias = (
     BooleanDtypeArg
@@ -192,11 +266,10 @@ AstypeArg: TypeAlias = (
     | TimedeltaDtypeArg
     | TimestampDtypeArg
     | CategoryDtypeArg
-    | ExtensionDtype
+    | DtypeObj
     | type[object]
+    | str
 )
-# DtypeArg specifies all allowable dtypes in a functions its dtype argument
-DtypeObj: TypeAlias = np.dtype[np.generic] | ExtensionDtype
 
 # filenames and file-like-objects
 AnyStr_cov = TypeVar("AnyStr_cov", str, bytes, covariant=True)

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -233,6 +233,21 @@ TimedeltaDtypeArg: TypeAlias = Literal[
     "timedelta64[ps]",
     "timedelta64[fs]",
     "timedelta64[as]",
+    # numpy type codes
+    "<m8[Y]",
+    "<m8[M]",
+    "<m8[W]",
+    "<m8[D]",
+    "<m8[h]",
+    "<m8[m]",
+    "<m8[s]",
+    "<m8[ms]",
+    "<m8[us]",
+    "<m8[μs]",
+    "<m8[ns]",
+    "<m8[ps]",
+    "<m8[fs]",
+    "<m8[as]",
     # PyArrow duration type and its string alias
     "duration[s][pyarrow]",
     "duration[ms][pyarrow]",
@@ -254,6 +269,21 @@ TimestampDtypeArg: TypeAlias = Literal[
     "datetime64[ps]",
     "datetime64[fs]",
     "datetime64[as]",
+    # numpy type codes
+    "<M8[Y]",
+    "<M8[M]",
+    "<M8[W]",
+    "<M8[D]",
+    "<M8[h]",
+    "<M8[m]",
+    "<M8[s]",
+    "<M8[ms]",
+    "<M8[us]",
+    "<M8[μs]",
+    "<M8[ns]",
+    "<M8[ps]",
+    "<M8[fs]",
+    "<M8[as]",
     # PyArrow timestamp type and its string alias
     "date32[pyarrow]",
     "date64[pyarrow]",
@@ -288,7 +318,6 @@ AstypeArg: TypeAlias = (
     | CategoryDtypeArg
     | ObjectDtypeArg
     | DtypeObj
-    | str
 )
 
 # filenames and file-like-objects

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -185,7 +185,7 @@ FloatDtypeArg: TypeAlias = (
     | Literal["d", "f8", "float64", "double", "float_"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.longdouble
     | type[np.longdouble]
-    | Literal["g", "f16", "float96", "float128", "longdouble", "longfloat"]
+    | Literal["g", "f16", "float128", "longdouble", "longfloat"]
     # PyArrow floating point types and their string aliases
     | Literal[
         "float[pyarrow]",
@@ -212,7 +212,6 @@ ComplexDtypeArg: TypeAlias = (
     | Literal[
         "G",
         "c32",
-        "complex192",
         "complex256",
         "clongdouble",
         "clongfloat",

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -159,10 +159,7 @@ BytesDtypeArg: TypeAlias = type[bytes]
 FloatDtypeArg: TypeAlias = (
     # Builtin float type and its string alias
     type[float]  # noqa: Y030
-    | Literal[
-        "float",
-        "float",
-    ]
+    | Literal["float"]
     # Pandas nullable float types and their string aliases
     | pd.Float32Dtype
     | pd.Float64Dtype

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -185,7 +185,7 @@ FloatDtypeArg: TypeAlias = (
     | Literal["d", "f8", "float64", "double", "float_"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.longdouble
     | type[np.longdouble]
-    | Literal["g", "f16", "float128", "longdouble", "longfloat"]
+    | Literal["g", "f16", "float96", "float128", "longdouble", "longfloat"]
     # PyArrow floating point types and their string aliases
     | Literal[
         "float[pyarrow]",
@@ -209,7 +209,15 @@ ComplexDtypeArg: TypeAlias = (
     #  https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.clongdouble
     # NOTE: Alias np.complex256 only on Linux x86_64, use np.clongdouble instead
     | type[np.clongdouble]
-    | Literal["G", "c32", "complex256", "clongdouble", "clongfloat", "longcomplex"]
+    | Literal[
+        "G",
+        "c32",
+        "complex192",
+        "complex256",
+        "clongdouble",
+        "clongfloat",
+        "longcomplex",
+    ]
 )
 # Refer to https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units
 TimedeltaDtypeArg: TypeAlias = Literal[

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -113,7 +113,7 @@ IntDtypeArg: TypeAlias = (
     | type[np.byte]
     | Literal["b", "int8", "byte"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.short
-    | type[np.int16]
+    | type[np.short]
     | Literal["h", "int16", "short"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.intc
     | type[np.intc]
@@ -152,10 +152,24 @@ StrDtypeArg: TypeAlias = (
     # Pandas nullable string type and its string alias
     | pd.StringDtype
     | Literal["string"]
+    # Numpy string type and its string alias
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.str_
+    | type[np.str_]
+    | Literal["U", "str_", "unicode"]
     # PyArrow string type and its string alias
     | Literal["string[pyarrow]"]
 )
-BytesDtypeArg: TypeAlias = type[bytes]
+BytesDtypeArg: TypeAlias = (
+    # Builtin bytes type and its string alias
+    type[bytes]  # noqa: Y030
+    | Literal["bytes"]
+    # Numpy bytes type and its string alias
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bytes_
+    | type[np.bytes_]
+    | Literal["S", "bytes_", "string_"]
+    # PyArrow binary type and its string alias
+    | Literal["binary[pyarrow]"]
+)
 FloatDtypeArg: TypeAlias = (
     # Builtin float type and its string alias
     type[float]  # noqa: Y030
@@ -194,7 +208,7 @@ ComplexDtypeArg: TypeAlias = (
     # Numpy complex types and their aliases
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.csingle
     | type[np.csingle]
-    | Literal["F", "complex64", "singlecomplex"]
+    | Literal["F", "complex64", "csingle", "singlecomplex"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.cdouble
     | type[np.cdouble]
     | Literal["D", "complex128", "cdouble", "cfloat", "complex_"]
@@ -250,6 +264,15 @@ TimestampDtypeArg: TypeAlias = Literal[
 ]
 CategoryDtypeArg: TypeAlias = CategoricalDtype | Literal["category"]
 
+ObjectDtypeArg: TypeAlias = (
+    # Builtin object type and its string alias
+    type[object]  # noqa: Y030
+    | Literal["object"]
+    # Numpy object type and its string alias
+    # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.object_
+    | type[np.object_]
+    | Literal["O"]  # NOTE: "object_" not assigned
+)
 # DtypeArg specifies all allowable dtypes in a functions its dtype argument
 DtypeObj: TypeAlias = np.dtype[np.generic] | ExtensionDtype
 
@@ -263,8 +286,8 @@ AstypeArg: TypeAlias = (
     | TimedeltaDtypeArg
     | TimestampDtypeArg
     | CategoryDtypeArg
+    | ObjectDtypeArg
     | DtypeObj
-    | type[object]
     | str
 )
 

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -125,13 +125,13 @@ IntDtypeArg: TypeAlias = (
     | Literal["i", "i4", "int32", "intc"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.int_
     | type[np.int_]
-    | Literal["l", "i8", "int64", "int0", "int_", "long"]
+    | Literal["l", "i8", "int64", "int_", "long"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.longlong
     | type[np.longlong]
     | Literal["q", "longlong"]  # NOTE: int128 not assigned
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.intp
     | type[np.intp]  # signed pointer (=`intptr_t`, platform dependent)
-    | Literal["p", "intp"]
+    | Literal["p", "intp", "int0"]
     # PyArrow integer types and their string aliases
     | Literal["int8[pyarrow]", "int16[pyarrow]", "int32[pyarrow]", "int64[pyarrow]"]
 )
@@ -154,13 +154,13 @@ UIntDtypeArg: TypeAlias = (
     | Literal["I", "u4", "uint32", "uintc"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.uint
     | type[np.uint]
-    | Literal["L", "u8", "uint", "ulong", "uint64", "uint0"]
+    | Literal["L", "u8", "uint", "ulong", "uint64"]
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.ulonglong
     | type[np.ulonglong]
     | Literal["Q", "ulonglong"]  # NOTE: uint128 not assigned
     # https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.uintp
     | type[np.uintp]  # unsigned pointer (=`uintptr_t`, platform dependent)
-    | Literal["P", "uintp"]
+    | Literal["P", "uintp", "uint0"]
     # PyArrow unsigned integer types and their string aliases
     | Literal["uint8[pyarrow]", "uint16[pyarrow]", "uint32[pyarrow]", "uint64[pyarrow]"]
 )

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -329,7 +329,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
         is_copy: _bool | None = ...,
         **kwargs,
     ) -> Series[S1]: ...
-    def __getattr__(self, name: str) -> S1: ...
+    def __getattr__(self, name: _str) -> S1: ...
     @overload
     def __getitem__(
         self,
@@ -1208,7 +1208,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def astype(
         self,
-        dtype: type[object] | ExtensionDtype,
+        dtype: type[object] | ExtensionDtype | DtypeObj | _str,
         copy: _bool = ...,
         errors: IgnoreRaise = ...,
     ) -> Series: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -127,6 +127,7 @@ from pandas._typing import (
     ListLikeU,
     MaskType,
     NaPosition,
+    ObjectDtypeArg,
     QuantileInterpolation,
     RandomState,
     Renamer,
@@ -1208,7 +1209,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def astype(
         self,
-        dtype: type[object] | ExtensionDtype | DtypeObj | _str,
+        dtype: ObjectDtypeArg | ExtensionDtype | DtypeObj | _str,
         copy: _bool = ...,
         errors: IgnoreRaise = ...,
     ) -> Series: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -139,6 +139,8 @@ from pandas._typing import (
     TimedeltaDtypeArg,
     TimestampConvention,
     TimestampDtypeArg,
+    UIntDtypeArg,
+    VoidDtypeArg,
     WriteBuffer,
     np_ndarray_anyint,
     np_ndarray_bool,
@@ -1153,7 +1155,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def astype(
         self,
-        dtype: IntDtypeArg,
+        dtype: IntDtypeArg | UIntDtypeArg,
         copy: _bool = ...,
         errors: IgnoreRaise = ...,
     ) -> Series[int]: ...
@@ -1209,7 +1211,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def astype(
         self,
-        dtype: ObjectDtypeArg | ExtensionDtype | DtypeObj,
+        dtype: ObjectDtypeArg | VoidDtypeArg | ExtensionDtype | DtypeObj,
         copy: _bool = ...,
         errors: IgnoreRaise = ...,
     ) -> Series: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1209,7 +1209,7 @@ class Series(IndexOpsMixin, NDFrame, Generic[S1]):
     @overload
     def astype(
         self,
-        dtype: ObjectDtypeArg | ExtensionDtype | DtypeObj | _str,
+        dtype: ObjectDtypeArg | ExtensionDtype | DtypeObj,
         copy: _bool = ...,
         errors: IgnoreRaise = ...,
     ) -> Series: ...

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1715,9 +1715,14 @@ def test_updated_astype() -> None:
     check(assert_type(s1.astype("boolean"), "pd.Series[bool]"), pd.Series, np.bool_)
     # Numpy bool type
     check(assert_type(s.astype(np.bool_), "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type(s.astype("bool_"), "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type(s.astype("bool8"), "pd.Series[bool]"), pd.Series, np.bool_)
+    check(assert_type(s.astype("?"), "pd.Series[bool]"), pd.Series, np.bool_)
+    # pyarrow bool type
+    check(assert_type(s.astype("bool[pyarrow]"), "pd.Series[bool]"), pd.Series, bool)
+    check(assert_type(s.astype("boolean[pyarrow]"), "pd.Series[bool]"), pd.Series, bool)
 
     # Integer types
-
     # Builtin integer types
     check(assert_type(s.astype(int), "pd.Series[int]"), pd.Series, np.integer)
     check(assert_type(s.astype("int"), "pd.Series[int]"), pd.Series, np.integer)
@@ -1730,48 +1735,114 @@ def test_updated_astype() -> None:
     check(assert_type(s.astype("Int16"), "pd.Series[int]"), pd.Series, np.int16)
     check(assert_type(s.astype("Int32"), "pd.Series[int]"), pd.Series, np.int32)
     check(assert_type(s.astype("Int64"), "pd.Series[int]"), pd.Series, np.int64)
+    # Pandas nullable unsigned integer types
+    check(assert_type(s.astype(pd.UInt8Dtype()), "pd.Series[int]"), pd.Series, np.uint8)
+    check(
+        assert_type(s.astype(pd.UInt16Dtype()), "pd.Series[int]"), pd.Series, np.uint16
+    )
+    check(
+        assert_type(s.astype(pd.UInt32Dtype()), "pd.Series[int]"), pd.Series, np.uint32
+    )
+    check(
+        assert_type(s.astype(pd.UInt64Dtype()), "pd.Series[int]"), pd.Series, np.uint64
+    )
+    check(assert_type(s.astype("UInt8"), "pd.Series[int]"), pd.Series, np.uint8)
+    check(assert_type(s.astype("UInt16"), "pd.Series[int]"), pd.Series, np.uint16)
+    check(assert_type(s.astype("UInt32"), "pd.Series[int]"), pd.Series, np.uint32)
+    check(assert_type(s.astype("UInt64"), "pd.Series[int]"), pd.Series, np.uint64)
+
     # Numpy signed integer types
+    # int8
     check(assert_type(s.astype(np.byte), "pd.Series[int]"), pd.Series, np.byte)
-    check(assert_type(s.astype(np.int8), "pd.Series[int]"), pd.Series, np.int8)
-    check(assert_type(s.astype(np.int16), "pd.Series[int]"), pd.Series, np.int16)
-    check(assert_type(s.astype(np.int32), "pd.Series[int]"), pd.Series, np.int32)
-    check(assert_type(s.astype(np.int64), "pd.Series[int]"), pd.Series, np.int64)
-    check(assert_type(s.astype(np.intp), "pd.Series[int]"), pd.Series, np.intp)
     check(assert_type(s.astype("byte"), "pd.Series[int]"), pd.Series, np.byte)
-    check(assert_type(s.astype("int8"), "pd.Series[int]"), pd.Series, np.int8)
-    check(assert_type(s.astype("int16"), "pd.Series[int]"), pd.Series, np.int16)
-    check(assert_type(s.astype("int32"), "pd.Series[int]"), pd.Series, np.int32)
-    check(assert_type(s.astype("int64"), "pd.Series[int]"), pd.Series, np.int64)
-    check(assert_type(s.astype("intp"), "pd.Series[int]"), pd.Series, np.intp)
+    check(assert_type(s.astype("int8"), "pd.Series[int]"), pd.Series, np.byte)
+    check(assert_type(s.astype("b"), "pd.Series[int]"), pd.Series, np.byte)
+    # int16
+    check(assert_type(s.astype(np.short), "pd.Series[int]"), pd.Series, np.short)
+    check(assert_type(s.astype("short"), "pd.Series[int]"), pd.Series, np.short)
+    check(assert_type(s.astype("int16"), "pd.Series[int]"), pd.Series, np.short)
+    check(assert_type(s.astype("h"), "pd.Series[int]"), pd.Series, np.short)
+    # int32
+    check(assert_type(s.astype(np.intc), "pd.Series[int]"), pd.Series, np.intc)
+    check(assert_type(s.astype("intc"), "pd.Series[int]"), pd.Series, np.intc)
+    check(assert_type(s.astype("int32"), "pd.Series[int]"), pd.Series, np.intc)
+    check(assert_type(s.astype("i"), "pd.Series[int]"), pd.Series, np.intc)
+    # int64
+    check(assert_type(s.astype(np.int_), "pd.Series[int]"), pd.Series, np.int_)
+    check(assert_type(s.astype("int_"), "pd.Series[int]"), pd.Series, np.int_)
+    check(assert_type(s.astype("int64"), "pd.Series[int]"), pd.Series, np.int_)
+    check(assert_type(s.astype("intp"), "pd.Series[int]"), pd.Series, np.int_)
+    check(assert_type(s.astype("long"), "pd.Series[int]"), pd.Series, np.int_)
+    check(assert_type(s.astype("l"), "pd.Series[int]"), pd.Series, np.int_)
+    # int128
+    # NOTE: currently not supported by pandas
+    # check(assert_type(s.astype(np.longlong), "pd.Series[int]"), pd.Series, np.longlong)
+    # check(assert_type(s.astype("longlong"), "pd.Series[int]"), pd.Series, np.longlong)
+    # check(assert_type(s.astype("q"), "pd.Series[int]"), pd.Series, np.longlong)
+
     # Numpy unsigned integer types
+    # uint8
     check(assert_type(s.astype(np.ubyte), "pd.Series[int]"), pd.Series, np.ubyte)
-    check(assert_type(s.astype(np.uint8), "pd.Series[int]"), pd.Series, np.uint8)
-    check(assert_type(s.astype(np.uint16), "pd.Series[int]"), pd.Series, np.uint16)
-    check(assert_type(s.astype(np.uint32), "pd.Series[int]"), pd.Series, np.uint32)
-    check(assert_type(s.astype(np.uint64), "pd.Series[int]"), pd.Series, np.uint64)
-    check(assert_type(s.astype(np.uintp), "pd.Series[int]"), pd.Series, np.uintp)
     check(assert_type(s.astype("ubyte"), "pd.Series[int]"), pd.Series, np.ubyte)
-    check(assert_type(s.astype("uint8"), "pd.Series[int]"), pd.Series, np.uint8)
-    check(assert_type(s.astype("uint16"), "pd.Series[int]"), pd.Series, np.uint16)
-    check(assert_type(s.astype("uint32"), "pd.Series[int]"), pd.Series, np.uint32)
-    check(assert_type(s.astype("uint64"), "pd.Series[int]"), pd.Series, np.uint64)
-    check(assert_type(s.astype("uintp"), "pd.Series[int]"), pd.Series, np.uintp)
+    check(assert_type(s.astype("uint8"), "pd.Series[int]"), pd.Series, np.ubyte)
+    check(assert_type(s.astype("B"), "pd.Series[int]"), pd.Series, np.ubyte)
+    # uint16
+    check(assert_type(s.astype(np.ushort), "pd.Series[int]"), pd.Series, np.ushort)
+    check(assert_type(s.astype("ushort"), "pd.Series[int]"), pd.Series, np.ushort)
+    check(assert_type(s.astype("uint16"), "pd.Series[int]"), pd.Series, np.ushort)
+    check(assert_type(s.astype("H"), "pd.Series[int]"), pd.Series, np.ushort)
+    # uint32
+    check(assert_type(s.astype(np.uintc), "pd.Series[int]"), pd.Series, np.uintc)
+    check(assert_type(s.astype("uintc"), "pd.Series[int]"), pd.Series, np.uintc)
+    check(assert_type(s.astype("uint32"), "pd.Series[int]"), pd.Series, np.uintc)
+    check(assert_type(s.astype("I"), "pd.Series[int]"), pd.Series, np.uintc)
+    # uint64
+    check(assert_type(s.astype(np.uint), "pd.Series[int]"), pd.Series, np.uint)
+    check(assert_type(s.astype("uint"), "pd.Series[int]"), pd.Series, np.uint)
+    check(assert_type(s.astype("uint64"), "pd.Series[int]"), pd.Series, np.uint)
+    check(assert_type(s.astype("uintp"), "pd.Series[int]"), pd.Series, np.uint)
+    check(assert_type(s.astype("L"), "pd.Series[int]"), pd.Series, np.uint)
+
+    # pyarrow integer types
+    check(assert_type(s.astype("int8[pyarrow]"), "pd.Series[int]"), pd.Series, int)
+    check(assert_type(s.astype("int16[pyarrow]"), "pd.Series[int]"), pd.Series, int)
+    check(assert_type(s.astype("int32[pyarrow]"), "pd.Series[int]"), pd.Series, int)
+    check(assert_type(s.astype("int64[pyarrow]"), "pd.Series[int]"), pd.Series, int)
+    # pyarrow unsigned integer types
+    check(assert_type(s.astype("uint8[pyarrow]"), "pd.Series[int]"), pd.Series, int)
+    check(assert_type(s.astype("uint16[pyarrow]"), "pd.Series[int]"), pd.Series, int)
+    check(assert_type(s.astype("uint32[pyarrow]"), "pd.Series[int]"), pd.Series, int)
+    check(assert_type(s.astype("uint64[pyarrow]"), "pd.Series[int]"), pd.Series, int)
 
     # String types
-
     # Builtin str types
     check(assert_type(s.astype(str), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.astype("str"), "pd.Series[str]"), pd.Series, str)
     # Pandas nullable string types
     check(assert_type(s.astype(pd.StringDtype()), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.astype("string"), "pd.Series[str]"), pd.Series, str)
+    # Numpy string types
+    check(assert_type(s.astype(np.str_), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.astype("str_"), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.astype("unicode"), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.astype("U"), "pd.Series[str]"), pd.Series, str)
+    # pyarrow string types
+    check(assert_type(s.astype("string[pyarrow]"), "pd.Series[str]"), pd.Series, str)
 
     # Bytes types
-
     check(assert_type(s.astype(bytes), "pd.Series[bytes]"), pd.Series, bytes)
+    check(assert_type(s.astype("bytes"), "pd.Series[bytes]"), pd.Series, bytes)
+    # NumPy bytes types
+    check(assert_type(s.astype(np.bytes_), "pd.Series[bytes]"), pd.Series, bytes)
+    check(assert_type(s.astype("bytes_"), "pd.Series[bytes]"), pd.Series, bytes)
+    check(assert_type(s.astype("string_"), "pd.Series[bytes]"), pd.Series, bytes)
+    check(assert_type(s.astype("S"), "pd.Series[bytes]"), pd.Series, bytes)
+    # pyarrow bytes types
+    check(
+        assert_type(s.astype("binary[pyarrow]"), "pd.Series[bytes]"), pd.Series, bytes
+    )
 
     # Float types
-
     # Builtin float types
     check(assert_type(s.astype(float), "pd.Series[float]"), pd.Series, float)
     check(assert_type(s.astype("float"), "pd.Series[float]"), pd.Series, float)
@@ -1789,54 +1860,149 @@ def test_updated_astype() -> None:
     check(assert_type(s.astype("Float32"), "pd.Series[float]"), pd.Series, np.float32)
     check(assert_type(s.astype("Float64"), "pd.Series[float]"), pd.Series, np.float64)
     # Numpy float types
-    check(assert_type(s.astype(np.float16), "pd.Series[float]"), pd.Series, np.float16)
-    check(assert_type(s.astype(np.float32), "pd.Series[float]"), pd.Series, np.float32)
-    check(assert_type(s.astype(np.float64), "pd.Series[float]"), pd.Series, np.float64)
-    check(assert_type(s.astype("float16"), "pd.Series[float]"), pd.Series, np.float16)
-    check(assert_type(s.astype("float32"), "pd.Series[float]"), pd.Series, np.float32)
-    check(assert_type(s.astype("float64"), "pd.Series[float]"), pd.Series, np.float64)
-    check(assert_type(s.astype("float64"), "pd.Series[float]"), pd.Series, np.float64)
-    check(assert_type(s.astype("float64"), "pd.Series[float]"), pd.Series, np.float64)
-
-    # pyarrow
+    # float16
+    check(assert_type(s.astype(np.half), "pd.Series[float]"), pd.Series, np.half)
+    check(assert_type(s.astype("half"), "pd.Series[float]"), pd.Series, np.half)
+    check(assert_type(s.astype("float16"), "pd.Series[float]"), pd.Series, np.half)
+    check(assert_type(s.astype("e"), "pd.Series[float]"), pd.Series, np.half)
+    # float32
+    check(assert_type(s.astype(np.single), "pd.Series[float]"), pd.Series, np.single)
+    check(assert_type(s.astype("single"), "pd.Series[float]"), pd.Series, np.single)
+    check(assert_type(s.astype("float32"), "pd.Series[float]"), pd.Series, np.single)
+    check(assert_type(s.astype("f"), "pd.Series[float]"), pd.Series, np.single)
+    # float64
+    check(assert_type(s.astype(np.double), "pd.Series[float]"), pd.Series, np.double)
+    check(assert_type(s.astype("double"), "pd.Series[float]"), pd.Series, np.double)
+    check(assert_type(s.astype("float_"), "pd.Series[float]"), pd.Series, np.double)
+    check(assert_type(s.astype("float64"), "pd.Series[float]"), pd.Series, np.double)
+    check(assert_type(s.astype("d"), "pd.Series[float]"), pd.Series, np.double)
+    # float128
     check(
-        assert_type(s.astype("int64[pyarrow]"), "pd.Series[int]"),
+        assert_type(s.astype(np.longdouble), "pd.Series[float]"),
         pd.Series,
-        int,
+        np.longdouble,
     )
     check(
-        assert_type(s.astype("float[pyarrow]"), "pd.Series[float]"),
+        assert_type(s.astype("longdouble"), "pd.Series[float]"),
         pd.Series,
-        float,
+        np.longdouble,
+    )
+    check(
+        assert_type(s.astype("longfloat"), "pd.Series[float]"), pd.Series, np.longdouble
+    )
+    check(
+        assert_type(s.astype("float128"), "pd.Series[float]"), pd.Series, np.longdouble
+    )
+    check(assert_type(s.astype("g"), "pd.Series[float]"), pd.Series, np.longdouble)
+
+    # pyarrow
+    check(assert_type(s.astype("float[pyarrow]"), "pd.Series[float]"), pd.Series, float)
+    check(
+        assert_type(s.astype("double[pyarrow]"), "pd.Series[float]"), pd.Series, float
+    )
+    # check(assert_type(s.astype("float16[pyarrow]"), "pd.Series[float]"), pd.Series, float)
+    check(
+        assert_type(s.astype("float32[pyarrow]"), "pd.Series[float]"), pd.Series, float
+    )
+    check(
+        assert_type(s.astype("float64[pyarrow]"), "pd.Series[float]"), pd.Series, float
     )
 
     # Complex types
-
     # Builtin complex types
     check(assert_type(s.astype(complex), "pd.Series[complex]"), pd.Series, complex)
     check(assert_type(s.astype("complex"), "pd.Series[complex]"), pd.Series, complex)
     # Numpy complex types
+    # complex64
     check(
-        assert_type(s.astype(np.complex64), "pd.Series[complex]"),
+        assert_type(s.astype(np.csingle), "pd.Series[complex]"),
         pd.Series,
-        np.complex64,
-    )
-    check(
-        assert_type(s.astype(np.complex128), "pd.Series[complex]"),
-        pd.Series,
-        np.complex128,
+        np.csingle,
     )
     check(
         assert_type(s.astype("complex64"), "pd.Series[complex]"),
         pd.Series,
-        np.complex64,
+        np.csingle,
+    )
+    check(
+        assert_type(s.astype("F"), "pd.Series[complex]"),
+        pd.Series,
+        np.csingle,
+    )
+    check(
+        assert_type(s.astype("csingle"), "pd.Series[complex]"),
+        pd.Series,
+        np.csingle,
+    )
+    check(
+        assert_type(s.astype("singlecomplex"), "pd.Series[complex]"),
+        pd.Series,
+        np.csingle,
+    )
+    # complex128
+    check(
+        assert_type(s.astype(np.cdouble), "pd.Series[complex]"),
+        pd.Series,
+        np.cdouble,
     )
     check(
         assert_type(s.astype("complex128"), "pd.Series[complex]"),
         pd.Series,
-        np.complex128,
+        np.cdouble,
+    )
+    check(
+        assert_type(s.astype("D"), "pd.Series[complex]"),
+        pd.Series,
+        np.cdouble,
+    )
+    check(
+        assert_type(s.astype("cdouble"), "pd.Series[complex]"),
+        pd.Series,
+        np.cdouble,
+    )
+    check(
+        assert_type(s.astype("cfloat"), "pd.Series[complex]"),
+        pd.Series,
+        np.cdouble,
+    )
+    check(
+        assert_type(s.astype("complex_"), "pd.Series[complex]"),
+        pd.Series,
+        np.cdouble,
+    )
+    # complex 256
+    check(
+        assert_type(s.astype(np.clongdouble), "pd.Series[complex]"),
+        pd.Series,
+        np.clongdouble,
+    )
+    check(
+        assert_type(s.astype("complex256"), "pd.Series[complex]"),
+        pd.Series,
+        np.clongdouble,
+    )
+    check(
+        assert_type(s.astype("G"), "pd.Series[complex]"),
+        pd.Series,
+        np.clongdouble,
+    )
+    check(
+        assert_type(s.astype("clongdouble"), "pd.Series[complex]"),
+        pd.Series,
+        np.clongdouble,
+    )
+    check(
+        assert_type(s.astype("clongfloat"), "pd.Series[complex]"),
+        pd.Series,
+        np.clongdouble,
+    )
+    check(
+        assert_type(s.astype("longcomplex"), "pd.Series[complex]"),
+        pd.Series,
+        np.clongdouble,
     )
 
+    # Timedelta Types
     check(
         assert_type(s.astype("timedelta64[Y]"), TimedeltaSeries),
         pd.Series,
@@ -2017,6 +2183,29 @@ def test_updated_astype() -> None:
         assert_type(s.astype("timestamp[ns][pyarrow]"), TimestampSeries),
         pd.Series,
         datetime.datetime,
+    )
+
+    # Object types
+    check(
+        assert_type(s.astype(object), "pd.Series[Any]"),
+        pd.Series,
+        object,
+    )
+    check(
+        assert_type(s.astype("object"), "pd.Series[Any]"),
+        pd.Series,
+        object,
+    )
+    # Numpy object types
+    check(
+        assert_type(s.astype(np.object_), "pd.Series[Any]"),
+        pd.Series,
+        object,
+    )
+    check(
+        assert_type(s.astype("O"), "pd.Series[Any]"),
+        pd.Series,
+        object,
     )
 
     orseries = pd.Series([Decimal(x) for x in [1, 2, 3]])

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1703,10 +1703,13 @@ def test_updated_astype() -> None:
 
     # dynamically typed
     # NOTE: https://github.com/python/typing/issues/801#issuecomment-1646171898
+    check(
+        assert_type(s.astype(s.dtype), "pd.Series[Any]"), pd.Series, np.integer
+    )  # #747
+
     # enable in the future if Intersection and Not supported
     # string: str = "int"  # not Literal!
     # check(assert_type(s.astype(string), "pd.Series[Any]"), pd.Series, np.integer)
-    # check(assert_type(s.astype(s.dtype), "pd.Series[Any]"), pd.Series, np.integer)
     # check bad literal
     # s.astype("some nonsense")
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -2570,14 +2570,14 @@ def test_all_astype_args_tested() -> None:
     """Check that all relevant numpy type aliases are tested."""
     NUMPY_ALIASES: set[str] = {k for k in np.sctypeDict if isinstance(k, str)}
     EXCLUDED_ALIASES = {
-        "M",
-        "m",
-        "object0",
-        "M8",
         "datetime64",
+        "m",
         "m8",
         "timedelta64",
+        "M",
+        "M8",
         "object_",
+        "object0",
     }
     TESTED_ASTYPE_ARGS: list[tuple[Any, type]] = (
         ASTYPE_BOOL_ARGS

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1743,29 +1743,29 @@ ASTYPE_INT_ARGS: list[tuple[IntDtypeArg, type]] = [
     # numpy int8
     (np.byte, np.byte),
     ("byte", np.byte),
-    ("int8", np.byte),
     ("b", np.byte),
-    ("i1", np.byte),
+    ("int8", np.int8),
+    ("i1", np.int8),
     # numpy int16
     (np.short, np.short),
     ("short", np.short),
-    ("int16", np.short),
     ("h", np.short),
-    ("i2", np.short),
+    ("int16", np.int16),
+    ("i2", np.int16),
     # numpy int32
     (np.intc, np.intc),
     ("intc", np.intc),
-    ("int32", np.intc),
     ("i", np.intc),
-    ("i4", np.intc),
+    ("int32", np.int32),
+    ("i4", np.int32),
     # numpy int64
     (np.int_, np.int_),
     ("int_", np.int_),
     ("int0", np.int_),
-    ("int64", np.int_),
     ("long", np.int_),
     ("l", np.int_),
-    ("i8", np.int_),
+    ("int64", np.int64),
+    ("i8", np.int64),
     # numpy extended int
     (np.longlong, np.longlong),
     ("longlong", np.longlong),
@@ -1797,29 +1797,29 @@ ASTYPE_UINT_ARGS: list[tuple[UIntDtypeArg, type]] = [
     # numpy uint8
     (np.ubyte, np.ubyte),
     ("ubyte", np.ubyte),
-    ("uint8", np.ubyte),
     ("B", np.ubyte),
-    ("u1", np.ubyte),
+    ("uint8", np.uint8),
+    ("u1", np.uint8),
     # numpy uint16
     (np.ushort, np.ushort),
     ("ushort", np.ushort),
-    ("uint16", np.ushort),
     ("H", np.ushort),
-    ("u2", np.ushort),
+    ("uint16", np.uint16),
+    ("u2", np.uint16),
     # numpy uint32
     (np.uintc, np.uintc),
     ("uintc", np.uintc),
-    ("uint32", np.uintc),
     ("I", np.uintc),
-    ("u4", np.uintc),
+    ("uint32", np.uint32),
+    ("u4", np.uint32),
     # numpy uint64
     (np.uint, np.uint),
     ("uint", np.uint),
     ("uint0", np.uint),
-    ("uint64", np.uint),
     ("ulong", np.uint),
     ("L", np.uint),
-    ("u8", np.uint),
+    ("uint64", np.uint64),
+    ("u8", np.uint64),
     # numpy extended uint
     (np.ulonglong, np.ulonglong),
     ("ulonglong", np.ulonglong),
@@ -1848,29 +1848,30 @@ ASTYPE_FLOAT_ARGS: list[tuple[FloatDtypeArg, type]] = [
     # numpy float16
     (np.half, np.half),
     ("half", np.half),
-    ("float16", np.half),
     ("e", np.half),
-    ("f2", np.half),
+    ("float16", np.float16),
+    ("f2", np.float16),
     # numpy float32
     (np.single, np.single),
     ("single", np.single),
-    ("float32", np.single),
     ("f", np.single),
-    ("f4", np.single),
+    ("float32", np.float32),
+    ("f4", np.float32),
     # numpy float64
     (np.double, np.double),
     ("double", np.double),
     ("float_", np.double),
-    ("float64", np.double),
     ("d", np.double),
-    ("f8", np.double),
+    ("float64", np.float64),
+    ("f8", np.float64),
     # numpy float128
     (np.longdouble, np.longdouble),
     ("longdouble", np.longdouble),
     ("longfloat", np.longdouble),
-    ("float128", np.longdouble),
     ("g", np.longdouble),
     ("f16", np.longdouble),
+    ("float96", np.longdouble),  # NOTE: WINDOWS ONLY
+    ("float128", np.longdouble),  # NOTE: UNIX ONLY
     # pyarrow float32
     ("float32[pyarrow]", float),
     ("float[pyarrow]", float),
@@ -1887,25 +1888,26 @@ ASTYPE_COMPLEX_ARGS: list[tuple[ComplexDtypeArg, type]] = [
     (np.csingle, np.csingle),
     ("csingle", np.csingle),
     ("singlecomplex", np.csingle),
-    ("complex64", np.csingle),
     ("F", np.csingle),
-    ("c8", np.csingle),
+    ("complex64", np.complex64),
+    ("c8", np.complex64),
     # numpy complex128
     (np.cdouble, np.cdouble),
     ("cdouble", np.cdouble),
     ("cfloat", np.cdouble),
     ("complex_", np.cdouble),
-    ("complex128", np.cdouble),
     ("D", np.cdouble),
-    ("c16", np.cdouble),
+    ("complex128", np.complex128),
+    ("c16", np.complex128),
     # numpy complex256
     (np.clongdouble, np.clongdouble),
     ("clongdouble", np.clongdouble),
     ("clongfloat", np.clongdouble),
     ("longcomplex", np.clongdouble),
-    ("complex256", np.clongdouble),
     ("G", np.clongdouble),
     ("c32", np.clongdouble),
+    ("complex192", np.clongdouble),  # NOTE: WINDOWS ONLY
+    ("complex256", np.clongdouble),  # NOTE: UNIX ONLY
 ]
 
 
@@ -2232,6 +2234,10 @@ def test_astype_uint(cast_arg: IntDtypeArg, target_type: type) -> None:
 def test_astype_float(cast_arg: FloatDtypeArg, target_type: type) -> None:
     s = pd.Series([1, 2, 3])
 
+    if platform.system() != "Windows" and cast_arg == "float96":
+        with pytest.raises(TypeError):
+            s.astype(cast_arg)
+        pytest.skip("Unix does not support float96")
     if platform.system() == "Windows" and cast_arg == "float128":
         with pytest.raises(TypeError):
             s.astype(cast_arg)
@@ -2287,6 +2293,10 @@ def test_astype_float(cast_arg: FloatDtypeArg, target_type: type) -> None:
 def test_astype_complex(cast_arg: ComplexDtypeArg, target_type: type) -> None:
     s = pd.Series([1, 2, 3])
 
+    if platform.system() != "Windows" and cast_arg == "complex192":
+        with pytest.raises(TypeError):
+            s.astype(cast_arg)
+        pytest.skip("Unix does not support complex192")
     if platform.system() == "Windows" and cast_arg == "complex256":
         with pytest.raises(TypeError):
             s.astype(cast_arg)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -2512,7 +2512,7 @@ def test_astype_categorical(cast_arg: CategoryDtypeArg, target_type: type) -> No
 
 @pytest.mark.parametrize("cast_arg, target_type", ASTYPE_OBJECT_ARGS, ids=repr)
 def test_astype_object(cast_arg: ObjectDtypeArg, target_type: type) -> None:
-    s = pd.Series([1, 2, 3])
+    s = pd.Series([object(), 2, 3])
     check(s.astype(cast_arg), pd.Series, target_type)
 
     if TYPE_CHECKING:
@@ -2521,7 +2521,8 @@ def test_astype_object(cast_arg: ObjectDtypeArg, target_type: type) -> None:
         assert_type(s.astype("object"), "pd.Series[Any]")
         # numpy object
         assert_type(s.astype(np.object_), "pd.Series[Any]")
-        # "object_"  # NOTE: not assigned
+        # assert_type(s.astype("object_"), "pd.Series[Any]")  # NOTE: not assigned
+        # assert_type(s.astype("object0"), "pd.Series[Any]")  # NOTE: not assigned
         assert_type(s.astype("O"), "pd.Series[Any]")
 
 
@@ -2565,7 +2566,7 @@ def test_astype_other() -> None:
     # check(assert_type(s.astype(string), "pd.Series[Any]"), pd.Series, np.integer)
 
 
-def test_all_numpy_aliases_tested() -> None:
+def test_all_astype_args_tested() -> None:
     """Check that all relevant numpy type aliases are tested."""
     NUMPY_ALIASES: set[str] = {k for k in np.sctypeDict if isinstance(k, str)}
     EXCLUDED_ALIASES = {
@@ -2593,9 +2594,17 @@ def test_all_numpy_aliases_tested() -> None:
         + ASTYPE_VOID_ARGS  # noqa: W503
     )
 
-    TESTED_ALIASES = {arg for arg, _ in TESTED_ASTYPE_ARGS if isinstance(arg, str)}
-    UNTESTED = (NUMPY_ALIASES - TESTED_ALIASES) - EXCLUDED_ALIASES
-    assert not UNTESTED, f"following aliases were not tested! {UNTESTED}"
+    TESTED_ALIASES: set[str] = {
+        arg for arg, _ in TESTED_ASTYPE_ARGS if isinstance(arg, str)
+    }
+    UNTESTED_ALIASES = (NUMPY_ALIASES - TESTED_ALIASES) - EXCLUDED_ALIASES
+    assert not UNTESTED_ALIASES, f"{UNTESTED_ALIASES}"
+
+    NUMPY_TYPES: set[type] = set(np.sctypeDict.values())
+    EXCLUDED_TYPES: set[type] = {np.str_, np.object_, np.timedelta64, np.datetime64}
+    TESTED_TYPES: set[type] = {t for _, t in TESTED_ASTYPE_ARGS}
+    UNTESTED_TYPES = (NUMPY_TYPES - TESTED_TYPES) - EXCLUDED_TYPES
+    assert not UNTESTED_TYPES, f"{UNTESTED_TYPES}"
 
 
 def test_check_xs() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1697,8 +1697,12 @@ def test_updated_astype() -> None:
     s = pd.Series([3, 4, 5])
     s1 = pd.Series(True)
 
-    # Boolean types
+    # dynamically typed
+    string: str = "int"  # not Literal!
+    check(assert_type(s.astype(string), "pd.Series[Any]"), pd.Series, np.integer)
+    check(assert_type(s.astype(s.dtype), "pd.Series[Any]"), pd.Series, np.integer)
 
+    # Boolean types
     # Builtin bool types
     check(assert_type(s.astype(bool), "pd.Series[bool]"), pd.Series, np.bool_)
     check(assert_type(s.astype("bool"), "pd.Series[bool]"), pd.Series, np.bool_)
@@ -1791,6 +1795,20 @@ def test_updated_astype() -> None:
     check(assert_type(s.astype("float16"), "pd.Series[float]"), pd.Series, np.float16)
     check(assert_type(s.astype("float32"), "pd.Series[float]"), pd.Series, np.float32)
     check(assert_type(s.astype("float64"), "pd.Series[float]"), pd.Series, np.float64)
+    check(assert_type(s.astype("float64"), "pd.Series[float]"), pd.Series, np.float64)
+    check(assert_type(s.astype("float64"), "pd.Series[float]"), pd.Series, np.float64)
+
+    # pyarrow
+    check(
+        assert_type(s.astype("int64[pyarrow]"), "pd.Series[int]"),
+        pd.Series,
+        int,
+    )
+    check(
+        assert_type(s.astype("float[pyarrow]"), "pd.Series[float]"),
+        pd.Series,
+        float,
+    )
 
     # Complex types
 
@@ -1889,6 +1907,26 @@ def test_updated_astype() -> None:
         pd.Series,
         Timedelta,
     )
+    check(
+        assert_type(s.astype("duration[s][pyarrow]"), TimedeltaSeries),
+        pd.Series,
+        datetime.timedelta,
+    )
+    check(
+        assert_type(s.astype("duration[ms][pyarrow]"), TimedeltaSeries),
+        pd.Series,
+        datetime.timedelta,
+    )
+    check(
+        assert_type(s.astype("duration[us][pyarrow]"), TimedeltaSeries),
+        pd.Series,
+        datetime.timedelta,
+    )
+    check(
+        assert_type(s.astype("duration[ns][pyarrow]"), TimedeltaSeries),
+        pd.Series,
+        datetime.timedelta,
+    )
 
     check(
         assert_type(s.astype("datetime64[Y]"), TimestampSeries),
@@ -1959,6 +1997,26 @@ def test_updated_astype() -> None:
         assert_type(s.astype("datetime64[as]"), TimestampSeries),
         pd.Series,
         Timestamp,
+    )
+    check(
+        assert_type(s.astype("timestamp[s][pyarrow]"), TimestampSeries),
+        pd.Series,
+        datetime.datetime,
+    )
+    check(
+        assert_type(s.astype("timestamp[ms][pyarrow]"), TimestampSeries),
+        pd.Series,
+        datetime.datetime,
+    )
+    check(
+        assert_type(s.astype("timestamp[us][pyarrow]"), TimestampSeries),
+        pd.Series,
+        datetime.datetime,
+    )
+    check(
+        assert_type(s.astype("timestamp[ns][pyarrow]"), TimestampSeries),
+        pd.Series,
+        datetime.datetime,
     )
 
     orseries = pd.Series([Decimal(x) for x in [1, 2, 3]])

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1697,10 +1697,18 @@ def test_updated_astype() -> None:
     s = pd.Series([3, 4, 5])
     s1 = pd.Series(True)
 
+    # Test incorrect Literal
+    if TYPE_CHECKING_INVALID_USAGE:
+        s.astype("foobar")  # type: ignore[call-overload] # pyright: ignore[reportGeneralTypeIssues]
+
     # dynamically typed
-    string: str = "int"  # not Literal!
-    check(assert_type(s.astype(string), "pd.Series[Any]"), pd.Series, np.integer)
-    check(assert_type(s.astype(s.dtype), "pd.Series[Any]"), pd.Series, np.integer)
+    # NOTE: https://github.com/python/typing/issues/801#issuecomment-1646171898
+    # enable in the future if Intersection and Not supported
+    # string: str = "int"  # not Literal!
+    # check(assert_type(s.astype(string), "pd.Series[Any]"), pd.Series, np.integer)
+    # check(assert_type(s.astype(s.dtype), "pd.Series[Any]"), pd.Series, np.integer)
+    # check bad literal
+    # s.astype("some nonsense")
 
     # Boolean types
     # Builtin bool types

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1761,7 +1761,6 @@ ASTYPE_INT_ARGS: list[tuple[IntDtypeArg, type]] = [
     # numpy int64
     (np.int_, np.int_),
     ("int_", np.int_),
-    ("int0", np.int_),
     ("long", np.int_),
     ("l", np.int_),
     ("int64", np.int64),
@@ -1773,6 +1772,7 @@ ASTYPE_INT_ARGS: list[tuple[IntDtypeArg, type]] = [
     # numpy signed pointer  (platform dependent one of int[8,16,32,64])
     (np.intp, np.intp),
     ("intp", np.intp),
+    ("int0", np.intp),
     ("p", np.intp),
     # pyarrow integer types
     ("int8[pyarrow]", int),
@@ -1815,7 +1815,6 @@ ASTYPE_UINT_ARGS: list[tuple[UIntDtypeArg, type]] = [
     # numpy uint64
     (np.uint, np.uint),
     ("uint", np.uint),
-    ("uint0", np.uint),
     ("ulong", np.uint),
     ("L", np.uint),
     ("uint64", np.uint64),
@@ -1827,6 +1826,7 @@ ASTYPE_UINT_ARGS: list[tuple[UIntDtypeArg, type]] = [
     # numpy unsigned pointer  (platform dependent one of uint[8,16,32,64])
     (np.uintp, np.uintp),
     ("uintp", np.uintp),
+    ("uint0", np.uintp),
     ("P", np.uintp),
     # pyarrow unsigned integer types
     ("uint8[pyarrow]", int),
@@ -1870,7 +1870,7 @@ ASTYPE_FLOAT_ARGS: list[tuple[FloatDtypeArg, type]] = [
     ("longfloat", np.longdouble),
     ("g", np.longdouble),
     ("f16", np.longdouble),
-    ("float96", np.longdouble),  # NOTE: WINDOWS ONLY
+    # ("float96", np.longdouble),  # NOTE: WINDOWS ONLY
     ("float128", np.longdouble),  # NOTE: UNIX ONLY
     # pyarrow float32
     ("float32[pyarrow]", float),
@@ -1906,7 +1906,7 @@ ASTYPE_COMPLEX_ARGS: list[tuple[ComplexDtypeArg, type]] = [
     ("longcomplex", np.clongdouble),
     ("G", np.clongdouble),
     ("c32", np.clongdouble),
-    ("complex192", np.clongdouble),  # NOTE: WINDOWS ONLY
+    # ("complex192", np.clongdouble),  # NOTE: WINDOWS ONLY
     ("complex256", np.clongdouble),  # NOTE: UNIX ONLY
 ]
 
@@ -2234,11 +2234,7 @@ def test_astype_uint(cast_arg: IntDtypeArg, target_type: type) -> None:
 def test_astype_float(cast_arg: FloatDtypeArg, target_type: type) -> None:
     s = pd.Series([1, 2, 3])
 
-    if platform.system() != "Windows" and cast_arg == "float96":
-        with pytest.raises(TypeError):
-            s.astype(cast_arg)
-        pytest.skip("Unix does not support float96")
-    if platform.system() == "Windows" and cast_arg == "float128":
+    if platform.system() == "Windows" and cast_arg in ("f16", "float128"):
         with pytest.raises(TypeError):
             s.astype(cast_arg)
         pytest.skip("Windows does not support float128")
@@ -2293,11 +2289,7 @@ def test_astype_float(cast_arg: FloatDtypeArg, target_type: type) -> None:
 def test_astype_complex(cast_arg: ComplexDtypeArg, target_type: type) -> None:
     s = pd.Series([1, 2, 3])
 
-    if platform.system() != "Windows" and cast_arg == "complex192":
-        with pytest.raises(TypeError):
-            s.astype(cast_arg)
-        pytest.skip("Unix does not support complex192")
-    if platform.system() == "Windows" and cast_arg == "complex256":
+    if platform.system() == "Windows" and cast_arg in ("c32", "complex256"):
         with pytest.raises(TypeError):
             s.astype(cast_arg)
         pytest.skip("Windows does not support complex256")

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -2109,11 +2109,6 @@ def test_astype_bool(cast_arg: BooleanDtypeArg, target_type: type) -> None:
 def test_astype_int(cast_arg: IntDtypeArg, target_type: type) -> None:
     s = pd.Series([1, 2, 3])
 
-    if platform.system() == "Windows":
-        # Different behavior for uint32, uint64 and uintp on Windows
-        if cast_arg in ["uint32", "uint64", "uintp"]:
-            pass
-
     if cast_arg in (np.longlong, "longlong", "q"):
         pytest.skip(
             "longlong is bugged, for details, see"

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1870,7 +1870,7 @@ ASTYPE_FLOAT_ARGS: list[tuple[FloatDtypeArg, type]] = [
     ("longfloat", np.longdouble),
     ("g", np.longdouble),
     ("f16", np.longdouble),
-    # ("float96", np.longdouble),  # NOTE: WINDOWS ONLY
+    # ("float96", np.longdouble),  # NOTE: unsupported
     ("float128", np.longdouble),  # NOTE: UNIX ONLY
     # pyarrow float32
     ("float32[pyarrow]", float),
@@ -1906,7 +1906,7 @@ ASTYPE_COMPLEX_ARGS: list[tuple[ComplexDtypeArg, type]] = [
     ("longcomplex", np.clongdouble),
     ("G", np.clongdouble),
     ("c32", np.clongdouble),
-    # ("complex192", np.clongdouble),  # NOTE: WINDOWS ONLY
+    # ("complex192", np.clongdouble),  # NOTE: unsupported
     ("complex256", np.clongdouble),  # NOTE: UNIX ONLY
 ]
 

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -81,7 +81,7 @@ def test_types_init() -> None:
     pd.Series(1)
     pd.Series((1, 2, 3))
     pd.Series(np.array([1, 2, 3]))
-    pd.Series(data=[1, 2, 3, 4], name="pd.Series")
+    pd.Series(data=[1, 2, 3, 4], name="series")
     pd.Series(data=[1, 2, 3, 4], dtype=np.int8)
     pd.Series(data={"row1": [1, 2], "row2": [3, 4]})
     pd.Series(data=[1, 2, 3, 4], index=[4, 3, 2, 1], copy=True)
@@ -135,7 +135,7 @@ def test_types_select() -> None:
     s = pd.Series(data={"row1": 1, "row2": 2})
     with pytest_warns_bounded(
         FutureWarning,
-        "pd.Series.__getitem__ treating keys as positions is deprecated",
+        "Series.__getitem__ treating keys as positions is deprecated",
         lower="2.0.99",
     ):
         s[0]
@@ -268,7 +268,7 @@ def test_types_fillna() -> None:
     check(assert_type(s.fillna(0, axis="index"), pd.Series), pd.Series)
     with pytest_warns_bounded(
         FutureWarning,
-        "pd.Series.fillna with 'method' is deprecated",
+        "Series.fillna with 'method' is deprecated",
         lower="2.0.99",
     ):
         check(assert_type(s.fillna(method="backfill", axis=0), pd.Series), pd.Series)


### PR DESCRIPTION
- [x] Closes #733
- [x] Closes #747
- [x] Tests added: Please use `assert_type()` to assert the type of any return value


- pandas nullable `UInt` data types were missing
- numpy type code literals
- numpy alternative literals (half, short, double, etc.)
- pyarrow literals
- added `DtypeObj | _str` to final `astype` overload (resulting in `Series[Any]`)
- added few tests
- fixed random bug: `def __getattr__(self, name: str) -> S1` accidentally using `str` instead of `_str`.