### PR TITLE
Add `ignore_index` keyword arg in `dropna` and `drop_duplicates` (Part of GH624)

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -880,6 +880,7 @@ class DataFrame(NDFrame, OpsMixin):
         thresh: int | None = ...,
         subset: ListLikeU | Scalar | None = ...,
         inplace: Literal[True],
+        ignore_index: _bool = ...,
     ) -> None: ...
     @overload
     def dropna(
@@ -890,6 +891,7 @@ class DataFrame(NDFrame, OpsMixin):
         thresh: int | None = ...,
         subset: ListLikeU | Scalar | None = ...,
         inplace: Literal[False] = ...,
+        ignore_index: _bool = ...,
     ) -> DataFrame: ...
     @overload
     def dropna(
@@ -900,7 +902,27 @@ class DataFrame(NDFrame, OpsMixin):
         thresh: int | None = ...,
         subset: ListLikeU | Scalar | None = ...,
         inplace: _bool | None = ...,
+        ignore_index: _bool = ...,
     ) -> DataFrame | None: ...
+    @overload
+    def drop_duplicates(
+        self,
+        subset: Hashable | Iterable[Hashable] | None = ...,
+        *,
+        keep: NaPosition | _bool = ...,
+        inplace: Literal[False] = ...,
+        ignore_index: _bool = ...,
+    ) -> DataFrame: ...
+    @overload
+    def drop_duplicates(
+        self,
+        subset: Hashable | Iterable[Hashable] | None = ...,
+        *,
+        keep: NaPosition | _bool = ...,
+        inplace: Literal[True] = ...,
+        ignore_index: _bool = ...,
+    ) -> None: ...
+    @overload
     def drop_duplicates(
         self,
         subset: Hashable | Iterable[Hashable] | None = ...,
@@ -908,7 +930,7 @@ class DataFrame(NDFrame, OpsMixin):
         keep: NaPosition | _bool = ...,
         inplace: _bool = ...,
         ignore_index: _bool = ...,
-    ) -> DataFrame: ...
+    ) -> DataFrame | None: ...
     def duplicated(
         self,
         subset: Hashable | Iterable[Hashable] | None = ...,

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -910,18 +910,18 @@ class DataFrame(NDFrame, OpsMixin):
         subset: Hashable | Iterable[Hashable] | None = ...,
         *,
         keep: NaPosition | _bool = ...,
-        inplace: Literal[False] = ...,
+        inplace: Literal[True],
         ignore_index: _bool = ...,
-    ) -> DataFrame: ...
+    ) -> None: ...
     @overload
     def drop_duplicates(
         self,
         subset: Hashable | Iterable[Hashable] | None = ...,
         *,
         keep: NaPosition | _bool = ...,
-        inplace: Literal[True] = ...,
+        inplace: Literal[False] = ...,
         ignore_index: _bool = ...,
-    ) -> None: ...
+    ) -> DataFrame: ...
     @overload
     def drop_duplicates(
         self,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -729,17 +729,17 @@ class Series(IndexOpsMixin[S1], NDFrame):
         self,
         *,
         keep: NaPosition | Literal[False] = ...,
-        inplace: Literal[False] = ...,
+        inplace: Literal[True],
         ignore_index: _bool = ...,
-    ) -> Series[S1]: ...
+    ) -> None: ...
     @overload
     def drop_duplicates(
         self,
         *,
         keep: NaPosition | Literal[False] = ...,
-        inplace: Literal[True],
+        inplace: Literal[False] = ...,
         ignore_index: _bool = ...,
-    ) -> None: ...
+    ) -> Series[S1]: ...
     @overload
     def drop_duplicates(
         self,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -726,15 +726,27 @@ class Series(IndexOpsMixin[S1], NDFrame):
     def unique(self) -> np.ndarray: ...
     @overload
     def drop_duplicates(
-        self, *, keep: NaPosition | Literal[False] = ..., inplace: Literal[False] = ...
+        self,
+        *,
+        keep: NaPosition | Literal[False] = ...,
+        inplace: Literal[False] = ...,
+        ignore_index: _bool = ...,
     ) -> Series[S1]: ...
     @overload
     def drop_duplicates(
-        self, *, keep: NaPosition | Literal[False] = ..., inplace: Literal[True]
+        self,
+        *,
+        keep: NaPosition | Literal[False] = ...,
+        inplace: Literal[True],
+        ignore_index: _bool = ...,
     ) -> None: ...
     @overload
     def drop_duplicates(
-        self, *, keep: NaPosition | Literal[False] = ..., inplace: bool = ...
+        self,
+        *,
+        keep: NaPosition | Literal[False] = ...,
+        inplace: bool = ...,
+        ignore_index: _bool = ...,
     ) -> Series[S1] | None: ...
     def duplicated(self, keep: NaPosition | Literal[False] = ...) -> Series[_bool]: ...
     def idxmax(
@@ -1148,6 +1160,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex = ...,
         inplace: Literal[True],
         how: Literal["any", "all"] | None = ...,
+        ignore_index: _bool = ...,
     ) -> None: ...
     @overload
     def dropna(
@@ -1156,6 +1169,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex = ...,
         inplace: Literal[False] = ...,
         how: Literal["any", "all"] | None = ...,
+        ignore_index: _bool = ...,
     ) -> Series[S1]: ...
     @overload
     def dropna(
@@ -1164,6 +1178,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         axis: AxisIndex = ...,
         inplace: _bool = ...,
         how: Literal["any", "all"] | None = ...,
+        ignore_index: _bool = ...,
     ) -> Series[S1] | None: ...
     def to_timestamp(
         self,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -373,12 +373,21 @@ def test_arguments_drop() -> None:
 
 def test_types_dropna() -> None:
     df = pd.DataFrame(data={"col1": [np.nan, np.nan], "col2": [3, np.nan]})
-    res: pd.DataFrame = df.dropna()
-    res2: pd.DataFrame = df.dropna(ignore_index=True)
-    res3: pd.DataFrame = df.dropna(axis=1, thresh=1)
-    res4: None = df.dropna(axis=0, how="all", subset=["col1"], inplace=True)
-    res5: None = df.dropna(
-        axis=0, how="all", subset=["col1"], inplace=True, ignore_index=False
+    check(assert_type(df.dropna(), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.dropna(ignore_index=True), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.dropna(axis=1, thresh=1), pd.DataFrame), pd.DataFrame)
+    assert (
+        assert_type(df.dropna(axis=0, how="all", subset=["col1"], inplace=True), None)
+        is None
+    )
+    assert (
+        assert_type(
+            df.dropna(
+                axis=0, how="all", subset=["col1"], inplace=True, ignore_index=False
+            ),
+            None,
+        )
+        is None
     )
 
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -374,8 +374,12 @@ def test_arguments_drop() -> None:
 def test_types_dropna() -> None:
     df = pd.DataFrame(data={"col1": [np.nan, np.nan], "col2": [3, np.nan]})
     res: pd.DataFrame = df.dropna()
-    res2: pd.DataFrame = df.dropna(axis=1, thresh=1)
-    res3: None = df.dropna(axis=0, how="all", subset=["col1"], inplace=True)
+    res2: pd.DataFrame = df.dropna(ignore_index=True)
+    res3: pd.DataFrame = df.dropna(axis=1, thresh=1)
+    res4: None = df.dropna(axis=0, how="all", subset=["col1"], inplace=True)
+    res5: None = df.dropna(
+        axis=0, how="all", subset=["col1"], inplace=True, ignore_index=False
+    )
 
 
 def test_types_drop_duplicates() -> None:
@@ -392,6 +396,13 @@ def test_types_drop_duplicates() -> None:
     check(assert_type(df.drop_duplicates(["AAA"]), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.drop_duplicates(("AAA",)), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.drop_duplicates("AAA"), pd.DataFrame), pd.DataFrame)
+    assert assert_type(df.drop_duplicates("AAA", inplace=True), None) is None
+    check(
+        assert_type(
+            df.drop_duplicates("AAA", inplace=False, ignore_index=True), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
 
     if not PD_LTE_22:
         check(assert_type(df.drop_duplicates({"AAA"}), pd.DataFrame), pd.DataFrame)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -308,10 +308,20 @@ def test_types_drop_multilevel() -> None:
     res: pd.Series = s.drop(labels="first", level=1)
 
 
+def test_types_drop_duplicates() -> None:
+    s = pd.Series([1.0, 2.0, 2.0])
+    check(assert_type(s.drop_duplicates(), "pd.Series[float]"), pd.Series, float)
+    assert assert_type(s.drop_duplicates(inplace=True), None) is None
+    assert (
+        assert_type(s.drop_duplicates(inplace=True, ignore_index=False), None) is None
+    )
+
+
 def test_types_dropna() -> None:
     s = pd.Series([1.0, np.nan, np.nan])
     check(assert_type(s.dropna(), "pd.Series[float]"), pd.Series, float)
     assert assert_type(s.dropna(axis=0, inplace=True), None) is None
+    assert assert_type(s.dropna(axis=0, inplace=True, ignore_index=True), None) is None
 
 
 def test_pop() -> None:


### PR DESCRIPTION
- [x] Should cover two bullet points of #624 (dropna and drop_duplicates for both Series and DFs) 
- [x] Tests added

- Additionally add overloads to dataframe `drop_duplicates` method
- Additionally convert existing tests of DF `drop_na` method to use `assert_type`.