### PR TITLE
Fix `Series.rename_axis` and `DataFrame.rename_axis` typing

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,7 +1,7 @@
 ## Set Up Environment
 
 - Make sure you have `python >= 3.10` installed.
-- Make sure you have `hdf5` installed.
+- If using macOS, you may need to install `hdf5` (e.g., via `brew install hdf5`).
 - Install poetry: `pip install 'poetry>=1.8'`
 - Install the project dependencies: `poetry update`
 - Enter the virtual environment: `poetry shell`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,7 @@
 ## Set Up Environment
 
 - Make sure you have `python >= 3.10` installed.
+- Make sure you have `hdf5` installed.
 - Install poetry: `pip install 'poetry>=1.8'`
 - Install the project dependencies: `poetry update`
 - Enter the virtual environment: `poetry shell`

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -2070,40 +2070,44 @@ class DataFrame(NDFrame, OpsMixin):
         limit: int | None = ...,
         tolerance=...,
     ) -> DataFrame: ...
+    # Rename axis with `mapper`, `axis`, and `inplace=True`
     @overload
     def rename_axis(
         self,
-        mapper=...,
+        mapper: Scalar | ListLike | None = ...,
+        *,
         axis: Axis | None = ...,
         copy: _bool = ...,
-        *,
         inplace: Literal[True],
     ) -> None: ...
+    # Rename axis with `mapper`, `axis`, and `inplace=False`
     @overload
     def rename_axis(
         self,
-        mapper=...,
+        mapper: Scalar | ListLike | None = ...,
+        *,
         axis: Axis | None = ...,
         copy: _bool = ...,
-        *,
         inplace: Literal[False] = ...,
     ) -> DataFrame: ...
+    # Rename axis with `index` and/or `columns` and `inplace=True`
     @overload
     def rename_axis(
         self,
+        *,
         index: _str | Sequence[_str] | dict[_str | int, _str] | Callable | None = ...,
         columns: _str | Sequence[_str] | dict[_str | int, _str] | Callable | None = ...,
         copy: _bool = ...,
-        *,
         inplace: Literal[True],
     ) -> None: ...
+    # Rename axis with `index` and/or `columns` and `inplace=False`
     @overload
     def rename_axis(
         self,
+        *,
         index: _str | Sequence[_str] | dict[_str | int, _str] | Callable | None = ...,
         columns: _str | Sequence[_str] | dict[_str | int, _str] | Callable | None = ...,
         copy: _bool = ...,
-        *,
         inplace: Literal[False] = ...,
     ) -> DataFrame: ...
     def rfloordiv(

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -2105,7 +2105,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         copy: _bool = ...,
         inplace: Literal[True],
     ) -> None: ...
-    # Rename axis with `index` and `inplace=True`
+    # Rename axis with `index` and `inplace=False`
     @overload
     def rename_axis(
         self,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -2076,24 +2076,41 @@ class Series(IndexOpsMixin[S1], NDFrame):
         numeric_only: _bool = ...,
         **kwargs,
     ) -> Scalar: ...
+    # Rename axis with `mapper`, `axis`, and `inplace=True`
     @overload
     def rename_axis(
         self,
-        mapper: Scalar | ListLike = ...,
-        index: Scalar | ListLike | Callable | dict | None = ...,
-        columns: Scalar | ListLike | Callable | dict | None = ...,
+        mapper: Scalar | ListLike | None = ...,
+        *,
         axis: AxisIndex | None = ...,
         copy: _bool = ...,
-        *,
         inplace: Literal[True],
     ) -> None: ...
