### PR TITLE
GH1089 Fix pandas nightly and migrate tests to new framework

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2962,6 +2962,7 @@ def test_groupby_apply() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.apply operated on the grouping columns.",
+        upper="2.99",
     ):
         check(
             assert_type(df.groupby("col1").apply(sum_mean), pd.Series),
@@ -2972,6 +2973,7 @@ def test_groupby_apply() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.apply operated on the grouping columns.",
+        upper="2.99",
     ):
         check(assert_type(df.groupby("col1").apply(lfunc), pd.Series), pd.Series)
 
@@ -2981,6 +2983,7 @@ def test_groupby_apply() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.apply operated on the grouping columns.",
+        upper="2.99",
     ):
         check(assert_type(df.groupby("col1").apply(sum_to_list), pd.Series), pd.Series)
 
@@ -2990,6 +2993,7 @@ def test_groupby_apply() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.apply operated on the grouping columns.",
+        upper="2.99",
     ):
         check(
             assert_type(df.groupby("col1").apply(sum_to_series), pd.DataFrame),
@@ -3002,6 +3006,7 @@ def test_groupby_apply() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.apply operated on the grouping columns.",
+        upper="2.99",
     ):
         check(
             assert_type(

--- a/tests/test_groupby.py
+++ b/tests/test_groupby.py
@@ -80,6 +80,7 @@ def test_frame_groupby_resample() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+        upper="2.99",
     ):
         check(assert_type(GB_DF.resample("ME").sum(), DataFrame), DataFrame)
         check(assert_type(GB_DF.resample("ME").prod(), DataFrame), DataFrame)
@@ -126,6 +127,7 @@ def test_frame_groupby_resample() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+        upper="2.99",
     ):
         with pytest_warns_bounded(
             FutureWarning,
@@ -173,6 +175,7 @@ def test_frame_groupby_resample() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+        upper="2.99",
     ):
         check(assert_type(GB_DF.resample("ME").aggregate(f), DataFrame), DataFrame)
 
