### PR TITLE
Fixed TYP of values argument of the pandas.DataFrame.pivot_table 

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1125,7 +1125,7 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> DataFrame: ...
     def pivot_table(
         self,
-        values: _str | None = ...,
+        values: _str | None | Sequence[_str] = ...,
         index: _str | Grouper | Sequence | None = ...,
         columns: _str | Grouper | Sequence | None = ...,
         aggfunc=...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -943,11 +943,12 @@ def test_types_pivot_table() -> None:
     )
     check(
         assert_type(
-            df.pivot_table(index="col1", columns="col3", values=["col2", "col4"]), pd.DataFrame,
+            df.pivot_table(index="col1", columns="col3", values=["col2", "col4"]),
+            pd.DataFrame,
         ),
         pd.DataFrame,
     )
- 
+
 
 def test_types_groupby() -> None:
     df = pd.DataFrame(data={"col1": [1, 1, 2], "col2": [3, 4, 5], "col3": [0, 1, 0]})

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -943,7 +943,7 @@ def test_types_pivot_table() -> None:
     )
     check(
         assert_type(
-            df.pivot_table(index="col2", columns="col4", values=["col1", "col3"]), pd.DataFrame,
+            df.pivot_table(index="col1", columns="col3", values=["col2", "col4"]), pd.DataFrame,
         ),
         pd.DataFrame,
     )

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -932,6 +932,23 @@ def test_types_pivot() -> None:
     )
 
 
+def test_types_pivot_table() -> None:
+    df = pd.DataFrame(
+        data={
+            "col1": ["first", "second", "third", "fourth"],
+            "col2": [50, 70, 56, 111],
+            "col3": ["A", "B", "C", "D"],
+            "col4": [100, 102, 500, 600],
+        }
+    )
+    check(
+        assert_type(
+            df.pivot_table(index="col2", columns="col4", values=["col1", "col3"]), pd.DataFrame,
+        ),
+        pd.DataFrame,
+    )
+ 
+
 def test_types_groupby() -> None:
     df = pd.DataFrame(data={"col1": [1, 1, 2], "col2": [3, 4, 5], "col3": [0, 1, 0]})
     df.index.name = "ind"


### PR DESCRIPTION
 This pull request addresses _issue #885_ by modifying the _pivot_table_ stub definition in _frame.pyi_ to allow lists of strings as the values argument. Previously, the stub definition only supported single strings or None for values.

**Changes Introduced:**
Updated the values argument type in the _pivot_table_ stub definition to include _Sequence[_str]_. This allows lists of strings to be used for values.


**Test Case:**
No test case added as there was already an existing test case in the file test_frame.py on line 922 : 
check(
```
assert_type(
df.pivot(index="col1", columns="col3", values=["col2", "col4"]),
pd.DataFrame,
),
pd.DataFrame,
)
```
Which already test the addressed issue and updated fix.

[ ] Closes #885