### PR TITLE
GH571 Update typehint when creating a Series from an empty list

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -241,6 +241,16 @@ class Series(IndexOpsMixin[S1], NDFrame):
         copy: bool = ...,
     ) -> Series[float]: ...
     @overload
+    def __new__(  # type: ignore[overload-overlap]
+        cls,
+        data: Sequence[Never],
+        index: Axes | None = ...,
+        *,
+        dtype: Dtype = ...,
+        name: Hashable = ...,
+        copy: bool = ...,
+    ) -> Series[Any]: ...
+    @overload
     def __new__(
         cls,
         data: (

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -7,6 +7,7 @@ from collections.abc import (
     Iterator,
     Mapping,
     MutableMapping,
+    Sequence,
 )
 import csv
 import datetime
@@ -21,6 +22,7 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Never,
     TypedDict,
     TypeVar,
     Union,
@@ -3556,3 +3558,9 @@ def test_series_typed_dict() -> None:
     my_dict = MyDict(a="", b="")
     sr = pd.Series(my_dict)
     check(assert_type(sr, pd.Series), pd.Series)
+
+
+def test_series_empty_dtype() -> None:
+    """Test for the creation of a Series from an empty list GH571."""
+    new_tab: Sequence[Never] = []
+    check(assert_type(pd.Series(new_tab), "pd.Series[Any]"), pd.Series)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -22,7 +22,6 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Never,
     TypedDict,
     TypeVar,
     Union,
@@ -40,6 +39,7 @@ from pandas.core.resample import (
 from pandas.core.series import Series
 import pytest
 from typing_extensions import (
+    Never,
     TypeAlias,
     assert_never,
     assert_type,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3561,6 +3561,9 @@ def test_series_typed_dict() -> None:
 
 
 def test_series_empty_dtype() -> None:
-    """Test for the creation of a Series from an empty list GH571."""
-    new_tab: Sequence[Never] = []
+    """Test for the creation of a Series from an empty list GH571 to map to a Series[Any]."""
+    new_tab: Sequence[Never] = []  # need to be typehinted to please mypy
     check(assert_type(pd.Series(new_tab), "pd.Series[Any]"), pd.Series)
+    check(assert_type(pd.Series([]), "pd.Series[Any]"), pd.Series)
+    # ensure that an empty string does not get matched to Sequence[Never]
+    check(assert_type(pd.Series(""), "pd.Series[str]"), pd.Series)


### PR DESCRIPTION
- [x] Closes #571
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

Potential fix for #571 to typehint a `Series` created from an empty list to be typed as `pd.Series[Any]`.
Open for feedback if this is not the optimal type.