### PR TITLE
set up workflows to test numpy 1.x and 2.0

### DIFF
--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -5,6 +5,8 @@ inputs:
     required: true
   os:
     required: true
+  numpy-version:
+    required: true
 
 runs:
   using: composite
@@ -33,3 +35,7 @@ runs:
     - name: Install project dependencies
       shell: bash
       run: poetry install -vvv --no-root
+      
+    - name: Set numpy version
+      shell: bash
+      run: pip install numpy${{ inputs. numpy-version }}

--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -38,4 +38,4 @@ runs:
       
     - name: Set numpy version
       shell: bash
-      run: pip install numpy${{ inputs. numpy-version }}
+      run: pip install numpy"${{ inputs. numpy-version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: 'Test'
+name: "Test"
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  MPLBACKEND: 'Agg'
+  MPLBACKEND: "Agg"
 
 jobs:
   released:
@@ -19,34 +19,41 @@ jobs:
       matrix:
         # Don't use macos-latest because it is arm64
         os: [ubuntu-latest, windows-latest, macos-13]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        include:
+          - numpy-version: "<2.0"
+          - numpy-version: ">= 2.0"
+            os: ubuntu-latest
+
+    name: OS ${{ matrix.os }} - Python ${{ matrix.python-version }} - Numpy ${{ matrix.numpy-version }}
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Install project dependencies
-      uses: ./.github/setup
-      with:
-        os: ${{ matrix.os }}
-        python-version: ${{ matrix.python-version }}
+      - name: Install project dependencies
+        uses: ./.github/setup
+        with:
+          os: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+          numpy-verson: ${{ matrix.numpy-version }}
 
-    - name: Run mypy on 'tests' (using the local stubs) and on the local stubs
-      run: poetry run poe mypy
+      - name: Run mypy on 'tests' (using the local stubs) and on the local stubs
+        run: poetry run poe mypy
 
-    - name: Run pyright on 'tests' (using the local stubs) and on the local stubs
-      run: poetry run poe pyright
+      - name: Run pyright on 'tests' (using the local stubs) and on the local stubs
+        run: poetry run poe pyright
 
-    - name: Run pytest
-      run: poetry run poe pytest
+      - name: Run pytest
+        run: poetry run poe pytest
 
-    - name: Install pandas-stubs and run tests on the installed stubs
-      run: poetry run poe test_dist
+      - name: Install pandas-stubs and run tests on the installed stubs
+        run: poetry run poe test_dist
 
   precommit:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-          numpy-verson: ${{ matrix.numpy-version }}
+          numpy-version: ${{ matrix.numpy-version }}
 
       - name: Run mypy on 'tests' (using the local stubs) and on the local stubs
         run: poetry run poe mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,7 @@ packages = [{ "include" = "pandas-stubs" }]
 [tool.poetry.dependencies]
 python = ">=3.9"
 types-pytz = ">= 2022.1.1"
-numpy = [
-  { version = ">=1.23.5,<2.0.0", python = ">=3.9,<3.12" },
-  { version = ">=2.0.0", python = ">=3.12,<3.13" },
-]
+numpy = ">= 1.23.5"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "1.10.1"


### PR DESCRIPTION
- [x] Closes #970

I checked the jobs and they are doing the right things in terms of testing numpy > 2.0 and < 2.0 on ubuntu, and < 2.0 on windows and macos
