### PR TITLE
Use the new poetry dev dependency group

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ conda install poetry
 
 ```sh
 # or PyPI
-pip install poetry
+pip install 'poetry>=1.2'
 ```
 
 - Install the project dependencies

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,7 +1,7 @@
 ## Set Up Environment
 
 - Make sure you have `python >= 3.9` installed.
-- Install poetry: `pip install poetry`
+- Install poetry: `pip install 'poetry>=1.2'`
 - Install the project dependencies: `poetry update`
 - Enter the virtual environment: `poetry shell`
 - Run all tests: `poe test_all`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,4 +6,4 @@
 - Enter the virtual environment: `poetry shell`
 - Run all tests: `poe test_all`
 - Enable pre-commit:  `pre-commit install`
-- Do you want to add a new dependency? `poetry add --dev foo-pkg`
+- Do you want to add a new dependency? `poetry add foo-pkg --group dev`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ python = ">=3.9"
 types-pytz = ">= 2022.1.1"
 numpy = { version = ">=1.26.0", python = "<3.13" }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 mypy = "1.6.0"
 pandas = "2.1.1"
 pyarrow = ">=10.0.1"


### PR DESCRIPTION
The `*.dev-dependencies` section and the `--dev` flag of the `poetry add` command are deprecated. You will receive if you run:

```zsh
❯ poetry add --dev foo-pkg
The --dev option is deprecated, use the `--group dev` notation instead.
```

Instead, use groups (`*.group.dev.dependencies`):

```zsh
❯ poetry add foo-pkg --group dev
```

---

refs:
- https://python-poetry.org/docs/cli/#options-4
- https://python-poetry.org/docs/managing-dependencies/#dependency-groups