### PR TITLE
Validate all values for csv.QUOTE

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -9,6 +9,7 @@ from collections.abc import (
 )
 import datetime
 from os import PathLike
+import sys
 from typing import (
     Any,
     Literal,
@@ -18,7 +19,6 @@ from typing import (
     TypeVar,
     overload,
 )
-import sys
 
 import numpy as np
 from numpy import typing as npt

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -738,7 +738,7 @@ JsonSeriesOrient: TypeAlias = Literal["split", "records", "index", "table"]
 TimestampConvention: TypeAlias = Literal["start", "end", "s", "e"]
 
 CSVEngine: TypeAlias = Literal["c", "python", "pyarrow", "python-fwf"]
-CSVQuoting: TypeAlias = Literal[0, 1, 2, 3]
+CSVQuoting: TypeAlias = Literal[0, 1, 2, 3, 4, 5]
 
 HDFCompLib: TypeAlias = Literal["zlib", "lzo", "bzip2", "blosc"]
 ParquetEngine: TypeAlias = Literal["auto", "pyarrow", "fastparquet"]

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -18,6 +18,7 @@ from typing import (
     TypeVar,
     overload,
 )
+import sys
 
 import numpy as np
 from numpy import typing as npt
@@ -738,7 +739,20 @@ JsonSeriesOrient: TypeAlias = Literal["split", "records", "index", "table"]
 TimestampConvention: TypeAlias = Literal["start", "end", "s", "e"]
 
 CSVEngine: TypeAlias = Literal["c", "python", "pyarrow", "python-fwf"]
-CSVQuoting: TypeAlias = Literal[0, 1, 2, 3, 4, 5]
+# [pandas-dev/pandas-stubs/991]
+# Ref: https://github.com/python/cpython/blob/5a4fb7ea1c96f67dbb3df5d4ccaf3f66a1e19731/Modules/_csv.c#L88-L91
+# QUOTE_MINIMAL = 0
+# QUOTE_ALL = 1
+# QUOTE_NONNUMERIC = 2
+# QUOTE_NONE = 3
+# Added in 3.12:
+# QUOTE_STRINGS = 4
+# QUOTE_NOTNULL = 5
+CSVQuotingCompat: TypeAlias = Literal[0, 1, 2, 3]
+if sys.version_info < (3, 12):
+    CSVQuoting: TypeAlias = CSVQuotingCompat
+else:
+    CSVQuoting: TypeAlias = CSVQuotingCompat | Literal[4, 5]
 
 HDFCompLib: TypeAlias = Literal["zlib", "lzo", "bzip2", "blosc"]
 ParquetEngine: TypeAlias = Literal["auto", "pyarrow", "fastparquet"]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -15,6 +15,7 @@ import io
 import itertools
 from pathlib import Path
 import string
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -25,7 +26,6 @@ from typing import (
     Union,
     cast,
 )
-import sys
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -25,6 +25,7 @@ from typing import (
     Union,
     cast,
 )
+import sys
 
 import numpy as np
 import numpy.typing as npt
@@ -172,8 +173,12 @@ def test_types_to_csv() -> None:
     # Testing support for binary file handles, added in 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html
     df.to_csv(io.BytesIO(), quoting=csv.QUOTE_ALL, encoding="utf-8", compression="gzip")
 
-    with ensure_clean() as path:
-        df.to_csv(path, quoting=csv.QUOTE_STRINGS)
+    if sys.version_info >= (3, 12):
+        with ensure_clean() as path:
+            df.to_csv(path, quoting=csv.QUOTE_STRINGS)
+
+        with ensure_clean() as path:
+            df.to_csv(path, quoting=csv.QUOTE_NOTNULL)
 
 
 def test_types_to_csv_when_path_passed() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -172,6 +172,9 @@ def test_types_to_csv() -> None:
     # Testing support for binary file handles, added in 1.2.0 https://pandas.pydata.org/docs/whatsnew/v1.2.0.html
     df.to_csv(io.BytesIO(), quoting=csv.QUOTE_ALL, encoding="utf-8", compression="gzip")
 
+    with ensure_clean() as path:
+        df.to_csv(path, quoting=csv.QUOTE_STRINGS)
+
 
 def test_types_to_csv_when_path_passed() -> None:
     df = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})


### PR DESCRIPTION
4 and 5 added in 3.12 (python/cpython/67230)
ref: https://docs.python.org/3/library/csv.html#csv.QUOTE_NOTNULL
ref: https://github.com/python/cpython/blob/a8bc03696c7c2c03e1d580633151ec7b850366f3/Modules/_csv.c#L88-L106

- [x] Tests added: Please use `assert_type()` to assert the type of any return value
