### PR TITLE
GH677 Allow pd.RangeIndex to be initialized with range

### DIFF
--- a/pandas-stubs/core/indexes/range.pyi
+++ b/pandas-stubs/core/indexes/range.pyi
@@ -22,15 +22,6 @@ class RangeIndex(Index[int]):
         copy: bool = ...,
         name=...,
     ): ...
-    def __init__(
-        self,
-        start: int | RangeIndex | range = ...,
-        stop: int = ...,
-        step: int = ...,
-        dtype=...,
-        copy: bool = ...,
-        name=...,
-    ) -> None: ...
     @classmethod
     def from_range(cls, data, name=..., dtype=...): ...
     def __reduce__(self): ...

--- a/pandas-stubs/core/indexes/range.pyi
+++ b/pandas-stubs/core/indexes/range.pyi
@@ -15,7 +15,7 @@ from pandas._typing import (
 class RangeIndex(Index[int]):
     def __new__(
         cls,
-        start: int | RangeIndex = ...,
+        start: int | RangeIndex | range = ...,
         stop: int = ...,
         step: int = ...,
         dtype=...,
@@ -24,7 +24,7 @@ class RangeIndex(Index[int]):
     ): ...
     def __init__(
         self,
-        start: int | RangeIndex = ...,
+        start: int | RangeIndex | range = ...,
         stop: int = ...,
         step: int = ...,
         dtype=...,

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -912,6 +912,12 @@ def test_getitem() -> None:
     check(assert_type(i0[[0, 2]], "pd.Index[str]"), pd.Index, str)
 
 
+def test_range_index_range() -> None:
+    """Test that pd.RangeIndex can be initialized from range."""
+    iri = pd.RangeIndex(range(5))
+    check(assert_type(iri, pd.RangeIndex), pd.RangeIndex, int)
+
+
 def test_multiindex_dtypes():
     # GH-597
     mi = pd.MultiIndex.from_tuples([(1, 2.0), (2, 3.0)], names=["foo", "bar"])


### PR DESCRIPTION
- [x] Closes #677 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
