### PR TITLE
Add "Typing :: Stubs Only" trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering",
+  "Typing :: Stubs Only",
 ]
 packages = [{ "include" = "pandas-stubs" }]
 


### PR DESCRIPTION
That classifier is specifically for standalone type stubs packages, so I think pandas-stubs should have it.

See https://github.com/pypa/trove-classifiers/issues/84