### PR TITLE
Fix series.map overloads

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -568,6 +568,8 @@ S2 = TypeVar(
     | BaseOffset,
 )
 
+SN = TypeVar("SN", bound=bool | int | float | complex)
+
 IndexingInt: TypeAlias = (
     int | np.int_ | np.integer | np.unsignedinteger | np.signedinteger | np.int8
 )

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -917,7 +917,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     def map(
         self,
         arg: Callable[[S1], S2 | NAType] | Mapping[S1, S2] | Series[S2],
-        na_action: Literal["ignore"] = ...,
+        na_action: Literal["ignore"],
     ) -> Series[S2]: ...
     @overload
     def map(

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -94,6 +94,7 @@ from pandas._libs.tslibs.nattype import NaTType
 from pandas._typing import (
     S1,
     S2,
+    SN,
     AggFuncTypeBase,
     AggFuncTypeDictFrame,
     AggFuncTypeSeriesToFrame,
@@ -913,6 +914,12 @@ class Series(IndexOpsMixin[S1], NDFrame):
         level: Level = ...,
         fill_value: int | _str | dict | None = ...,
     ) -> DataFrame: ...
+    @overload
+    def map(
+        self,
+        arg: Callable[[SN], S2 | NAType] | Mapping[SN, S2] | Series[S2],
+        na_action: Literal["ignore"] = ...,
+    ) -> Series[S2]: ...
     @overload
     def map(
         self,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3284,12 +3284,14 @@ def test_map_na() -> None:
         return x
 
     def bad_callable(x: int) -> int:
-        return x + 1
+        return x << 1
 
-    s.map(
-        bad_callable, na_action=None  # type: ignore[arg-type] # pyright: ignore[reportCallIssue, reportArgumentType]
-    )
-    s.map(bad_callable)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+    with pytest.raises(TypeError):
+        s.map(
+            bad_callable, na_action=None  # type: ignore[arg-type] # pyright: ignore[reportCallIssue, reportArgumentType]
+        )
+    with pytest.raises(TypeError):
+        s.map(bad_callable)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
     check(
         assert_type(s.map(bad_callable, na_action="ignore"), "pd.Series[int]"),
         pd.Series,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3283,21 +3283,6 @@ def test_map_na() -> None:
             return str(x)
         return x
 
-    def bad_callable(x: int) -> int:
-        return x << 1
-
-    with pytest.raises(TypeError):
-        s.map(
-            bad_callable, na_action=None  # type: ignore[arg-type] # pyright: ignore[reportCallIssue, reportArgumentType]
-        )
-    with pytest.raises(TypeError):
-        s.map(bad_callable)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
-    check(
-        assert_type(s.map(bad_callable, na_action="ignore"), "pd.Series[int]"),
-        pd.Series,
-        int,
-    )
-
     check(
         assert_type(s.map(callable, na_action=None), "pd.Series[str]"), pd.Series, str
     )
@@ -3306,6 +3291,40 @@ def test_map_na() -> None:
     series = pd.Series(["a", "b", "c"])
     check(assert_type(s.map(series, na_action=None), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.map(series), "pd.Series[str]"), pd.Series, str)
+
+    s2: pd.Series[float] = pd.Series([1.0, pd.NA, 3.0])
+
+    def callable2(x: float) -> float:
+        return x + 1
+
+    check(
+        assert_type(s2.map(callable2, na_action="ignore"), "pd.Series[float]"),
+        pd.Series,
+        float,
+    )
+    check(
+        assert_type(s2.map(callable2), "pd.Series[float]"),
+        pd.Series,
+        float,
+    )
+    if TYPE_CHECKING_INVALID_USAGE:
+        s2.map(callable2, na_action=None)  # type: ignore[arg-type] # pyright: ignore[reportCallIssue, reportArgumentType]
+
+    s3: pd.Series[str] = pd.Series(["A", pd.NA, "C"])
+
+    def callable3(x: str) -> str:
+        return x.lower()
+
+    check(
+        assert_type(s3.map(callable3, na_action="ignore"), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
+    if TYPE_CHECKING_INVALID_USAGE:
+        s3.map(
+            callable3, na_action=None  # type: ignore[arg-type] # pyright: ignore[reportCallIssue, reportArgumentType]
+        )
+        s3.map(callable3)  # type: ignore[type-var] # pyright: ignore[reportCallIssue, reportArgumentType]
 
 
 def test_case_when() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3276,18 +3276,34 @@ def test_map_na() -> None:
 
     mapping = {1: "a", 2: "b", 3: "c"}
     check(assert_type(s.map(mapping, na_action=None), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.map(mapping), "pd.Series[str]"), pd.Series, str)
 
     def callable(x: int | NAType) -> str | NAType:
         if isinstance(x, int):
             return str(x)
         return x
 
+    def bad_callable(x: int) -> int:
+        return x + 1
+
+    s.map(
+        bad_callable, na_action=None  # type: ignore[arg-type] # pyright: ignore[reportCallIssue, reportArgumentType]
+    )
+    s.map(bad_callable)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+    check(
+        assert_type(s.map(bad_callable, na_action="ignore"), "pd.Series[int]"),
+        pd.Series,
+        int,
+    )
+
     check(
         assert_type(s.map(callable, na_action=None), "pd.Series[str]"), pd.Series, str
     )
+    check(assert_type(s.map(callable), "pd.Series[str]"), pd.Series, str)
 
     series = pd.Series(["a", "b", "c"])
     check(assert_type(s.map(series, na_action=None), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.map(series), "pd.Series[str]"), pd.Series, str)
 
 
 def test_case_when() -> None:


### PR DESCRIPTION
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

In my last PR that handles `series.map()` i introduced a slight error by adding the `= ...` to the overload with `"ignore"` as this is not the actual default value.

Subsequently invalid function that do not handle `pd.NA` were accepted when the `na_action` was not explicitely specified.

This has been addressed and test cases have been added to check this.