### PR TITLE
GH987 Add limit_area parameter in `ffill` and `bfill` methods

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1656,6 +1656,7 @@ class DataFrame(NDFrame, OpsMixin):
         axis: Axis | None = ...,
         inplace: Literal[True],
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> None: ...
     @overload
@@ -1665,6 +1666,7 @@ class DataFrame(NDFrame, OpsMixin):
         axis: Axis | None = ...,
         inplace: Literal[False] = ...,
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> DataFrame: ...
     def clip(
@@ -1736,6 +1738,7 @@ class DataFrame(NDFrame, OpsMixin):
         axis: Axis | None = ...,
         inplace: Literal[True],
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> None: ...
     @overload
@@ -1745,6 +1748,7 @@ class DataFrame(NDFrame, OpsMixin):
         axis: Axis | None = ...,
         inplace: Literal[False] = ...,
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> DataFrame: ...
     def filter(

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1333,17 +1333,6 @@ class Series(IndexOpsMixin[S1], NDFrame):
         limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> Series[S1]: ...
-    @overload
-    def bfill(
-        self,
-        *,
-        value: S1 | dict | Series[S1] | DataFrame,
-        axis: AxisIndex = ...,
-        inplace: _bool = ...,
-        limit: int | None = ...,
-        limit_area: Literal["inside", "outside"] | None = ...,
-        downcast: dict | None = ...,
-    ) -> Series[S1] | None: ...
     def interpolate(
         self,
         method: InterpolateOptions = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1300,6 +1300,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex | None = ...,
         inplace: Literal[True],
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> None: ...
     @overload
@@ -1309,6 +1310,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex | None = ...,
         inplace: Literal[False] = ...,
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> Series[S1]: ...
     @overload
@@ -1318,6 +1320,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex | None = ...,
         inplace: Literal[True],
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> None: ...
     @overload
@@ -1327,6 +1330,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex | None = ...,
         inplace: Literal[False] = ...,
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> Series[S1]: ...
     @overload
@@ -1337,6 +1341,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex = ...,
         inplace: _bool = ...,
         limit: int | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> Series[S1] | None: ...
     def interpolate(

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2328,7 +2328,12 @@ def test_types_ffill() -> None:
     df = pd.DataFrame([[1, 2, 3]])
     check(assert_type(df.ffill(), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.ffill(inplace=False), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.ffill(inplace=False, limit_area="inside"), pd.DataFrame),
+        pd.DataFrame,
+    )
     assert assert_type(df.ffill(inplace=True), None) is None
+    assert assert_type(df.ffill(inplace=True, limit_area="outside"), None) is None
 
 
 def test_types_bfill() -> None:
@@ -2336,7 +2341,12 @@ def test_types_bfill() -> None:
     df = pd.DataFrame([[1, 2, 3]])
     check(assert_type(df.bfill(), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.bfill(inplace=False), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.bfill(inplace=False, limit_area="inside"), pd.DataFrame),
+        pd.DataFrame,
+    )
     assert assert_type(df.bfill(inplace=True), None) is None
+    assert assert_type(df.bfill(inplace=True, limit_area="outside"), None) is None
 
 
 def test_types_replace() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1160,7 +1160,13 @@ def test_types_bfill() -> None:
     s1 = pd.Series([1, 2, 3])
     check(assert_type(s1.bfill(), "pd.Series[int]"), pd.Series, np.integer)
     check(assert_type(s1.bfill(inplace=False), "pd.Series[int]"), pd.Series, np.integer)
+    check(
+        assert_type(s1.bfill(inplace=False, limit_area="inside"), "pd.Series[int]"),
+        pd.Series,
+        np.integer,
+    )
     assert assert_type(s1.bfill(inplace=True), None) is None
+    assert assert_type(s1.bfill(inplace=True, limit_area="outside"), None) is None
 
 
 def test_types_ewm() -> None:
@@ -1205,7 +1211,13 @@ def test_types_ffill() -> None:
     s1 = pd.Series([1, 2, 3])
     check(assert_type(s1.ffill(), "pd.Series[int]"), pd.Series, np.integer)
     check(assert_type(s1.ffill(inplace=False), "pd.Series[int]"), pd.Series, np.integer)
+    check(
+        assert_type(s1.ffill(inplace=False, limit_area="inside"), "pd.Series[int]"),
+        pd.Series,
+        np.integer,
+    )
     assert assert_type(s1.ffill(inplace=True), None) is None
+    assert assert_type(s1.ffill(inplace=True, limit_area="outside"), None) is None
 
 
 def test_types_as_type() -> None:


### PR DESCRIPTION
- [x] Closes #987
- [x] Tests added

Hi! 
Seeing the issue was a bit old I thought it was a good opportunity to give it a try, hope that's ok.

This PR adds the missing limit_area parameter to the `ffill` and `bfill` method to match the implementation in the [main pandas](https://github.com/pandas-dev/pandas/blob/v2.2.3/pandas/core/generic.py#L7688) repo. (also adds tests)
