### PR TITLE
Remove references to Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ pip install pandas-stubs
 
 ## Installation from sources
 
-- Make sure you have `python >= 3.9` installed.
+- Make sure you have `python >= 3.10` installed.
 - Install poetry
 
 ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering",
 ]
 packages = [{ "include" = "pandas-stubs" }]
@@ -125,7 +125,7 @@ args = [
 
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.isort]
 known_pre_libs = "pandas._config"


### PR DESCRIPTION
- [x] Closes #998 
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
