### PR TITLE
Add type parameters for types used in df.merge

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -54,7 +54,7 @@ from pandas.io.formats.format import EngFormatter
 Incomplete: TypeAlias = Any
 
 ArrayLike: TypeAlias = ExtensionArray | np.ndarray[Any, Any]
-AnyArrayLike: TypeAlias = Index | Series | np.ndarray
+AnyArrayLike: TypeAlias = Index[Any] | Series[Any] | np.ndarray[Any, Any]
 PythonScalar: TypeAlias = str | bool | complex
 DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", Period, Timestamp, Timedelta)
 PandasScalar: TypeAlias = bytes | datetime.date | datetime.datetime | datetime.timedelta

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1403,7 +1403,7 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> DataFrame: ...
     def merge(
         self,
-        right: DataFrame | Series,
+        right: DataFrame | Series[Any],
         how: MergeHow = ...,
         on: IndexLabel | AnyArrayLike | None = ...,
         left_on: IndexLabel | AnyArrayLike | None = ...,


### PR DESCRIPTION
- [x] Closes https://github.com/pandas-dev/pandas-stubs/issues/946
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

Closes: https://github.com/pandas-dev/pandas-stubs/issues/946

I verified that the df.merge parts of [this](https://github.com/pandas-dev/pandas-stubs/blob/main/tests/test_merge.py#L17) test fail in pyright strict mode without these changes, and do not after these changes.

