### PR TITLE
 Setup optional CI jobs using pyright strict mode

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - strict-ci
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - strict-ci
   workflow_dispatch:
 
 jobs:
@@ -38,3 +39,19 @@ jobs:
 
     - name: Run mypy tests with mypy nightly
       run: poetry run poe mypy --mypy_nightly
+
+  pyright_strict:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install project dependencies
+      uses: ./.github/setup
+      with:
+        os: ubuntu-latest
+        python-version: '3.11'
+
+    - name: Run pyright tests with full strict mode
+      run: poetry run poe pyright_strict

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -18,4 +18,5 @@ The following tests are **optional**. Some of them are run by the CI but it is o
 
 - Run pytest against pandas nightly: `poe pytest --nightly`
 - Use mypy nightly to validate the annotations: `poe mypy --mypy_nightly`
+- Use pyright in full strict mode: `poe pyright_strict`
 - Run stubtest to compare the installed pandas-stubs against pandas (this will fail): `poe stubtest`. If you have created an allowlist to ignore certain errors: `poe stubtest path_to_the_allow_list`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,10 @@ script = "scripts.test:test(dist=True, type_checker='mypy')"
 help = "Run pyright on 'tests' (using the local stubs) and on the local stubs"
 script = "scripts.test.run:pyright_src"
 
+[tool.poe.tasks.pyright_strict]
+help = "Run pyright on 'tests' (using the local stubs) and on the local stubs in full strict mode"
+script = "scripts.test.run:pyright_src_strict"
+
 [tool.poe.tasks.pyright_dist]
 help = "Run pyright on 'tests' using the installed stubs"
 script = "scripts.test:test(dist=True, type_checker='pyright')"

--- a/pyrightconfig-strict.json
+++ b/pyrightconfig-strict.json
@@ -2,6 +2,7 @@
   "typeCheckingMode": "strict",
   "stubPath": ".",
   "include": ["tests", "pandas-stubs"],
+  "enableTypeIgnoreComments": false,
   "reportUnnecessaryTypeIgnoreComment": true,
   "reportMissingModuleSource": true,
   "useLibraryCodeForTypes": false

--- a/pyrightconfig-strict.json
+++ b/pyrightconfig-strict.json
@@ -1,0 +1,8 @@
+{
+  "typeCheckingMode": "strict",
+  "stubPath": ".",
+  "include": ["tests", "pandas-stubs"],
+  "reportUnnecessaryTypeIgnoreComment": true,
+  "reportMissingModuleSource": true,
+  "useLibraryCodeForTypes": false
+}

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -9,6 +9,10 @@ pyright_src = Step(
     name="Run pyright on 'tests' (using the local stubs) and on the local stubs",
     run=run.pyright_src,
 )
+pyright_src_strict = Step(
+    name="Run pyright on 'tests' (using the local stubs) and on the local stubs in full strict mode",
+    run=run.pyright_src_strict,
+)
 pytest = Step(name="Run pytest", run=run.pytest)
 style = Step(name="Run pre-commit", run=run.style)
 build_dist = Step(name="Build pandas-stubs", run=run.build_dist)

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -15,6 +15,11 @@ def pyright_src():
     subprocess.run(cmd, check=True)
 
 
+def pyright_src_strict():
+    cmd = ["pyright", "--project", "pyrightconfig-strict.json"]
+    subprocess.run(cmd, check=True)
+
+
 def pytest():
     cmd = ["pytest", "--cache-clear"]
     subprocess.run(cmd, check=True)


### PR DESCRIPTION
Setup a optional CI job that uses full pyright strict mode by taking its settings from `pyrightconfig-strict.json`.

Addresses the other points made here: https://github.com/pandas-dev/pandas-stubs/issues/952
