### PR TITLE
adjust test for slice due to typeshed changes

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2398,7 +2398,13 @@ def test_indexslice_getitem():
         .set_index(["x", "y"])
     )
     ind = pd.Index([2, 3])
-    check(assert_type(pd.IndexSlice[ind, :], tuple["pd.Index[int]", slice]), tuple)
+    # This next test is written this way to support both mypy 1.13 and newer
+    # versions of mypy and pyright that treat slice as a Generic due to
+    # a change in typeshed.
+    # Once pyright 1.1.390 and mypy 1.14 are released, the test can be
+    # reverted to the standard form.
+    tmp: tuple[pd.Index[int], slice] = pd.IndexSlice[ind, :]
+    check(assert_type(tmp, tuple["pd.Index[int]", slice]), tuple)
     check(assert_type(df.loc[pd.IndexSlice[ind, :]], pd.DataFrame), pd.DataFrame)
     check(assert_type(df.loc[pd.IndexSlice[1:2]], pd.DataFrame), pd.DataFrame)
     check(

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2403,6 +2403,7 @@ def test_indexslice_getitem():
     # a change in typeshed.
     # Once pyright 1.1.390 and mypy 1.14 are released, the test can be
     # reverted to the standard form.
+    # check(assert_type(pd.IndexSlice[ind, :], tuple["pd.Index[int]", slice]), tuple)
     tmp: tuple[pd.Index[int], slice] = pd.IndexSlice[ind, :]
     check(assert_type(tmp, tuple["pd.Index[int]", slice]), tuple)
     check(assert_type(df.loc[pd.IndexSlice[ind, :]], pd.DataFrame), pd.DataFrame)


### PR DESCRIPTION
A change was made to `typeshed` to make `slice` a `Generic`, which is causing the `mypy_nightly` tests to fail.  More discussion here:
https://github.com/python/mypy/issues/18225

This fix should allow the CI to pass as well as the `mypy_nightly` runs.  See comment in code.