+    # Rename axis with `mapper`, `axis`, and `inplace=False`
     @overload
     def rename_axis(
         self,
-        mapper: Scalar | ListLike = ...,
-        index: Scalar | ListLike | Callable | dict | None = ...,
-        columns: Scalar | ListLike | Callable | dict | None = ...,
+        mapper: Scalar | ListLike | None = ...,
+        *,
         axis: AxisIndex | None = ...,
+        copy: _bool = ...,
+        inplace: Literal[False] = ...,
+    ) -> Self: ...
+    # Rename axis with `index` and `inplace=True`
+    @overload
+    def rename_axis(
+        self,
+        *,
+        index: Scalar | ListLike | Callable | dict | None = ...,
+        copy: _bool = ...,
+        inplace: Literal[True],
+    ) -> None: ...
+    # Rename axis with `index` and `inplace=True`
+    @overload
+    def rename_axis(
+        self,
+        *,
+        index: Scalar | ListLike | Callable | dict | None = ...,
         copy: _bool = ...,
         inplace: Literal[False] = ...,
     ) -> Self: ...

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1960,25 +1960,41 @@ def test_types_rename_axis() -> None:
     df.index.name = "a"
     df.columns.name = "b"
 
-    for _df in [
-        # Rename axes with `mapper` and `axis`
-        df.rename_axis("A"),
-        df.rename_axis(["A"]),
-        df.rename_axis(None),
-        df.rename_axis("B", axis=1),
-        df.rename_axis(["B"], axis=1),
-        df.rename_axis(None, axis=1),
-        # Rename axes with `index` and `columns`
-        df.rename_axis(index="A", columns="B"),
-        df.rename_axis(index=["A"], columns=["B"]),
-        df.rename_axis(index={"a": "A"}, columns={"b": "B"}),
-        df.rename_axis(
-            index=lambda name: name.upper(),
-            columns=lambda name: name.upper(),
+    # Rename axes with `mapper` and `axis`
+    check(assert_type(df.rename_axis("A"), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.rename_axis(["A"]), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.rename_axis(None), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.rename_axis("B", axis=1), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.rename_axis(["B"], axis=1), pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.rename_axis(None, axis=1), pd.DataFrame), pd.DataFrame)
+
+    # Rename axes with `index` and `columns`
+    check(
+        assert_type(df.rename_axis(index="A", columns="B"), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.rename_axis(index=["A"], columns=["B"]), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.rename_axis(index={"a": "A"}, columns={"b": "B"}), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(
+            df.rename_axis(
+                index=lambda name: name.upper(),
+                columns=lambda name: name.upper(),
+            ),
+            pd.DataFrame,
         ),
-        df.rename_axis(index=None, columns=None),
-    ]:
-        check(assert_type(_df, pd.DataFrame), pd.DataFrame)
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.rename_axis(index=None, columns=None), pd.DataFrame),
+        pd.DataFrame,
+    )
 
 
 def test_types_eq() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1955,6 +1955,27 @@ def test_types_rename() -> None:
     df.rename(columns=lambda s: s.upper())
 
 
+def test_types_rename_axis() -> None:
+    df = pd.DataFrame({"col_name": [1, 2, 3]})
+    df.index.name = "a"
+    df.columns.name = "b"
+
+    # Rename axes with `mapper` and `axis`
+    df.rename_axis("A")
+    df.rename_axis(["A"])
+    df.rename_axis(None)
+    df.rename_axis("B", axis=1)
+    df.rename_axis(["B"], axis=1)
+    df.rename_axis(None, axis=1)
+
+    # Rename axes with `index` and `columns`
+    df.rename_axis(index="A", columns="B")
+    df.rename_axis(index=["A"], columns=["B"])
+    df.rename_axis(index={"a": "A"}, columns={"b": "B"})
+    df.rename_axis(index=lambda name: name.upper(), columns=lambda name: name.upper())
+    df.rename_axis(index=None, columns=None)
+
+
 def test_types_eq() -> None:
     df1 = pd.DataFrame([[1, 2], [8, 9]], columns=["A", "B"])
     res1: pd.DataFrame = df1 == 1

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1960,19 +1960,15 @@ def test_types_rename_axis() -> None:
     df.index.name = "a"
     df.columns.name = "b"
 
-    # Rename axes with `mapper` and `axis`
     for _df in [
+        # Rename axes with `mapper` and `axis`
         df.rename_axis("A"),
         df.rename_axis(["A"]),
         df.rename_axis(None),
         df.rename_axis("B", axis=1),
         df.rename_axis(["B"], axis=1),
         df.rename_axis(None, axis=1),
-    ]:
-        check(assert_type(_df, pd.DataFrame), pd.DataFrame)
-
-    # Rename axes with `index` and `columns`
-    for _df in [
+        # Rename axes with `index` and `columns`
         df.rename_axis(index="A", columns="B"),
         df.rename_axis(index=["A"], columns=["B"]),
         df.rename_axis(index={"a": "A"}, columns={"b": "B"}),

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1961,19 +1961,28 @@ def test_types_rename_axis() -> None:
     df.columns.name = "b"
 
     # Rename axes with `mapper` and `axis`
-    df.rename_axis("A")
-    df.rename_axis(["A"])
-    df.rename_axis(None)
-    df.rename_axis("B", axis=1)
-    df.rename_axis(["B"], axis=1)
-    df.rename_axis(None, axis=1)
+    for _df in [
+        df.rename_axis("A"),
+        df.rename_axis(["A"]),
+        df.rename_axis(None),
+        df.rename_axis("B", axis=1),
+        df.rename_axis(["B"], axis=1),
+        df.rename_axis(None, axis=1),
+    ]:
+        check(assert_type(_df, pd.DataFrame), pd.DataFrame)
 
     # Rename axes with `index` and `columns`
-    df.rename_axis(index="A", columns="B")
-    df.rename_axis(index=["A"], columns=["B"])
-    df.rename_axis(index={"a": "A"}, columns={"b": "B"})
-    df.rename_axis(index=lambda name: name.upper(), columns=lambda name: name.upper())
-    df.rename_axis(index=None, columns=None)
+    for _df in [
+        df.rename_axis(index="A", columns="B"),
+        df.rename_axis(index=["A"], columns=["B"]),
+        df.rename_axis(index={"a": "A"}, columns={"b": "B"}),
+        df.rename_axis(
+            index=lambda name: name.upper(),
+            columns=lambda name: name.upper(),
+        ),
+        df.rename_axis(index=None, columns=None),
+    ]:
+        check(assert_type(_df, pd.DataFrame), pd.DataFrame)
 
 
 def test_types_eq() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1125,16 +1125,22 @@ def test_types_rename_axis() -> None:
     s.index.name = "a"
 
     # Rename index with `mapper`
-    s.rename_axis("A")
-    s.rename_axis(["A"])
-    s.rename_axis(None)
+    for _s in [
+        s.rename_axis("A"),
+        s.rename_axis(["A"]),
+        s.rename_axis(None),
+    ]:
+        check(assert_type(_s, pd.Series[int]), pd.Series[int])
 
     # Rename index with `index`
-    s.rename_axis(index="A")
-    s.rename_axis(index=["A"])
-    s.rename_axis(index={"a": "A"})
-    s.rename_axis(index=lambda name: name.upper())
-    s.rename_axis(index=None)
+    for _s in [
+        s.rename_axis(index="A"),
+        s.rename_axis(index=["A"]),
+        s.rename_axis(index={"a": "A"}),
+        s.rename_axis(index=lambda name: name.upper()),
+        s.rename_axis(index=None),
+    ]:
+        check(assert_type(_s, pd.Series[int]), pd.Series[int])
 
 
 def test_types_values() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1124,19 +1124,20 @@ def test_types_rename_axis() -> None:
     s = pd.Series([1, 2, 3])
     s.index.name = "a"
 
-    for _s in [
-        # Rename index with `mapper`
-        s.rename_axis("A"),
-        s.rename_axis(["A"]),
-        s.rename_axis(None),
-        # Rename index with `index`
-        s.rename_axis(index="A"),
-        s.rename_axis(index=["A"]),
-        s.rename_axis(index={"a": "A"}),
-        s.rename_axis(index=lambda name: name.upper()),
-        s.rename_axis(index=None),
-    ]:
-        check(assert_type(_s, pd.Series[int]), pd.Series[int])
+    # Rename index with `mapper`
+    check(assert_type(s.rename_axis("A"), "pd.Series[int]"), pd.Series)
+    check(assert_type(s.rename_axis(["A"]), "pd.Series[int]"), pd.Series)
+    check(assert_type(s.rename_axis(None), "pd.Series[int]"), pd.Series)
+
+    # Rename index with `index`
+    check(assert_type(s.rename_axis(index="A"), "pd.Series[int]"), pd.Series)
+    check(assert_type(s.rename_axis(index=["A"]), "pd.Series[int]"), pd.Series)
+    check(assert_type(s.rename_axis(index={"a": "A"}), "pd.Series[int]"), pd.Series)
+    check(
+        assert_type(s.rename_axis(index=lambda name: name.upper()), "pd.Series[int]"),
+        pd.Series,
+    )
+    check(assert_type(s.rename_axis(index=None), "pd.Series[int]"), pd.Series)
 
 
 def test_types_values() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1124,16 +1124,12 @@ def test_types_rename_axis() -> None:
     s = pd.Series([1, 2, 3])
     s.index.name = "a"
 
-    # Rename index with `mapper`
     for _s in [
+        # Rename index with `mapper`
         s.rename_axis("A"),
         s.rename_axis(["A"]),
         s.rename_axis(None),
-    ]:
-        check(assert_type(_s, pd.Series[int]), pd.Series[int])
-
-    # Rename index with `index`
-    for _s in [
+        # Rename index with `index`
         s.rename_axis(index="A"),
         s.rename_axis(index=["A"]),
         s.rename_axis(index={"a": "A"}),

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1121,7 +1121,20 @@ def test_types_eq() -> None:
 
 
 def test_types_rename_axis() -> None:
-    s: pd.Series = pd.Series([1, 2, 3]).rename_axis("A")
+    s = pd.Series([1, 2, 3])
+    s.index.name = "a"
+
+    # Rename index with `mapper`
+    s.rename_axis("A")
+    s.rename_axis(["A"])
+    s.rename_axis(None)
+
+    # Rename index with `index`
+    s.rename_axis(index="A")
+    s.rename_axis(index=["A"])
+    s.rename_axis(index={"a": "A"})
+    s.rename_axis(index=lambda name: name.upper())
+    s.rename_axis(index=None)
 
 
 def test_types_values() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1139,6 +1139,9 @@ def test_types_rename_axis() -> None:
     )
     check(assert_type(s.rename_axis(index=None), "pd.Series[int]"), pd.Series)
 
+    if TYPE_CHECKING_INVALID_USAGE:
+        s.rename_axis(columns="A")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue]
+
 
 def test_types_values() -> None:
     n1: np.ndarray | ExtensionArray = pd.Series([1, 2, 3]).values


### PR DESCRIPTION
- [x] Closes #1042
- [x] Tests added

Note that the four failing tests also fail on `main` and are unrelated to these changes:
```
FAILED tests/test_series.py::test_astype_float['f16'-<class 'numpy.longdouble'>] - TypeError: data type 'f16' not understood
FAILED tests/test_series.py::test_astype_float['float128'-<class 'numpy.longdouble'>] - TypeError: data type 'float128' not understood
FAILED tests/test_series.py::test_astype_complex['c32'-<class 'numpy.clongdouble'>] - TypeError: data type 'c32' not understood
FAILED tests/test_series.py::test_astype_complex['complex256'-<class 'numpy.clongdouble'>] - TypeError: data type 'complex256' not understood
```
