### PR TITLE
GH978 Build pd.Series from typed dict

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -334,7 +334,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         data: (
             Scalar
             | _ListLike
-            | dict[HashableT1, Any]
+            | Mapping[HashableT1, Any]
             | BaseGroupBy
             | NaTType
             | NAType
@@ -702,8 +702,6 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex = ...,
         level: IndexLabel | None = ...,
         as_index: _bool = ...,
-        sort: _bool = ...,
-        group_keys: _bool = ...,
         observed: _bool | NoDefault = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Any]: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -702,6 +702,8 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex = ...,
         level: IndexLabel | None = ...,
         as_index: _bool = ...,
+        sort: _bool = ...,
+        group_keys: _bool = ...,
         observed: _bool | NoDefault = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Any]: ...

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3490,3 +3490,15 @@ def test_info() -> None:
     check(assert_type(df.info(show_counts=True), None), type(None))
     check(assert_type(df.info(show_counts=False), None), type(None))
     check(assert_type(df.info(show_counts=None), None), type(None))
+
+
+def test_series_typed_dict() -> None:
+    """Test that no error is raised when constructing a series from a typed dict."""
+
+    class MyDict(TypedDict):
+        a: str
+        b: str
+
+    my_dict = MyDict(a="", b="")
+    sr = pd.Series(my_dict)
+    check(assert_type(sr, pd.Series), pd.Series)


### PR DESCRIPTION
- [x] Closes #978 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
