### PR TITLE
upgrade mypy and pyright. close 4 issues

### DIFF
--- a/pandas-stubs/_libs/tslibs/timestamps.pyi
+++ b/pandas-stubs/_libs/tslibs/timestamps.pyi
@@ -11,6 +11,7 @@ from time import struct_time
 from typing import (
     ClassVar,
     Literal,
+    SupportsIndex,
     overload,
 )
 
@@ -48,7 +49,7 @@ _Nonexistent: TypeAlias = (
     Literal["raise", "NaT", "shift_backward", "shift_forward"] | Timedelta | timedelta
 )
 
-class Timestamp(datetime):
+class Timestamp(datetime, SupportsIndex):
     min: ClassVar[Timestamp]  # pyright: ignore[reportIncompatibleVariableOverride]
     max: ClassVar[Timestamp]  # pyright: ignore[reportIncompatibleVariableOverride]
 
@@ -309,3 +310,5 @@ class Timestamp(datetime):
     @property
     def unit(self) -> TimeUnit: ...
     def as_unit(self, unit: TimeUnit, round_ok: bool = ...) -> Self: ...
+    # To support slicing
+    def __index__(self) -> int: ...

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -113,6 +113,7 @@ from pandas._typing import (
     ReplaceMethod,
     Scalar,
     ScalarT,
+    SequenceNotStr,
     SeriesByT,
     SortKind,
     StataDateFormat,
@@ -194,7 +195,11 @@ class _LocIndexerFrame(_LocIndexer):
     def __getitem__(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
         self,
         idx: tuple[
-            int | StrLike | tuple[Scalar, ...] | Callable[[DataFrame], ScalarT],
+            int
+            | StrLike
+            | Timestamp
+            | tuple[Scalar, ...]
+            | Callable[[DataFrame], ScalarT],
             int | StrLike | tuple[Scalar, ...],
         ],
     ) -> Scalar: ...
@@ -207,6 +212,7 @@ class _LocIndexerFrame(_LocIndexer):
                 IndexType
                 | MaskType
                 | _IndexSliceTuple
+                | SequenceNotStr[float | str | Timestamp]
                 | Callable[
                     [DataFrame], ScalarT | list[HashableT] | IndexType | MaskType
                 ],

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -220,7 +220,9 @@ class _LocIndexerFrame(_LocIndexer):
     @overload
     def __setitem__(
         self,
-        idx: MaskType | StrLike | _IndexSliceTuple | list[ScalarT] | IndexingInt,
+        idx: (
+            MaskType | StrLike | _IndexSliceTuple | list[ScalarT] | IndexingInt | slice
+        ),
         value: Scalar | NAType | NaTType | ArrayLike | Series | DataFrame | list | None,
     ) -> None: ...
     @overload

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -139,6 +139,7 @@ from pandas._typing import (
     ReplaceMethod,
     Scalar,
     ScalarT,
+    SequenceNotStr,
     SeriesByT,
     SortKind,
     StrDtypeArg,
@@ -195,8 +196,7 @@ class _LocIndexerSeries(_LocIndexer, Generic[S1]):
         idx: (
             MaskType
             | Index
-            | Sequence[float]
-            | list[str]
+            | SequenceNotStr[float | str | Timestamp]
             | slice
             | _IndexSliceTuple
             | Sequence[_IndexSliceTuple]

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -208,7 +208,7 @@ class _LocIndexerSeries(_LocIndexer, Generic[S1]):
     @overload
     def __setitem__(
         self,
-        idx: Index | MaskType,
+        idx: Index | MaskType | slice,
         value: S1 | ArrayLike | Series[S1] | None,
     ) -> None: ...
     @overload

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1032,6 +1032,14 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def apply(
         self,
+        func: Callable[..., BaseOffset],
+        convertDType: _bool = ...,
+        args: tuple = ...,
+        **kwds,
+    ) -> OffsetSeries: ...
+    @overload
+    def apply(
+        self,
         func: Callable[..., Series],
         convertDType: _bool = ...,
         args: tuple = ...,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ types-pytz = ">= 2022.1.1"
 numpy = ">= 1.23.5"
 
 [tool.poetry.group.dev.dependencies]
-mypy = "1.13.0"
+mypy = "1.14.1"
 pandas = "2.2.3"
 pyarrow = ">=10.0.1"
 pytest = ">=7.1.2"
-pyright = ">= 1.1.390"
+pyright = ">= 1.1.391"
 poethepoet = ">=0.16.5"
 loguru = ">=0.6.0"
 typing-extensions = ">=4.4.0"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3767,3 +3767,17 @@ def test_frame_single_slice() -> None:
     check(assert_type(df.loc[:], pd.DataFrame), pd.DataFrame)
 
     df.loc[:] = 1 + df
+
+
+def test_frame_index_timestamp() -> None:
+    # GH 620
+    dt1 = pd.to_datetime("2023-05-01")
+    dt2 = pd.to_datetime("2023-05-02")
+    s = pd.Series([1, 2], index=[dt1, dt2])
+    df = pd.DataFrame(s)
+    # Next result is Series or DataFrame because the index could be a MultiIndex
+    check(assert_type(df.loc[dt1, :], pd.Series | pd.DataFrame), pd.Series)
+    check(assert_type(df.loc[[dt1], :], pd.DataFrame), pd.DataFrame)
+    df2 = pd.DataFrame({"x": s})
+    check(assert_type(df2.loc[dt1, "x"], Scalar), np.integer)
+    check(assert_type(df2.loc[[dt1], "x"], pd.Series), pd.Series, np.integer)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -7,7 +7,6 @@ from collections.abc import (
     Iterator,
     Mapping,
     MutableMapping,
-    Sequence,
 )
 import csv
 import datetime
@@ -39,7 +38,6 @@ from pandas.core.resample import (
 from pandas.core.series import Series
 import pytest
 from typing_extensions import (
-    Never,
     TypeAlias,
     assert_never,
     assert_type,
@@ -3763,22 +3761,9 @@ def test_info() -> None:
     check(assert_type(df.info(show_counts=None), None), type(None))
 
 
-def test_series_typed_dict() -> None:
-    """Test that no error is raised when constructing a series from a typed dict."""
+def test_frame_single_slice() -> None:
+    # GH 572
+    df = pd.DataFrame([1, 2, 3])
+    check(assert_type(df.loc[:], pd.DataFrame), pd.DataFrame)
 
-    class MyDict(TypedDict):
-        a: str
-        b: str
-
-    my_dict = MyDict(a="", b="")
-    sr = pd.Series(my_dict)
-    check(assert_type(sr, pd.Series), pd.Series)
-
-
-def test_series_empty_dtype() -> None:
-    """Test for the creation of a Series from an empty list GH571 to map to a Series[Any]."""
-    new_tab: Sequence[Never] = []  # need to be typehinted to please mypy
-    check(assert_type(pd.Series(new_tab), "pd.Series[Any]"), pd.Series)
-    check(assert_type(pd.Series([]), "pd.Series[Any]"), pd.Series)
-    # ensure that an empty string does not get matched to Sequence[Never]
-    check(assert_type(pd.Series(""), "pd.Series[str]"), pd.Series)
+    df.loc[:] = 1 + df

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2409,14 +2409,12 @@ def test_indexslice_getitem():
         .set_index(["x", "y"])
     )
     ind = pd.Index([2, 3])
-    # This next test is written this way to support both mypy 1.13 and newer
-    # versions of mypy and pyright that treat slice as a Generic due to
-    # a change in typeshed.
-    # Once pyright 1.1.390 and mypy 1.14 are released, the test can be
-    # reverted to the standard form.
-    # check(assert_type(pd.IndexSlice[ind, :], tuple["pd.Index[int]", slice]), tuple)
-    tmp = cast(tuple["pd.Index[int]", slice], pd.IndexSlice[ind, :])  # type: ignore[redundant-cast]
-    check(assert_type(tmp, tuple["pd.Index[int]", slice]), tuple)
+    check(
+        assert_type(
+            pd.IndexSlice[ind, :], tuple["pd.Index[int]", "slice[None, None, None]"]
+        ),
+        tuple,
+    )
     check(assert_type(df.loc[pd.IndexSlice[ind, :]], pd.DataFrame), pd.DataFrame)
     check(assert_type(df.loc[pd.IndexSlice[1:2]], pd.DataFrame), pd.DataFrame)
     check(

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3435,3 +3435,22 @@ def test_series_unique_timedelta() -> None:
     """Test type return of Series.unique on Series[timedeta64[ns]]."""
     sr = pd.Series([pd.Timedelta("1 days"), pd.Timedelta("3 days")])
     check(assert_type(sr.unique(), TimedeltaArray), TimedeltaArray)
+
+
+def test_slice_timestamp() -> None:
+    dti = pd.date_range("1/1/2025", "2/28/2025")
+
+    s = pd.Series([i for i in range(len(dti))], index=dti)
+
+    # For `s1`, see discussion in GH 397.  Needs mypy fix.
+    # s1 = s.loc["2025-01-15":"2025-01-20"]
+
+    # GH 397
+    check(
+        assert_type(
+            s.loc[pd.Timestamp("2025-01-15") : pd.Timestamp("2025-01-20")],
+            "pd.Series[int]",
+        ),
+        pd.Series,
+        np.integer,
+    )

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3496,3 +3496,12 @@ def test_series_empty_dtype() -> None:
     check(assert_type(pd.Series([]), "pd.Series[Any]"), pd.Series)
     # ensure that an empty string does not get matched to Sequence[Never]
     check(assert_type(pd.Series(""), "pd.Series[str]"), pd.Series)
+
+
+def test_series_index_timestamp() -> None:
+    # GH 620
+    dt1 = pd.to_datetime("2023-05-01")
+    dt2 = pd.to_datetime("2023-05-02")
+    s = pd.Series([1, 2], index=[dt1, dt2])
+    check(assert_type(s[dt1], int), np.integer)
+    check(assert_type(s.loc[[dt1]], "pd.Series[int]"), pd.Series, np.integer)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3454,3 +3454,14 @@ def test_slice_timestamp() -> None:
         pd.Series,
         np.integer,
     )
+
+
+def test_apply_dateoffset() -> None:
+    # GH 454
+    months = [1, 2, 3]
+    s = pd.Series(months)
+    check(
+        assert_type(s.apply(lambda x: pd.DateOffset(months=x)), "OffsetSeries"),
+        pd.Series,
+        pd.DateOffset,
+    )


### PR DESCRIPTION
- [X] Closes #397 
- [X] Closes #454
- [x] Closes #572 
- [x] Closes #620
- [X] Tests added
  - `test_series.py:test_slice_timestamp()`
  - `test_series.py:test_apply_dateoffset()`
  - `test_series..py:test_series_single_slice()`
  - `test_frame.py:test_frame_single_slice()`
  - `test_series.py:test_series_index_timestamp()`
  - `test_frame.py:test_frame_index_timestamp()`
- Updates mypy to 1.14.1 and pyright to 1.391.0
- Moves some series based tests from `test_frame.py` to `test_series.py`
