### PR TITLE
fix signature of frame.filter

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1711,7 +1711,7 @@ class DataFrame(NDFrame, OpsMixin):
     ) -> DataFrame: ...
     def filter(
         self,
-        items: list | None = ...,
+        items: ListLike | None = ...,
         like: _str | None = ...,
         regex: _str | None = ...,
         axis: Axis | None = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -319,6 +319,8 @@ def test_types_filter() -> None:
     df.filter(items=["col1"])
     df.filter(regex="co.*")
     df.filter(like="1")
+    # [PR 964] Docs state `items` is `list-like`
+    df.filter(items=("col2", "col2", 1, tuple([4])))
 
 
 def test_types_setting() -> None:


### PR DESCRIPTION
`items` can be `ListLike`

It is turned into and `Index` which can handle and `ListLike` as data
https://github.com/pandas-dev/pandas/blob/9b375be5aa3610e8a21ef0b5b81e4db04270f3d3/pandas/core/generic.py#L5448


- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
