### PR TITLE
pin tables to 3.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ pre-commit = ">=2.19.0"
 black = ">=23.3.0"
 isort = ">=5.12.0"
 openpyxl = ">=3.0.10"
-tables = { version = ">=3.8.0",  python = "<4"}  # 3.8.0 depends on blosc2 which caps python to <4
+tables = { version = "==3.9.1",  python = "<4"}  # 3.8.0 depends on blosc2 which caps python to <4
 lxml = ">=4.9.1"
 pyreadstat = ">=1.2.0"
 xlrd = ">=2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pre-commit = ">=2.19.0"
 black = ">=23.3.0"
 isort = ">=5.12.0"
 openpyxl = ">=3.0.10"
+# for tables, MacOS gives random CI failures on 3.9.2
 tables = { version = "==3.9.1",  python = "<4"}  # 3.8.0 depends on blosc2 which caps python to <4
 lxml = ">=4.9.1"
 pyreadstat = ">=1.2.0"


### PR DESCRIPTION
I am guessing that the MacOS failures in testing are due to the version of pytables.  Let's see if this fixes it.


