### PR TITLE
'Fix' mypy-nightly

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -517,7 +517,7 @@ S1 = TypeVar(
     | datetime.datetime  # includes pd.Timestamp
     | datetime.timedelta  # includes pd.Timedelta
     | Period
-    | Interval[int | float | Timestamp | Timedelta]
+    | Interval
     | CategoricalDtype,
 )
 

--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -203,8 +203,7 @@ class Index(IndexOpsMixin[S1]):
     @overload
     def __new__(  # type: ignore[misc]
         cls,
-        data: Sequence[Interval[_OrderableT]]  # type: ignore[type-var]
-        | IndexOpsMixin[Interval[_OrderableT]],
+        data: Sequence[Interval[_OrderableT]] | IndexOpsMixin[Interval[_OrderableT]],
         *,
         dtype: Literal["Interval"] = ...,
         copy: bool = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -269,7 +269,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         copy: bool = ...,
     ) -> TimedeltaSeries: ...
     @overload
-    def __new__(
+    def __new__(  # type: ignore[misc]
         cls,
         data: IntervalIndex[Interval[_OrderableT]]
         | Interval[_OrderableT]
@@ -2134,6 +2134,6 @@ class OffsetSeries(Series):
     @overload
     def __radd__(self, other: BaseOffset) -> OffsetSeries: ...
 
-class IntervalSeries(Series, Generic[_OrderableT]):
+class IntervalSeries(Series[Interval[_OrderableT]], Generic[_OrderableT]):
     @property
     def array(self) -> IntervalArray: ...


### PR DESCRIPTION
When specifying the generic type of IntervalSeries, the current mypy also sees it as an error.