### PR TITLE
fixed pivot_table sort argument in pandas_stubs

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1295,7 +1295,7 @@ class DataFrame(NDFrame, OpsMixin):
         dropna: _bool = ...,
         margins_name: _str = ...,
         observed: _bool = ...,
-        sort: _bool = True,
+        sort: _bool = ...,
     ) -> DataFrame: ...
     @overload
     def stack(

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1295,6 +1295,7 @@ class DataFrame(NDFrame, OpsMixin):
         dropna: _bool = ...,
         margins_name: _str = ...,
         observed: _bool = ...,
+        sort: _bool = True,
     ) -> DataFrame: ...
     @overload
     def stack(

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1088,14 +1088,16 @@ def test_types_pivot_table() -> None:
     )
 
     def test_pivot_table_sort():
-        df = DataFrame(
-            {'a': [1, 2],
-             'b': [3, 4],
-             'c': [5, 6],
-             'd': [7, 8]}
+        df = pd.DataFrame(
+            {"a": [1, 2],
+             "b": [3, 4],
+             "c": [5, 6],
+             "d": [7, 8]}
         )
-        check(assert_type(df.pivot_table(values='a', index='b', columns='c', sort=True),
-                          pd.DataFrame), pd.DataFrame)
+
+
+        check(assert_type(df.pivot_table(values="a", index="b", columns="c"
+                                         , sort=True), pd.DataFrame), pd.DataFrame)
 
 
 def test_types_groupby_as_index() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1087,17 +1087,16 @@ def test_types_pivot_table() -> None:
         pd.DataFrame,
     )
 
-    def test_pivot_table_sort():
-        df = pd.DataFrame(
-            {"a": [1, 2],
-             "b": [3, 4],
-             "c": [5, 6],
-             "d": [7, 8]}
-        )
 
+def test_pivot_table_sort():
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6], "d": [7, 8]})
 
-        check(assert_type(df.pivot_table(values="a", index="b", columns="c"
-                                         , sort=True), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(
+            df.pivot_table(values="a", index="b", columns="c", sort=True), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
 
 
 def test_types_groupby_as_index() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1094,8 +1094,8 @@ def test_types_pivot_table() -> None:
              'c': [5, 6],
              'd': [7, 8]}
         )
-        result = df.pivot_table(values='a', index='b', columns='c', sort=True)
-        assert result is not None
+        check(assert_type(df.pivot_table(values='a', index='b', columns='c', sort=True),
+                          pd.DataFrame), pd.DataFrame)
 
 
 def test_types_groupby_as_index() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1087,6 +1087,16 @@ def test_types_pivot_table() -> None:
         pd.DataFrame,
     )
 
+    def test_pivot_table_sort():
+        df = DataFrame(
+            {'a': [1, 2],
+             'b': [3, 4],
+             'c': [5, 6],
+             'd': [7, 8]}
+        )
+        result = df.pivot_table(values='a', index='b', columns='c', sort=True)
+        assert result is not None
+
 
 def test_types_groupby_as_index() -> None:
     """Test type of groupby.size method depending on `as_index`."""


### PR DESCRIPTION
-  Closes #1076 
- Tests added:
Missing parameter for the sort argument of the pandas.DataFrame.pivot_table method added and implemented tests 