### PR TITLE
Add `storage_options` to `read_html` (2.1.0)

### DIFF
--- a/pandas-stubs/io/html.pyi
+++ b/pandas-stubs/io/html.pyi
@@ -22,6 +22,7 @@ from pandas._typing import (
     HashableT4,
     HashableT5,
     ReadBuffer,
+    StorageOptions,
 )
 
 def read_html(
@@ -52,4 +53,5 @@ def read_html(
     displayed_only: bool = ...,
     extract_links: Literal["header", "footer", "body", "all"] | None = ...,
     dtype_backend: DtypeBackend | NoDefault = ...,
+    storage_options: StorageOptions = ...,
 ) -> list[DataFrame]: ...


### PR DESCRIPTION
The argument has been added to pandas 2.1.0 in https://github.com/pandas-dev/pandas/pull/52620.

https://pandas.pydata.org/pandas-docs/version/2.1/reference/api/pandas.read_html.html