### PR TITLE
OffsetSeries inherits from Series[BaseOffset]

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -32,6 +32,7 @@ from typing_extensions import TypeAlias
 
 from pandas._libs.interval import Interval
 from pandas._libs.tslibs import (
+    BaseOffset,
     Period,
     Timedelta,
     Timestamp,
@@ -527,7 +528,8 @@ S1 = TypeVar(
     | datetime.timedelta  # includes pd.Timedelta
     | Period
     | Interval
-    | CategoricalDtype,
+    | CategoricalDtype
+    | BaseOffset,
 )
 
 IndexingInt: TypeAlias = (

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -2127,7 +2127,7 @@ class PeriodSeries(Series[Period]):
     def dt(self) -> PeriodProperties: ...  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride]
     def __sub__(self, other: PeriodSeries) -> OffsetSeries: ...  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride]
 
-class OffsetSeries(Series):
+class OffsetSeries(Series[BaseOffset]):
     @overload  # type: ignore[override]
     def __radd__(self, other: Period) -> PeriodSeries: ...
     @overload


### PR DESCRIPTION
I honestly would prefer to remove `OffsetSeries` and replace it with `Series[Any]` (personally, I'm not keen on maintaining operators for Series as there is no generic solution #820). If we want to keep this class, it would make sense to let it inherit from `Series[BaseOffset]` instead of `Series[Any/Unknown]`