### PR TITLE
update mypy and allow timestamp slicing

### DIFF
--- a/pandas-stubs/_libs/tslibs/timestamps.pyi
+++ b/pandas-stubs/_libs/tslibs/timestamps.pyi
@@ -11,6 +11,7 @@ from time import struct_time
 from typing import (
     ClassVar,
     Literal,
+    SupportsIndex,
     overload,
 )
 
@@ -48,7 +49,7 @@ _Nonexistent: TypeAlias = (
     Literal["raise", "NaT", "shift_backward", "shift_forward"] | Timedelta | timedelta
 )
 
-class Timestamp(datetime):
+class Timestamp(datetime, SupportsIndex):
     min: ClassVar[Timestamp]  # pyright: ignore[reportIncompatibleVariableOverride]
     max: ClassVar[Timestamp]  # pyright: ignore[reportIncompatibleVariableOverride]
 
@@ -309,3 +310,5 @@ class Timestamp(datetime):
     @property
     def unit(self) -> TimeUnit: ...
     def as_unit(self, unit: TimeUnit, round_ok: bool = ...) -> Self: ...
+    # To support slicing
+    def __index__(self) -> int: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ types-pytz = ">= 2022.1.1"
 numpy = ">= 1.23.5"
 
 [tool.poetry.group.dev.dependencies]
-mypy = "1.13.0"
+mypy = "1.14.1"
 pandas = "2.2.3"
 pyarrow = ">=10.0.1"
 pytest = ">=7.1.2"
-pyright = ">= 1.1.390"
+pyright = ">= 1.1.391"
 poethepoet = ">=0.16.5"
 loguru = ">=0.6.0"
 typing-extensions = ">=4.4.0"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2409,14 +2409,12 @@ def test_indexslice_getitem():
         .set_index(["x", "y"])
     )
     ind = pd.Index([2, 3])
-    # This next test is written this way to support both mypy 1.13 and newer
-    # versions of mypy and pyright that treat slice as a Generic due to
-    # a change in typeshed.
-    # Once pyright 1.1.390 and mypy 1.14 are released, the test can be
-    # reverted to the standard form.
-    # check(assert_type(pd.IndexSlice[ind, :], tuple["pd.Index[int]", slice]), tuple)
-    tmp = cast(tuple["pd.Index[int]", slice], pd.IndexSlice[ind, :])  # type: ignore[redundant-cast]
-    check(assert_type(tmp, tuple["pd.Index[int]", slice]), tuple)
+    check(
+        assert_type(
+            pd.IndexSlice[ind, :], tuple["pd.Index[int]", "slice[None, None, None]"]
+        ),
+        tuple,
+    )
     check(assert_type(df.loc[pd.IndexSlice[ind, :]], pd.DataFrame), pd.DataFrame)
     check(assert_type(df.loc[pd.IndexSlice[1:2]], pd.DataFrame), pd.DataFrame)
     check(

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3435,3 +3435,22 @@ def test_series_unique_timedelta() -> None:
     """Test type return of Series.unique on Series[timedeta64[ns]]."""
     sr = pd.Series([pd.Timedelta("1 days"), pd.Timedelta("3 days")])
     check(assert_type(sr.unique(), TimedeltaArray), TimedeltaArray)
+
+
+def test_slice_timestamp() -> None:
+    dti = pd.date_range("1/1/2025", "2/28/2025")
+
+    s = pd.Series([i for i in range(len(dti))], index=dti)
+
+    # For `s1`, see discussion in GH 397.  Needs mypy fix.
+    # s1 = s.loc["2025-01-15":"2025-01-20"]
+
+    # GH 397
+    check(
+        assert_type(
+            s.loc[pd.Timestamp("2025-01-15") : pd.Timestamp("2025-01-20")],
+            "pd.Series[int]",
+        ),
+        pd.Series,
+        np.integer,
+    )


### PR DESCRIPTION
- [X] Closes  #397 
- [X] Tests added: ` test_series.py:test_slice_timestamp()`

Also, updates mypy to 1.14.1 and pyright to 1.391.0