### PR TITLE
Allow 'integer' in select_dtypes include argument

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -624,6 +624,7 @@ class DataFrame(NDFrame, OpsMixin):
             "number",
             "datetime64",
             "datetime",
+            "integer",
             "timedelta",
             "timedelta64",
             "datetimetz",

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3226,6 +3226,7 @@ def test_convert_dtypes_dtype_backend() -> None:
 def test_select_dtypes() -> None:
     df = pd.DataFrame({"a": [1, 2] * 3, "b": [True, False] * 3, "c": [1.0, 2.0] * 3})
     check(assert_type(df.select_dtypes("number"), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.select_dtypes("integer"), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.select_dtypes(np.number), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.select_dtypes(object), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.select_dtypes(include="bool"), pd.DataFrame), pd.DataFrame)


### PR DESCRIPTION
- [x] Closes #927
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
