### PR TITLE
GH1043 Update _typing.pyi: add "cross" option to JoinHow

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -729,8 +729,8 @@ InterpolateOptions: TypeAlias = Literal[
 ReplaceMethod: TypeAlias = Literal["pad", "ffill", "bfill"]
 SortKind: TypeAlias = Literal["quicksort", "mergesort", "heapsort", "stable"]
 NaPosition: TypeAlias = Literal["first", "last"]
-JoinHow: TypeAlias = Literal["left", "right", "outer", "inner"]
-MergeHow: TypeAlias = JoinHow | Literal["cross"]
+JoinHow: TypeAlias = Literal["left", "right", "outer", "inner", "cross"]
+MergeHow: TypeAlias = JoinHow
 JsonFrameOrient: TypeAlias = Literal[
     "split", "records", "index", "columns", "values", "table"
 ]

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -729,8 +729,8 @@ InterpolateOptions: TypeAlias = Literal[
 ReplaceMethod: TypeAlias = Literal["pad", "ffill", "bfill"]
 SortKind: TypeAlias = Literal["quicksort", "mergesort", "heapsort", "stable"]
 NaPosition: TypeAlias = Literal["first", "last"]
-JoinHow: TypeAlias = Literal["left", "right", "outer", "inner", "cross"]
-MergeHow: TypeAlias = JoinHow
+JoinHow: TypeAlias = Literal["left", "right", "outer", "inner"]
+MergeHow: TypeAlias = JoinHow | Literal["cross"]
 JsonFrameOrient: TypeAlias = Literal[
     "split", "records", "index", "columns", "values", "table"
 ]

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1421,7 +1421,7 @@ class DataFrame(NDFrame, OpsMixin):
         self,
         other: DataFrame | Series | list[DataFrame | Series],
         on: _str | list[_str] | None = ...,
-        how: JoinHow = ...,
+        how: MergeHow = ...,
         lsuffix: _str = ...,
         rsuffix: _str = ...,
         sort: _bool = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2348,11 +2348,11 @@ def test_join() -> None:
 def test_types_join() -> None:
     df1 = pd.DataFrame({"A":[1,2], "B": ["test", "test"]})
     df2 = pd.DataFrame({"C":[2, 3], "D": ["test", "test"]})
-    df1.join(df2, how="cross")
-    df1.join(df2, how="inner")
-    df1.join(df2, how="outer")
-    df1.join(df2, how="left")
-    df1.join(df2, how="right")
+    check(assert_type(df1.join(df2, how="cross"), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df1.join(df2, how="inner"), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df1.join(df2, how="outer"), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df1.join(df2, how="left"), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df1.join(df2, how="right"), pd.DataFrame), pd.DataFrame)
 
 
 def test_types_ffill() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2346,8 +2346,8 @@ def test_join() -> None:
 
 
 def test_types_join() -> None:
-    df1 = pd.DataFrame({"A":[1,2], "B": ["test", "test"]})
-    df2 = pd.DataFrame({"C":[2, 3], "D": ["test", "test"]})
+    df1 = pd.DataFrame({"A": [1, 2], "B": ["test", "test"]})
+    df2 = pd.DataFrame({"C": [2, 3], "D": ["test", "test"]})
     check(assert_type(df1.join(df2, how="cross"), pd.DataFrame), pd.DataFrame)
     check(assert_type(df1.join(df2, how="inner"), pd.DataFrame), pd.DataFrame)
     check(assert_type(df1.join(df2, how="outer"), pd.DataFrame), pd.DataFrame)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2345,6 +2345,16 @@ def test_join() -> None:
     check(assert_type(left.join(right, validate="1:m"), pd.DataFrame), pd.DataFrame)
 
 
+def test_types_join() -> None:
+    df1 = pd.DataFrame({"A":[1,2], "B": ["test", "test"]})
+    df2 = pd.DataFrame({"C":[2, 3], "D": ["test", "test"]})
+    df1.join(df2, how="cross")
+    df1.join(df2, how="inner")
+    df1.join(df2, how="outer")
+    df1.join(df2, how="left")
+    df1.join(df2, how="right")
+
+
 def test_types_ffill() -> None:
     # GH 44
     df = pd.DataFrame([[1, 2, 3]])


### PR DESCRIPTION
- [ ] Closes #1043 (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

I haven't added tests since JoinHow doesn't seem to be tested in any case. Should I add some? Merge tests unimpacted.