### PR TITLE
Add type parameters to generics in isna and notna

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -53,7 +53,7 @@ from pandas.io.formats.format import EngFormatter
 # where it is the only acceptable type.
 Incomplete: TypeAlias = Any
 
-ArrayLike: TypeAlias = ExtensionArray | np.ndarray
+ArrayLike: TypeAlias = ExtensionArray | np.ndarray[Any, Any]
 AnyArrayLike: TypeAlias = Index | Series | np.ndarray
 PythonScalar: TypeAlias = str | bool | complex
 DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", Period, Timestamp, Timedelta)

--- a/pandas-stubs/core/dtypes/missing.pyi
+++ b/pandas-stubs/core/dtypes/missing.pyi
@@ -10,12 +10,12 @@ from pandas import (
     Index,
     Series,
 )
-from pandas.core.arrays.base import ExtensionArray
 from typing_extensions import TypeGuard
 
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs import NaTType
 from pandas._typing import (
+    ArrayLike,
     Scalar,
     ScalarT,
 )
@@ -28,9 +28,7 @@ def isna(obj: DataFrame) -> DataFrame: ...
 @overload
 def isna(obj: Series[Any]) -> Series[bool]: ...
 @overload
-def isna(
-    obj: Index[Any] | list[Any] | ExtensionArray | np.ndarray[Any, Any]
-) -> npt.NDArray[np.bool_]: ...
+def isna(obj: Index[Any] | list[Any] | ArrayLike) -> npt.NDArray[np.bool_]: ...
 @overload
 def isna(
     obj: Scalar | NaTType | NAType | None,
@@ -43,9 +41,7 @@ def notna(obj: DataFrame) -> DataFrame: ...
 @overload
 def notna(obj: Series[Any]) -> Series[bool]: ...
 @overload
-def notna(
-    obj: Index[Any] | list[Any] | ExtensionArray | np.ndarray[Any, Any]
-) -> npt.NDArray[np.bool_]: ...
+def notna(obj: Index[Any] | list[Any] | ArrayLike) -> npt.NDArray[np.bool_]: ...
 @overload
 def notna(obj: ScalarT | NaTType | NAType | None) -> TypeGuard[ScalarT]: ...
 

--- a/pandas-stubs/core/dtypes/missing.pyi
+++ b/pandas-stubs/core/dtypes/missing.pyi
@@ -1,4 +1,7 @@
-from typing import overload
+from typing import (
+    Any,
+    overload,
+)
 
 import numpy as np
 from numpy import typing as npt
@@ -7,12 +10,12 @@ from pandas import (
     Index,
     Series,
 )
+from pandas.core.arrays.base import ExtensionArray
 from typing_extensions import TypeGuard
 
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs import NaTType
 from pandas._typing import (
-    ArrayLike,
     Scalar,
     ScalarT,
 )
@@ -23,9 +26,11 @@ isneginf_scalar = ...
 @overload
 def isna(obj: DataFrame) -> DataFrame: ...
 @overload
-def isna(obj: Series) -> Series[bool]: ...
+def isna(obj: Series[Any]) -> Series[bool]: ...
 @overload
-def isna(obj: Index | list | ArrayLike) -> npt.NDArray[np.bool_]: ...
+def isna(
+    obj: Index[Any] | list[Any] | ExtensionArray | np.ndarray[Any, Any]
+) -> npt.NDArray[np.bool_]: ...
 @overload
 def isna(
     obj: Scalar | NaTType | NAType | None,
@@ -36,9 +41,11 @@ isnull = isna
 @overload
 def notna(obj: DataFrame) -> DataFrame: ...
 @overload
-def notna(obj: Series) -> Series[bool]: ...
+def notna(obj: Series[Any]) -> Series[bool]: ...
 @overload
-def notna(obj: Index | list | ArrayLike) -> npt.NDArray[np.bool_]: ...
+def notna(
+    obj: Index[Any] | list[Any] | ExtensionArray | np.ndarray[Any, Any]
+) -> npt.NDArray[np.bool_]: ...
 @overload
 def notna(obj: ScalarT | NaTType | NAType | None) -> TypeGuard[ScalarT]: ...
 


### PR DESCRIPTION
- [x] Closes https://github.com/pandas-dev/pandas-stubs/issues/944
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

This is to fix issues with pyright strict mode which complains about partially unknown types.

I verified that [this](https://github.com/pandas-dev/pandas-stubs/blob/main/tests/test_pandas.py#L319) test fails in strict mode without these changes and passes with them.

There are still some points i am unsure about:
 - Whether to use `Any` or an (unbounded?) `TypeVar` (or maybe i should use `Incomplete`?)
 - I had to split the `ArrayLike` annotation into its components to add the type parameters to the ndarray. While i did also change it in the `pandas-stubs/_typing.pyi`, it was still importing them from the actual pandas.
