### PR TITLE
Fix: dataframe.loc int label could be warn

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -202,7 +202,7 @@ class _LocIndexerFrame(_LocIndexer):
     @overload
     def __setitem__(
         self,
-        idx: MaskType | StrLike | _IndexSliceTuple | list[ScalarT],
+        idx: MaskType | StrLike | _IndexSliceTuple | list[ScalarT] | IndexingInt,
         value: Scalar | NAType | NaTType | ArrayLike | Series | DataFrame | list | None,
     ) -> None: ...
     @overload

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2290,6 +2290,16 @@ def test_loc_set() -> None:
     df.loc["a"] = [3, 4]
 
 
+def test_loc_int_set() -> None:
+    df = pd.DataFrame({1: [1, 2], 2: [3, 4]})
+    df.loc[1] = [3, 4]
+    df.loc[np.int_(1)] = pd.Series([1, 2])
+    df.loc[np.uint(1)] = pd.Series([1, 2])
+    df.loc[np.int8(1)] = pd.Series([1, 2])
+    df.loc[np.int32(1)] = [2, 3]
+    df.loc[np.uint64(1)] = [2, 3]
+
+
 def test_loclist() -> None:
     # GH 189
     df = pd.DataFrame({1: [1, 2], None: 5}, columns=pd.Index([1, None], dtype=object))


### PR DESCRIPTION
According to [the pandas document](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.loc.html)
> A single label, e.g. 5 or 'a', (note that 5 is interpreted as a label of the index, and never as an integer position along the index).

dataframe.loc can accept int label, but for the previous stubs,`df.loc[1]` or similar codes would be warn.