### PR TITLE
BUG/TST: fixed series apply frozenset error and created test case

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -939,7 +939,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def apply(
         self,
-        func: Callable[..., Scalar | Sequence | set | Mapping | NAType | None],
+        func: Callable[..., Scalar | Sequence | set | Mapping | NAType | frozenset | None],
         convertDType: _bool = ...,
         args: tuple = ...,
         **kwds,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -939,7 +939,9 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def apply(
         self,
-        func: Callable[..., Scalar | Sequence | set | Mapping | NAType | frozenset | None],
+        func: Callable[
+            ..., Scalar | Sequence | set | Mapping | NAType | frozenset | None
+        ],
         convertDType: _bool = ...,
         args: tuple = ...,
         **kwds,

--- a/tests/test_frozenset.py
+++ b/tests/test_frozenset.py
@@ -1,8 +1,0 @@
-import pandas as pd
-
-s = pd.Series(["A", "B", "AB"])
-
-s.apply(tuple)
-s.apply(list)
-s.apply(set)
-s.apply(frozenset)

--- a/tests/test_frozenset.py
+++ b/tests/test_frozenset.py
@@ -1,0 +1,8 @@
+import pandas as pd
+
+s = pd.Series(["A", "B", "AB"])
+
+s.apply(tuple)
+s.apply(list)
+s.apply(set)
+s.apply(frozenset)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3069,3 +3069,11 @@ def test_pipe() -> None:
             ),
             1,
         )
+
+def test_series_apply() -> None:
+    s = pd.Series(["A", "B", "AB"])
+    
+    s.apply(tuple)
+    s.apply(list)
+    s.apply(set)
+    s.apply(frozenset)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3072,7 +3072,11 @@ def test_pipe() -> None:
 
 def test_series_apply() -> None:
     s = pd.Series(["A", "B", "AB"])
-    s.apply(tuple)
-    s.apply(list)
-    s.apply(set)
-    s.apply(frozenset)
+
+    check(assert_type(s.apply(tuple), pd.Series), pd.Series, tuple)
+
+    check(assert_type(s.apply(list), pd.Series), pd.Series, list)
+
+    check(assert_type(s.apply(set), pd.Series), pd.Series, set)
+    
+    check(assert_type(s.apply(frozenset), pd.Series), pd.Series, frozenset)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3073,11 +3073,7 @@ def test_pipe() -> None:
 
 def test_series_apply() -> None:
     s = pd.Series(["A", "B", "AB"])
-    s.apply(tuple)
-    check(assert_type(s, "pd.Series[str]"), pd.Series, tuple)
-    s.apply(list)
-    check(assert_type(s, "pd.Series[str]"), pd.Series, list)
-    s.apply(set)
-    check(assert_type(s, "pd.Series[str]"), pd.Series, set)
-    s.apply(frozenset)
-    check(assert_type(s, "pd.Series[str]"), pd.Series, frozenset)
+    check(assert_type(s.apply(tuple), "pd.Series[Any]"), pd.Series)
+    check(assert_type(s.apply(list), "pd.Series[Any]"), pd.Series)
+    check(assert_type(s.apply(set), "pd.Series[Any]"), pd.Series)
+    check(assert_type(s.apply(frozenset), "pd.Series[Any]"), pd.Series)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3072,7 +3072,6 @@ def test_pipe() -> None:
 
 def test_series_apply() -> None:
     s = pd.Series(["A", "B", "AB"])
-    
     s.apply(tuple)
     s.apply(list)
     s.apply(set)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3070,13 +3070,14 @@ def test_pipe() -> None:
             1,
         )
 
+
 def test_series_apply() -> None:
     s = pd.Series(["A", "B", "AB"])
-
-    check(assert_type(s.apply(tuple), pd.Series), pd.Series, tuple)
-
-    check(assert_type(s.apply(list), pd.Series), pd.Series, list)
-
-    check(assert_type(s.apply(set), pd.Series), pd.Series, set)
-    
-    check(assert_type(s.apply(frozenset), pd.Series), pd.Series, frozenset)
+    s.apply(tuple)
+    check(assert_type(s, "pd.Series[str]"), pd.Series, tuple)
+    s.apply(list)
+    check(assert_type(s, "pd.Series[str]"), pd.Series, list)
+    s.apply(set)
+    check(assert_type(s, "pd.Series[str]"), pd.Series, set)
+    s.apply(frozenset)
+    check(assert_type(s, "pd.Series[str]"), pd.Series, frozenset)


### PR DESCRIPTION
- [x] Closes #871
- [x] Tests Added and Passed: test_frozenset.py 
- [x] All [code checks passed]

When trying to use series.Apply() on "frozenset", it raises the following error:

error: Argument 1 to "apply" of "Series" has incompatible type "type[frozenset[Any]]"; expected "Callable[..., str | bytes | date | datetime | timedelta | datetime64 | timedelta64 | bool | int | float | Timestamp | Timedelta | complex | Sequence[Any] | set[Any] | Mapping[Any, Any] | NAType | None]"  [arg-type]

Fixed this by adding "frozenset" to the enumerated Callable output types.
Created a test case by calling series.Apply(frozenset) and running "poe mypy".