### PR TITLE
Switch to_timedelta argument type from list to Sequence

### DIFF
--- a/pandas-stubs/core/tools/timedeltas.pyi
+++ b/pandas-stubs/core/tools/timedeltas.pyi
@@ -32,7 +32,6 @@ def to_timedelta(
 def to_timedelta(
     arg: (
         Sequence[str | float | timedelta]
-        | list[str | float | timedelta]
         | tuple[str | float | timedelta, ...]
         | range
         | ArrayLike

--- a/pandas-stubs/core/tools/timedeltas.pyi
+++ b/pandas-stubs/core/tools/timedeltas.pyi
@@ -31,7 +31,7 @@ def to_timedelta(
 @overload
 def to_timedelta(
     arg: (
-        Sequence[float | timedelta]
+        Sequence[str | float | timedelta]
         | list[str | float | timedelta]
         | tuple[str | float | timedelta, ...]
         | range

--- a/pandas-stubs/core/tools/timedeltas.pyi
+++ b/pandas-stubs/core/tools/timedeltas.pyi
@@ -32,7 +32,7 @@ def to_timedelta(
 @overload
 def to_timedelta(
     arg: (
-        SequenceNotStr[str]
+        SequenceNotStr
         | Sequence[float | timedelta]
         | tuple[str | float | timedelta, ...]
         | range

--- a/pandas-stubs/core/tools/timedeltas.pyi
+++ b/pandas-stubs/core/tools/timedeltas.pyi
@@ -14,6 +14,7 @@ from pandas._libs.tslibs.timedeltas import TimeDeltaUnitChoices
 from pandas._typing import (
     ArrayLike,
     RaiseCoerce,
+    SequenceNotStr,
 )
 
 @overload
@@ -31,7 +32,8 @@ def to_timedelta(
 @overload
 def to_timedelta(
     arg: (
-        Sequence[str | float | timedelta]
+        SequenceNotStr[str]
+        | Sequence[float | timedelta]
         | tuple[str | float | timedelta, ...]
         | range
         | ArrayLike

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -25,7 +25,10 @@ if TYPE_CHECKING:
     from pandas._typing import FulldatetimeDict
 else:
     FulldatetimeDict = Any
-from pandas._typing import TimeUnit
+from pandas._typing import (
+    SequenceNotStr,
+    TimeUnit,
+)
 
 from tests import (
     PD_LTE_22,
@@ -141,7 +144,8 @@ def test_timedelta_series_arithmetic() -> None:
 
 
 def test_timedelta_series_string() -> None:
-    check(assert_type(pd.to_timedelta(["1 day"]), pd.TimedeltaIndex), pd.TimedeltaIndex)
+    seq_list: SequenceNotStr[str] = ["1 day"]
+    check(assert_type(pd.to_timedelta(seq_list), pd.TimedeltaIndex), pd.TimedeltaIndex)
 
 
 def test_timestamp_timedelta_series_arithmetic() -> None:

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -140,6 +140,15 @@ def test_timedelta_series_arithmetic() -> None:
     r4: pd.TimedeltaIndex = tds1 / 10.2
 
 
+def test_timedelta_series_string() -> None:
+    tds1: pd.TimedeltaIndex = pd.to_timedelta(["1 day"])
+    td1: pd.Timedelta = pd.Timedelta("2 days")
+    r1: pd.TimedeltaIndex = tds1 + td1
+    r2: pd.TimedeltaIndex = tds1 - td1
+    r3: pd.TimedeltaIndex = tds1 * 4.3
+    r4: pd.TimedeltaIndex = tds1 / 10.2
+
+
 def test_timestamp_timedelta_series_arithmetic() -> None:
     ts1 = pd.to_datetime(pd.Series(["2022-03-05", "2022-03-06"]))
     assert isinstance(ts1.iloc[0], pd.Timestamp)

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -25,10 +25,7 @@ if TYPE_CHECKING:
     from pandas._typing import FulldatetimeDict
 else:
     FulldatetimeDict = Any
-from pandas._typing import (
-    SequenceNotStr,
-    TimeUnit,
-)
+from pandas._typing import TimeUnit
 
 from tests import (
     PD_LTE_22,

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -144,7 +144,7 @@ def test_timedelta_series_arithmetic() -> None:
 
 
 def test_timedelta_series_string() -> None:
-    seq_list: SequenceNotStr[str] = ["1 day"]
+    seq_list = ["1 day"]
     check(assert_type(pd.to_timedelta(seq_list), pd.TimedeltaIndex), pd.TimedeltaIndex)
 
 

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -141,12 +141,7 @@ def test_timedelta_series_arithmetic() -> None:
 
 
 def test_timedelta_series_string() -> None:
-    tds1: pd.TimedeltaIndex = pd.to_timedelta(["1 day"])
-    td1: pd.Timedelta = pd.Timedelta("2 days")
-    r1: pd.TimedeltaIndex = tds1 + td1
-    r2: pd.TimedeltaIndex = tds1 - td1
-    r3: pd.TimedeltaIndex = tds1 * 4.3
-    r4: pd.TimedeltaIndex = tds1 / 10.2
+    check(assert_type(pd.to_timedelta(["1 day"]), pd.TimedeltaIndex), pd.TimedeltaIndex)
 
 
 def test_timestamp_timedelta_series_arithmetic() -> None:


### PR DESCRIPTION
- [x] Closes #956
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

Should fix the issue in #956 with allowing the sequence of string type, I was not sure about the `assert_type` step above, please feel free to guide me on that one.