### PR TITLE
Add callable condition type in Series.mask, DataFrame.mask

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1833,7 +1833,13 @@ class DataFrame(NDFrame, OpsMixin):
     def lt(self, other, axis: Axis = ..., level: Level | None = ...) -> DataFrame: ...
     def mask(
         self,
-        cond: Series | DataFrame | np.ndarray,
+        cond: (
+            Series
+            | DataFrame
+            | np.ndarray
+            | Callable[[DataFrame], DataFrame]
+            | Callable[[Any], _bool]
+        ),
         other=...,
         *,
         inplace: _bool = ...,

--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -199,7 +199,7 @@ class DataFrameGroupBy(GroupBy[DataFrame], Generic[ByT]):
         **kwargs,
     ) -> DataFrame: ...
     @overload
-    def apply(  # pyright: ignore[reportOverlappingOverload,reportIncompatibleMethodOverride]
+    def apply(  # pyright: ignore[reportOverlappingOverload]
         self,
         func: Callable[[Iterable], float],
         *args,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1433,7 +1433,13 @@ class Series(IndexOpsMixin[S1], NDFrame):
     ) -> Series[S1]: ...
     def mask(
         self,
-        cond: MaskType,
+        cond: (
+            Series[S1]
+            | Series[_bool]
+            | np.ndarray
+            | Callable[[Series[S1]], Series[bool]]
+            | Callable[[S1], bool]
+        ),
         other: Scalar | Series[S1] | DataFrame | Callable | NAType | None = ...,
         *,
         inplace: _bool = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2755,6 +2755,15 @@ def test_where() -> None:
     check(assert_type(df.where(cond3), pd.DataFrame), pd.DataFrame)
 
 
+def test_mask() -> None:
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    def cond1(x: int) -> bool:
+        return x % 2 == 0
+
+    check(assert_type(df.mask(cond1), pd.DataFrame), pd.DataFrame)
+
+
 def test_setitem_loc() -> None:
     # GH 254
     df = pd.DataFrame.from_dict(

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -2823,6 +2823,12 @@ def test_types_mask() -> None:
     # Test case with a boolean condition and a scalar value
     check(assert_type(s.mask(s > 3, 10), "pd.Series[int]"), pd.Series, np.integer)
 
+    def cond(x: int) -> bool:
+        return x % 2 == 0
+
+    # Test case with a callable condition and a scalar value
+    check(assert_type(s.mask(cond, 10), "pd.Series[int]"), pd.Series, np.integer)
+
     # Test case with a boolean condition and a callable
     def double(x):
         return x * 2


### PR DESCRIPTION
- [x] Closes #917
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

I played around a bit and found that `Series.mask()` actually had the same issue as `DataFrame.mask()`:

```python
import pandas as pd
s = pd.Series([1]).mask(cond=lambda x: x % 2 == 1, other=2)
print(s)
# 0    2
# dtype: int64
```

```
(.venv) ➜  test python -m mypy test.py
test.py:2: error: Argument "cond" to "mask" of "Series" has incompatible type "Callable[[Any], Any]"; expected "Series[bool] | ndarray[Any, dtype[bool_]] | list[bool]"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```

I tried to fix both in this PR. The new `cond` types match those used in [`Series.where`](https://github.com/pandas-dev/pandas-stubs/blob/e63d1cbf5087cd7cd934db1c84184cb2caacbac9/pandas-stubs/core/series.pyi#L1420-L1426) and [`DataFrame.where`](https://github.com/pandas-dev/pandas-stubs/blob/e63d1cbf5087cd7cd934db1c84184cb2caacbac9/pandas-stubs/core/frame.pyi#L2309-L2315). Let me know if it's desirable to factor the `cond` type out by moving it to `_typing.pyi`.