### PR TITLE
fix concat for axis=0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
     autofix_prs: false
 repos:
 -   repo: https://github.com/python/black
-    rev: 24.1.1
+    rev: 24.2.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/isort
@@ -11,7 +11,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.3.0
     hooks:
     -   id: ruff
         args: [

--- a/pandas-stubs/core/reshape/concat.pyi
+++ b/pandas-stubs/core/reshape/concat.pyi
@@ -16,7 +16,6 @@ from typing_extensions import Never
 
 from pandas._typing import (
     Axis,
-    AxisColumn,
     AxisIndex,
     HashableT1,
     HashableT2,
@@ -53,7 +52,7 @@ def concat(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappin
     copy: bool = ...,
 ) -> DataFrame: ...
 @overload
-def concat(
+def concat(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
     objs: Iterable[Series | None] | Mapping[HashableT1, Series | None],
     *,
     axis: AxisIndex = ...,
@@ -73,7 +72,7 @@ def concat(
         | Mapping[HashableT1, Series | DataFrame | None]
     ),
     *,
-    axis: AxisColumn,
+    axis: Axis = ...,
     join: Literal["inner", "outer"] = ...,
     ignore_index: bool = ...,
     keys: Iterable[HashableT2] = ...,

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -62,11 +62,16 @@ def test_types_concat_none() -> None:
     check(
         assert_type(pd.concat([None, series, df], axis=1), pd.DataFrame), pd.DataFrame
     )
+    check(assert_type(pd.concat([None, series, df]), pd.DataFrame), pd.DataFrame)
 
     check(assert_type(pd.concat({"a": None, "b": series}), pd.Series), pd.Series)
     check(assert_type(pd.concat({"a": None, "b": df}), pd.DataFrame), pd.DataFrame)
     check(
         assert_type(pd.concat({"a": None, "b": series, "c": df}, axis=1), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(pd.concat({"a": None, "b": series, "c": df}), pd.DataFrame),
         pd.DataFrame,
     )
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -82,8 +82,8 @@ def test_types_concat_none() -> None:
 
 
 def test_types_concat() -> None:
-    s: pd.Series = pd.Series([0, 1, -10])
-    s2: pd.Series = pd.Series([7, -5, 10])
+    s = pd.Series([0, 1, -10])
+    s2 = pd.Series([7, -5, 10])
 
     check(assert_type(pd.concat([s, s2]), pd.Series), pd.Series)
     check(assert_type(pd.concat([s, s2], axis=1), pd.DataFrame), pd.DataFrame)
@@ -170,6 +170,9 @@ def test_types_concat() -> None:
     )
     adict = {"a": df, 2: df2}
     check(assert_type(pd.concat(adict), pd.DataFrame), pd.DataFrame)
+
+    data: pd.DataFrame | pd.Series = pd.Series()
+    check(assert_type(pd.concat([pd.DataFrame(), data]), pd.DataFrame), pd.DataFrame)
 
 
 def test_concat_args() -> None:


### PR DESCRIPTION
closes #879

Works on pyright - mypy behaves weirdly (the 3rd overload is clearly the first matching overload). @Dr-Irv, feel free to change this PR - not sure whether I will have time to debug the mypy issue before the weekend.