### PR TITLE
GH1071 Revert numpy version restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ packages = [{ "include" = "pandas-stubs" }]
 [tool.poetry.dependencies]
 python = ">=3.10"
 types-pytz = ">= 2022.1.1"
-numpy = ">= 1.23.5,< 2.2.0" # wait till numpy 2.2.1 to clear
+numpy = ">= 1.23.5"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "1.13.0"

--- a/tests/test_scalars.py
+++ b/tests/test_scalars.py
@@ -578,7 +578,13 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)
+    check(
+        assert_type(  # type: ignore[assert-type]
+            as_timedelta64 + td,  # pyright: ignore[reportAssertTypeFailure]
+            pd.Timedelta,
+        ),
+        pd.Timedelta,
+    )
     check(assert_type(as_timedelta_index + td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(
         assert_type(as_timedelta_series + td, TimedeltaSeries), pd.Series, pd.Timedelta
@@ -637,7 +643,13 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)
+    check(
+        assert_type(  # type: ignore[assert-type]
+            as_timedelta64 - td,  # pyright: ignore[reportAssertTypeFailure]
+            pd.Timedelta,
+        ),
+        pd.Timedelta,
+    )
     check(assert_type(as_timedelta_index - td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(
         assert_type(as_timedelta_series - td, TimedeltaSeries), pd.Series, pd.Timedelta

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -2766,7 +2766,7 @@ def test_astype_other() -> None:
 
 def test_all_astype_args_tested() -> None:
     """Check that all relevant numpy type aliases are tested."""
-    NUMPY_ALIASES: set[str] = {k for k in np.sctypeDict if isinstance(k, str)}
+    NUMPY_ALIASES: set[str] = {k for k in np.sctypeDict}
     EXCLUDED_ALIASES = {
         "datetime64",
         "m",


### PR DESCRIPTION
- [x] Closes #1071 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

Revert the version restriction for numpy as numpy released a 2.2.1 version.