### PR TITLE
Bump to pandas 2.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ numpy = ">= 1.23.5"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "1.10.1"
-pandas = "2.2.2"
+pandas = "2.2.3"
 pyarrow = ">=10.0.1"
 pytest = ">=7.1.2"
-pyright = ">= 1.1.374"
+pyright = ">= 1.1.383"
 poethepoet = ">=0.16.5"
 loguru = ">=0.6.0"
 typing-extensions = ">=4.4.0"

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,42 +1,13 @@
-from contextlib import (
-    AbstractContextManager,
-    nullcontext,
-)
-import platform
-
 import pandas as pd
-import pytest
 from typing_extensions import assert_type
 
-from tests import (
-    NUMPY20,
-    PD_LTE_22,
-    check,
-    pytest_warns_bounded,
-)
+from tests import check
 
 
 def test_show_version():
     """Test show_versions method types with split case for pandas and python versions."""
-    if PD_LTE_22:
-        context: AbstractContextManager = nullcontext()
-        # distutils warning is only raised with pandas<3.0.0
-        if NUMPY20:  # https://github.com/PyTables/PyTables/issues/1172
-            context = pytest.raises(ValueError)
-        with (
-            pytest_warns_bounded(
-                UserWarning,
-                match="Setuptools is replacing distutils",
-                upper="3.11.99",
-                version_str=platform.python_version(),
-            ),
-            context,
-        ):
-            check(assert_type(pd.show_versions(True), None), type(None))
-            check(assert_type(pd.show_versions(False), None), type(None))
-    else:
-        check(assert_type(pd.show_versions(True), None), type(None))
-        check(assert_type(pd.show_versions(False), None), type(None))
+    check(assert_type(pd.show_versions(True), None), type(None))
+    check(assert_type(pd.show_versions(False), None), type(None))
 
 
 def test_dummies():


### PR DESCRIPTION
Test with pandas 2.2.3.  Seems like `show_versions()` got fixed.