@@ -189,6 +192,7 @@ def test_frame_groupby_resample() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+        upper="2.99",
     ):
         with pytest_warns_bounded(
             FutureWarning,

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -84,10 +84,13 @@ def test_column_contains() -> None:
     df = pd.DataFrame({"A": [1, 2], "B": ["c", "d"], "E": [3, 4]})
 
     collist = [column for column in df.columns]
+    check(assert_type(collist, list[str]), list, str)
 
     collist2 = [column for column in df.columns[df.columns.str.contains("A|B")]]
+    check(assert_type(collist2, list[str]), list, str)
 
     length = len(df.columns[df.columns.str.contains("A|B")])
+    check(assert_type(length, int), int)
 
 
 def test_column_sequence() -> None:

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -12,28 +12,61 @@ from tests import (
 
 
 def test_interval_init() -> None:
-    i1: pd.Interval = pd.Interval(1, 2, closed="both")
-    i2: pd.Interval = pd.Interval(1, right=2, closed="right")
-    i3: pd.Interval = pd.Interval(left=1, right=2, closed="left")
+    check(
+        assert_type(pd.Interval(1, 2, closed="both"), "pd.Interval[int]"),
+        pd.Interval,
+        int,
+    )
+    check(
+        assert_type(pd.Interval(1, right=2, closed="right"), "pd.Interval[int]"),
+        pd.Interval,
+        int,
+    )
+    check(
+        assert_type(pd.Interval(left=1, right=2, closed="left"), "pd.Interval[int]"),
+        pd.Interval,
+        int,
+    )
 
 
 def test_interval_arithmetic() -> None:
-    i1: pd.Interval = pd.Interval(1, 2, closed="both")
-    i2: pd.Interval = pd.Interval(1, right=2, closed="right")
+    i1 = pd.Interval(1, 2, closed="both")
+    check(assert_type(i1, "pd.Interval[int]"), pd.Interval, int)
+    check(
+        assert_type(pd.Interval(1, right=2, closed="right"), "pd.Interval[int]"),
+        pd.Interval,
+        int,
+    )
 
-    i3: pd.Interval = i1 + 1
-    i4: pd.Interval = i1 - 1
-    i5: pd.Interval = i1 * 2
-    i6: pd.Interval = i1 / 2
-    i7: pd.Interval = i1 // 2
+    check(assert_type(i1 + 1, "pd.Interval[int]"), pd.Interval, int)
+    check(assert_type(i1 - 1, "pd.Interval[int]"), pd.Interval, int)
+    check(assert_type(i1 * 2, "pd.Interval[int]"), pd.Interval, int)
+    check(assert_type(i1 / 2, "pd.Interval[float]"), pd.Interval, float)
+    check(assert_type(i1 // 2, "pd.Interval[int]"), pd.Interval, int)
 
 
 def test_max_intervals() -> None:
-    i1 = pd.Interval(
-        pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02"), closed="both"
+    check(
+        assert_type(
+            pd.Interval(
+                pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02"), closed="both"
+            ),
+            "pd.Interval[pd.Timestamp]",
+        ),
+        pd.Interval,
+        pd.Timestamp,
     )
-    i2 = pd.Interval(
-        pd.Timestamp("2000-01-01T12:00:00"), pd.Timestamp("2000-01-02"), closed="both"
+    check(
+        assert_type(
+            pd.Interval(
+                pd.Timestamp("2000-01-01T12:00:00"),
+                pd.Timestamp("2000-01-02"),
+                closed="both",
+            ),
+            "pd.Interval[pd.Timestamp]",
+        ),
+        pd.Interval,
+        pd.Timestamp,
     )
 
 

--- a/tests/test_interval_index.py
+++ b/tests/test_interval_index.py
@@ -9,27 +9,63 @@ from tests import check
 
 
 def test_from_breaks() -> None:
-    ind1: pd.IntervalIndex = pd.IntervalIndex.from_breaks([0, 1, 2, 3], name="test")
-    ind2: pd.IntervalIndex = pd.IntervalIndex.from_breaks(
-        [0, 1, 2, 3], closed="right", name=123
+    check(
+        assert_type(
+            pd.IntervalIndex.from_breaks([0, 1, 2, 3], name="test"),
+            "pd.IntervalIndex[pd.Interval[int]]",
+        ),
+        pd.IntervalIndex,
+        pd.Interval,
+    )
+    check(
+        assert_type(
+            pd.IntervalIndex.from_breaks([0, 1, 2, 3], closed="right", name=123),
+            "pd.IntervalIndex[pd.Interval[int]]",
+        ),
+        pd.IntervalIndex,
+        pd.Interval,
     )
 
 
 def test_from_arrays() -> None:
-    ind1: pd.IntervalIndex = pd.IntervalIndex.from_arrays(
-        [0, 1, 2], [1, 2, 3], name="test"
+    check(
+        assert_type(
+            pd.IntervalIndex.from_arrays([0, 1, 2], [1, 2, 3], name="test"),
+            "pd.IntervalIndex[pd.Interval[int]]",
+        ),
+        pd.IntervalIndex,
+        pd.Interval,
     )
-    ind2: pd.IntervalIndex = pd.IntervalIndex.from_arrays(
-        [0, 1, 2], [1, 2, 3], closed="right", name=123
+    check(
+        assert_type(
+            pd.IntervalIndex.from_arrays(
+                [0, 1, 2], [1, 2, 3], closed="right", name=123
+            ),
+            "pd.IntervalIndex[pd.Interval[int]]",
+        ),
+        pd.IntervalIndex,
+        pd.Interval,
     )
 
 
 def test_from_tuples() -> None:
-    ind1: pd.IntervalIndex = pd.IntervalIndex.from_tuples(
-        [(0, 1), (1, 2), (2, 3)], name="test"
+    check(
+        assert_type(
+            pd.IntervalIndex.from_tuples([(0, 1), (1, 2), (2, 3)], name="test"),
+            "pd.IntervalIndex[pd.Interval[int]]",
+        ),
+        pd.IntervalIndex,
+        pd.Interval,
     )
-    ind2: pd.IntervalIndex = pd.IntervalIndex.from_tuples(
-        [(0, 1), (1, 2), (2, 3)], closed="right", name=123
+    check(
+        assert_type(
+            pd.IntervalIndex.from_tuples(
+                [(0, 1), (1, 2), (2, 3)], closed="right", name=123
+            ),
+            "pd.IntervalIndex[pd.Interval[int]]",
+        ),
+        pd.IntervalIndex,
+        pd.Interval,
     )
 
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -223,7 +223,7 @@ def test_types_concat() -> None:
 
     check(
         assert_type(
-            pd.concat(map(lambda x: s2, ["some_value", 3]), axis=1), pd.DataFrame
+            pd.concat(map(lambda _: s2, ["some_value", 3]), axis=1), pd.DataFrame
         ),
         pd.DataFrame,
     )

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -19,6 +19,7 @@ import pandas.util as pdutil
 import pytest
 from typing_extensions import (
     Never,
+    TypeAlias,
     assert_type,
 )
 
@@ -33,23 +34,66 @@ from tests import (
     pytest_warns_bounded,
 )
 
+if TYPE_CHECKING:
+    from pandas.core.series import TimestampSeries
+else:
+    TimestampSeries: TypeAlias = pd.Series
+
 
 def test_types_to_datetime() -> None:
     df = pd.DataFrame({"year": [2015, 2016], "month": [2, 3], "day": [4, 5]})
-    r1: pd.Series = pd.to_datetime(df)
+    check(assert_type(pd.to_datetime(df), TimestampSeries), pd.Series, pd.Timestamp)
 
-    r2: pd.Series = pd.to_datetime(df, unit="s", origin="unix")
-    r3: pd.Series = pd.to_datetime(
-        df, unit="ns", dayfirst=True, utc=False, format="%M:%D", exact=False
+    check(
+        assert_type(pd.to_datetime(df, unit="s", origin="unix"), TimestampSeries),
+        pd.Series,
+        pd.Timestamp,
     )
-    r4: pd.DatetimeIndex = pd.to_datetime(
-        [1, 2], unit="D", origin=pd.Timestamp("01/01/2000")
+    check(
+        assert_type(
+            pd.to_datetime(
+                df, unit="ns", dayfirst=True, utc=False, format="%M:%D", exact=False
+            ),
+            TimestampSeries,
+        ),
+        pd.Series,
+        pd.Timestamp,
     )
-    r5: pd.DatetimeIndex = pd.to_datetime([1, 2], unit="D", origin=3)
-    r6: pd.DatetimeIndex = pd.to_datetime(["2022-01-03", "2022-02-22"])
-    r7: pd.DatetimeIndex = pd.to_datetime(pd.Index(["2022-01-03", "2022-02-22"]))
-    r8: pd.Series = pd.to_datetime(
-        {"year": [2015, 2016], "month": [2, 3], "day": [4, 5]}
+    check(
+        assert_type(
+            pd.to_datetime([1, 2], unit="D", origin=pd.Timestamp("01/01/2000")),
+            pd.DatetimeIndex,
+        ),
+        pd.DatetimeIndex,
+    )
+    check(
+        assert_type(
+            pd.to_datetime([1, 2], unit="D", origin=3),
+            pd.DatetimeIndex,
+        ),
+        pd.DatetimeIndex,
+    )
+    check(
+        assert_type(
+            pd.to_datetime(["2022-01-03", "2022-02-22"]),
+            pd.DatetimeIndex,
+        ),
+        pd.DatetimeIndex,
+    )
+    check(
+        assert_type(
+            pd.to_datetime(pd.Index(["2022-01-03", "2022-02-22"])),
+            pd.DatetimeIndex,
+        ),
+        pd.DatetimeIndex,
+    )
+    check(
+        assert_type(
+            pd.to_datetime({"year": [2015, 2016], "month": [2, 3], "day": [4, 5]}),
+            TimestampSeries,
+        ),
+        pd.Series,
+        pd.Timestamp,
     )
 
 
@@ -306,14 +350,32 @@ def test_types_json_normalize() -> None:
         {"name": {"given": "Mose", "family": "Regner"}},
         {"id": 2, "name": "Faye Raker"},
     ]
-    df1: pd.DataFrame = pd.json_normalize(data=data1)
-    df2: pd.DataFrame = pd.json_normalize(data=data1, max_level=0, sep=";")
-    df3: pd.DataFrame = pd.json_normalize(
-        data=data1, meta_prefix="id", record_prefix="name", errors="raise"
+    check(assert_type(pd.json_normalize(data=data1), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(pd.json_normalize(data=data1, max_level=0, sep=";"), pd.DataFrame),
+        pd.DataFrame,
     )
-    df4: pd.DataFrame = pd.json_normalize(data=data1, record_path=None, meta="id")
+    check(
+        assert_type(
+            pd.json_normalize(
+                data=data1, meta_prefix="id", record_prefix="name", errors="raise"
+            ),
+            pd.DataFrame,
+        ),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(
+            pd.json_normalize(data=data1, record_path=None, meta="id"), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
     data2: dict[str, Any] = {"name": {"given": "Mose", "family": "Regner"}}
-    df5: pd.DataFrame = pd.json_normalize(data=data2)
+    check(
+        assert_type(data2, dict[str, Any]),
+        dict,
+    )
+    check(assert_type(pd.json_normalize(data=data2), pd.DataFrame), pd.DataFrame)
 
 
 def test_isna() -> None:

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -63,17 +63,37 @@ np_ndarray_bool = npt.NDArray[np.bool_]
 
 
 def test_types_init() -> None:
-    ts: pd.Timestamp = pd.Timestamp("2021-03-01T12")
-    ts1: pd.Timestamp = pd.Timestamp(dt.date(2021, 3, 15))
-    ts2: pd.Timestamp = pd.Timestamp(dt.datetime(2021, 3, 10, 12))
-    ts3: pd.Timestamp = pd.Timestamp(pd.Timestamp("2021-03-01T12"))
-    ts4: pd.Timestamp = pd.Timestamp(1515590000.1, unit="s")
-    ts5: pd.Timestamp = pd.Timestamp(1515590000.1, unit="s", tz="US/Pacific")
-    ts6: pd.Timestamp = pd.Timestamp(1515590000100000000)  # plain integer (nanosecond)
-    ts7: pd.Timestamp = pd.Timestamp(2021, 3, 10, 12)
-    ts8: pd.Timestamp = pd.Timestamp(year=2021, month=3, day=10, hour=12)
-    ts9: pd.Timestamp = pd.Timestamp(
-        year=2021, month=3, day=10, hour=12, tz="US/Pacific"
+    check(assert_type(pd.Timestamp("2021-03-01T12"), pd.Timestamp), pd.Timestamp)
+    check(assert_type(pd.Timestamp(dt.date(2021, 3, 15)), pd.Timestamp), pd.Timestamp)
+    check(
+        assert_type(pd.Timestamp(dt.datetime(2021, 3, 10, 12)), pd.Timestamp),
+        pd.Timestamp,
+    )
+    check(
+        assert_type(pd.Timestamp(pd.Timestamp("2021-03-01T12")), pd.Timestamp),
+        pd.Timestamp,
+    )
+    check(assert_type(pd.Timestamp(1515590000.1, unit="s"), pd.Timestamp), pd.Timestamp)
+    check(
+        assert_type(
+            pd.Timestamp(1515590000.1, unit="s", tz="US/Pacific"), pd.Timestamp
+        ),
+        pd.Timestamp,
+    )
+    check(
+        assert_type(pd.Timestamp(1515590000100000000), pd.Timestamp), pd.Timestamp
+    )  # plain integer (nanosecond)
+    check(assert_type(pd.Timestamp(2021, 3, 10, 12), pd.Timestamp), pd.Timestamp)
+    check(
+        assert_type(pd.Timestamp(year=2021, month=3, day=10, hour=12), pd.Timestamp),
+        pd.Timestamp,
+    )
+    check(
+        assert_type(
+            pd.Timestamp(year=2021, month=3, day=10, hour=12, tz="US/Pacific"),
+            pd.Timestamp,
+        ),
+        pd.Timestamp,
     )
 
 
@@ -82,18 +102,18 @@ def test_types_arithmetic() -> None:
     ts2: pd.Timestamp = pd.to_datetime("2021-01-01")
     delta: pd.Timedelta = pd.to_timedelta("1 day")
 
-    tsr: pd.Timedelta = ts - ts2
-    tsr2: pd.Timestamp = ts + delta
-    tsr3: pd.Timestamp = ts - delta
-    tsr4: pd.Timedelta = ts - dt.datetime(2021, 1, 3)
+    check(assert_type(ts - ts2, pd.Timedelta), pd.Timedelta)
+    check(assert_type(ts + delta, pd.Timestamp), pd.Timestamp)
+    check(assert_type(ts - delta, pd.Timestamp), pd.Timestamp)
+    check(assert_type(ts - dt.datetime(2021, 1, 3), pd.Timedelta), pd.Timedelta)
 
 
 def test_types_comparison() -> None:
     ts: pd.Timestamp = pd.to_datetime("2021-03-01")
     ts2: pd.Timestamp = pd.to_datetime("2021-01-01")
 
-    tsr: bool = ts < ts2
-    tsr2: bool = ts > ts2
+    check(assert_type(ts < ts2, bool), bool)
+    check(assert_type(ts > ts2, bool), bool)
 
 
 def test_types_timestamp_series_comparisons() -> None:
@@ -121,32 +141,37 @@ def test_types_timestamp_series_comparisons() -> None:
 def test_types_pydatetime() -> None:
     ts: pd.Timestamp = pd.Timestamp("2021-03-01T12")
 
-    datet: dt.datetime = ts.to_pydatetime()
-    datet2: dt.datetime = ts.to_pydatetime(False)
-    datet3: dt.datetime = ts.to_pydatetime(warn=True)
+    check(assert_type(ts.to_pydatetime(), dt.datetime), dt.datetime)
+    check(assert_type(ts.to_pydatetime(False), dt.datetime), dt.datetime)
+    check(assert_type(ts.to_pydatetime(warn=True), dt.datetime), dt.datetime)
 
 
 def test_to_timedelta() -> None:
-    td: pd.Timedelta = pd.to_timedelta(3, "days")
-    tds: pd.TimedeltaIndex = pd.to_timedelta([2, 3], "minutes")
+    check(assert_type(pd.to_timedelta(3, "days"), pd.Timedelta), pd.Timedelta)
+    check(
+        assert_type(pd.to_timedelta([2, 3], "minutes"), pd.TimedeltaIndex),
+        pd.TimedeltaIndex,
+    )
 
 
 def test_timedelta_arithmetic() -> None:
     td1: pd.Timedelta = pd.to_timedelta(3, "days")
     td2: pd.Timedelta = pd.to_timedelta(4, "hours")
     td3: pd.Timedelta = td1 + td2
-    td4: pd.Timedelta = td1 - td2
-    td5: pd.Timedelta = td1 * 4.3
-    td6: pd.Timedelta = td3 / 10.2
+    check(assert_type(td1 - td2, pd.Timedelta), pd.Timedelta)
+    check(assert_type(td1 * 4.3, pd.Timedelta), pd.Timedelta)
+    check(assert_type(td3 / 10.2, pd.Timedelta), pd.Timedelta)
 
 
 def test_timedelta_series_arithmetic() -> None:
-    tds1: pd.TimedeltaIndex = pd.to_timedelta([2, 3], "minutes")
-    td1: pd.Timedelta = pd.Timedelta("2 days")
-    r1: pd.TimedeltaIndex = tds1 + td1
-    r2: pd.TimedeltaIndex = tds1 - td1
-    r3: pd.TimedeltaIndex = tds1 * 4.3
-    r4: pd.TimedeltaIndex = tds1 / 10.2
+    tds1 = pd.to_timedelta([2, 3], "minutes")
+    td1 = pd.Timedelta("2 days")
+    check(assert_type(tds1, pd.TimedeltaIndex), pd.TimedeltaIndex)
+    check(assert_type(td1, pd.Timedelta), pd.Timedelta)
+    check(assert_type(tds1 + td1, pd.TimedeltaIndex), pd.TimedeltaIndex)
+    check(assert_type(tds1 - td1, pd.TimedeltaIndex), pd.TimedeltaIndex)
+    check(assert_type(tds1 * 4.3, pd.TimedeltaIndex), pd.TimedeltaIndex)
+    check(assert_type(tds1 / 10.2, pd.TimedeltaIndex), pd.TimedeltaIndex)
 
 
 def test_timedelta_float_value() -> None:
@@ -190,11 +215,18 @@ def test_timestamp_timedelta_series_arithmetic() -> None:
 def test_timestamp_dateoffset_arithmetic() -> None:
     ts = pd.Timestamp("2022-03-18")
     do = pd.DateOffset(days=366)
-    r1: pd.Timestamp = ts + do
+    check(assert_type(ts + do, pd.Timestamp), pd.Timestamp)
 
 
 def test_datetimeindex_plus_timedelta() -> None:
-    tscheck = pd.Series([pd.Timestamp("2022-03-05"), pd.Timestamp("2022-03-06")])
+    check(
+        assert_type(
+            pd.Series([pd.Timestamp("2022-03-05"), pd.Timestamp("2022-03-06")]),
+            "TimestampSeries",
+        ),
+        pd.Series,
+        pd.Timestamp,
+    )
     dti = pd.to_datetime(["2022-03-08", "2022-03-15"])
     td_s = pd.to_timedelta(pd.Series([10, 20]), "minutes")
     dti_td_s = dti + td_s
@@ -222,7 +254,14 @@ def test_datetimeindex_plus_timedelta() -> None:
 
 def test_datetimeindex_minus_timedelta() -> None:
     # GH 280
-    tscheck = pd.Series([pd.Timestamp("2022-03-05"), pd.Timestamp("2022-03-06")])
+    check(
+        assert_type(
+            pd.Series([pd.Timestamp("2022-03-05"), pd.Timestamp("2022-03-06")]),
+            "TimestampSeries",
+        ),
+        pd.Series,
+        pd.Timestamp,
+    )
     dti = pd.to_datetime(["2022-03-08", "2022-03-15"])
     td_s = pd.to_timedelta(pd.Series([10, 20]), "minutes")
     dti_td_s = dti - td_s
@@ -241,7 +280,14 @@ def test_datetimeindex_minus_timedelta() -> None:
 
 
 def test_timestamp_plus_timedelta_series() -> None:
-    tscheck = pd.Series([pd.Timestamp("2022-03-05"), pd.Timestamp("2022-03-06")])
+    check(
+        assert_type(
+            pd.Series([pd.Timestamp("2022-03-05"), pd.Timestamp("2022-03-06")]),
+            "TimestampSeries",
+        ),
+        pd.Series,
+        pd.Timestamp,
+    )
     ts = pd.Timestamp("2022-03-05")
     td = pd.to_timedelta(pd.Series([10, 20]), "minutes")
     r3 = td + ts
@@ -265,10 +311,10 @@ def test_timedelta_series_sum() -> None:
         pd.to_datetime(["04/05/2022 08:00", "04/03/2022 09:00"])
     )
     ssum = s.sum()
-    ires: int = ssum.days
+    check(assert_type(ssum.days, int), int)
 
     sf = pd.Series([1.0, 2.2, 3.3])
-    sfsum: float = sf.sum()
+    check(assert_type(sf.sum(), float), float)
 
 
 def test_iso_calendar() -> None:


### PR DESCRIPTION
- [x] Closes #1089 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
