### PR TITLE
Simplify and fix overloads for methods with `inplace` parameter

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -778,19 +778,6 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         errors: IgnoreRaise = ...,
     ) -> Self: ...
     @overload
-    def rename(
-        self,
-        mapper: Renamer | None = ...,
-        *,
-        index: Renamer | None = ...,
-        columns: Renamer | None = ...,
-        axis: Axis | None = ...,
-        copy: bool = ...,
-        inplace: bool = ...,
-        level: Level | None = ...,
-        errors: IgnoreRaise = ...,
-    ) -> Self | None: ...
-    @overload
     def fillna(
         self,
         value: Scalar | NAType | dict | Series | DataFrame | None = ...,
@@ -811,25 +798,15 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         inplace: Literal[False] = ...,
     ) -> Self: ...
     @overload
-    def fillna(
-        self,
-        value: Scalar | NAType | dict | Series | DataFrame | None = ...,
-        *,
-        axis: Axis | None = ...,
-        inplace: _bool | None = ...,
-        limit: int = ...,
-        downcast: dict | None = ...,
-    ) -> Self | None: ...
-    @overload
     def replace(
         self,
         to_replace=...,
         value: Scalar | NAType | Sequence | Mapping | Pattern | None = ...,
         *,
+        inplace: Literal[True],
         limit: int | None = ...,
         regex=...,
         method: ReplaceMethod = ...,
-        inplace: Literal[True],
     ) -> None: ...
     @overload
     def replace(
@@ -842,17 +819,6 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         regex=...,
         method: ReplaceMethod = ...,
     ) -> Self: ...
-    @overload
-    def replace(
-        self,
-        to_replace=...,
-        value: Scalar | NAType | Sequence | Mapping | Pattern | None = ...,
-        *,
-        inplace: _bool | None = ...,
-        limit: int | None = ...,
-        regex=...,
-        method: ReplaceMethod = ...,
-    ) -> Self | None: ...
     def shift(
         self,
         periods: int = ...,
@@ -918,18 +884,6 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         allow_duplicates: _bool = ...,
         names: Hashable | Sequence[Hashable] = ...,
     ) -> Self: ...
-    @overload
-    def reset_index(
-        self,
-        level: Level | Sequence[Level] = ...,
-        *,
-        drop: _bool = ...,
-        inplace: _bool | None = ...,
-        col_level: int | _str = ...,
-        col_fill: Hashable = ...,
-        allow_duplicates: _bool = ...,
-        names: Hashable | Sequence[Hashable] = ...,
-    ) -> Self | None: ...
     def isna(self) -> Self: ...
     def isnull(self) -> Self: ...
     def notna(self) -> Self: ...
@@ -957,17 +911,6 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         ignore_index: _bool = ...,
     ) -> Self: ...
     @overload
-    def dropna(
-        self,
-        *,
-        axis: Axis = ...,
-        how: Literal["any", "all"] = ...,
-        thresh: int | None = ...,
-        subset: ListLikeU | Scalar | None = ...,
-        inplace: _bool | None = ...,
-        ignore_index: _bool = ...,
-    ) -> Self | None: ...
-    @overload
     def drop_duplicates(
         self,
         subset: Hashable | Iterable[Hashable] | None = ...,
@@ -985,15 +928,6 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         inplace: Literal[False] = ...,
         ignore_index: _bool = ...,
     ) -> Self: ...
-    @overload
-    def drop_duplicates(
-        self,
-        subset: Hashable | Iterable[Hashable] | None = ...,
-        *,
-        keep: NaPosition | _bool = ...,
-        inplace: _bool = ...,
-        ignore_index: _bool = ...,
-    ) -> Self | None: ...
     def duplicated(
         self,
         subset: Hashable | Iterable[Hashable] | None = ...,
@@ -1026,19 +960,6 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         key: Callable | None = ...,
     ) -> Self: ...
     @overload
-    def sort_values(
-        self,
-        by: _str | Sequence[_str],
-        *,
-        axis: Axis = ...,
-        ascending: _bool | Sequence[_bool] = ...,
-        inplace: _bool | None = ...,
-        kind: SortKind = ...,
-        na_position: NaPosition = ...,
-        ignore_index: _bool = ...,
-        key: Callable | None = ...,
-    ) -> Self | None: ...
-    @overload
     def sort_index(
         self,
         *,
@@ -1066,20 +987,6 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         inplace: Literal[False] = ...,
         key: Callable | None = ...,
     ) -> Self: ...
-    @overload
-    def sort_index(
-        self,
-        *,
-        axis: Axis = ...,
-        level: Level | list[int] | list[_str] | None = ...,
-        ascending: _bool | Sequence[_bool] = ...,
-        inplace: _bool | None = ...,
-        kind: SortKind = ...,
-        na_position: NaPosition = ...,
-        sort_remaining: _bool = ...,
-        ignore_index: _bool = ...,
-        key: Callable | None = ...,
-    ) -> Self | None: ...
     @overload
     def value_counts(
         self,
@@ -1823,13 +1730,24 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> Self: ...
+    @overload
     def clip(
         self,
         lower: float | AnyArrayLike | None = ...,
         upper: float | AnyArrayLike | None = ...,
         *,
         axis: Axis | None = ...,
-        inplace: _bool = ...,
+        inplace: Literal[True],
+        **kwargs,
+    ) -> None: ...
+    @overload
+    def clip(
+        self,
+        lower: float | AnyArrayLike | None = ...,
+        upper: float | AnyArrayLike | None = ...,
+        *,
+        axis: Axis | None = ...,
+        inplace: Literal[False] = ...,
         **kwargs,
     ) -> Self: ...
     def copy(self, deep: _bool = ...) -> Self: ...
@@ -1962,19 +1880,6 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         inplace: Literal[False] = ...,
         **kwargs,
     ) -> Self: ...
-    @overload
-    def interpolate(
-        self,
-        method: InterpolateOptions = ...,
-        *,
-        axis: Axis = ...,
-        limit: int | None = ...,
-        inplace: _bool | None = ...,
-        limit_direction: Literal["forward", "backward", "both"] = ...,
-        limit_area: Literal["inside", "outside"] | None = ...,
-        downcast: Literal["infer"] | None = ...,
-        **kwargs,
-    ) -> Self | None: ...
     def keys(self) -> Index: ...
     def kurt(
         self,
@@ -1996,6 +1901,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     def last_valid_index(self) -> Scalar: ...
     def le(self, other, axis: Axis = ..., level: Level | None = ...) -> Self: ...
     def lt(self, other, axis: Axis = ..., level: Level | None = ...) -> Self: ...
+    @overload
     def mask(
         self,
         cond: (
@@ -2007,7 +1913,23 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         ),
         other: Scalar | Series[S1] | DataFrame | Callable | NAType | None = ...,
         *,
-        inplace: _bool = ...,
+        inplace: Literal[True],
+        axis: Axis | None = ...,
+        level: Level | None = ...,
+    ) -> None: ...
+    @overload
+    def mask(
+        self,
+        cond: (
+            Series
+            | DataFrame
+            | np.ndarray
+            | Callable[[DataFrame], DataFrame]
+            | Callable[[Any], _bool]
+        ),
+        other: Scalar | Series[S1] | DataFrame | Callable | NAType | None = ...,
+        *,
+        inplace: Literal[False] = ...,
         axis: Axis | None = ...,
         level: Level | None = ...,
     ) -> Self: ...
@@ -2469,6 +2391,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         numeric_only: _bool = ...,
         **kwargs,
     ) -> Series: ...
+    @overload
     def where(
         self,
         cond: (
@@ -2480,7 +2403,23 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         ),
         other=...,
         *,
-        inplace: _bool = ...,
+        inplace: Literal[True],
+        axis: Axis | None = ...,
+        level: Level | None = ...,
+    ) -> None: ...
+    @overload
+    def where(
+        self,
+        cond: (
+            Series
+            | DataFrame
+            | np.ndarray
+            | Callable[[DataFrame], DataFrame]
+            | Callable[[Any], _bool]
+        ),
+        other=...,
+        *,
+        inplace: Literal[False] = ...,
         axis: Axis | None = ...,
         level: Level | None = ...,
     ) -> Self: ...

--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -366,56 +366,34 @@ class NDFrame(indexing.IndexingMixin):
         inplace: Literal[False] = ...,
         errors: IgnoreRaise = ...,
     ) -> Self: ...
-    @overload
-    def drop(
-        self,
-        labels: None = ...,
-        *,
-        axis: Axis = ...,
-        index: Hashable | Sequence[Hashable] | Index[Any] = ...,
-        columns: Hashable | Sequence[Hashable] | Index[Any],
-        level: Level | None = ...,
-        inplace: _bool = ...,
-        errors: IgnoreRaise = ...,
-    ) -> Self | None: ...
-    @overload
-    def drop(
-        self,
-        labels: None = ...,
-        *,
-        axis: Axis = ...,
-        index: Hashable | Sequence[Hashable] | Index[Any],
-        columns: Hashable | Sequence[Hashable] | Index[Any] = ...,
-        level: Level | None = ...,
-        inplace: _bool = ...,
-        errors: IgnoreRaise = ...,
-    ) -> Self | None: ...
-    @overload
-    def drop(
-        self,
-        labels: Hashable | Sequence[Hashable] | Index[Any],
-        *,
-        axis: Axis = ...,
-        index: None = ...,
-        columns: None = ...,
-        level: Level | None = ...,
-        inplace: _bool = ...,
-        errors: IgnoreRaise = ...,
-    ) -> Self | None: ...
     def add_prefix(self, prefix: _str) -> Self: ...
     def add_suffix(self, suffix: _str) -> Self: ...
+    @overload
     def sort_index(
         self,
         *,
         axis: Axis = ...,
         level=...,
         ascending: _bool = ...,
-        inplace: _bool = ...,
+        inplace: Literal[True],
         kind: SortKind = ...,
         na_position: Literal["first", "last"] = ...,
         sort_remaining: _bool = ...,
         ignore_index: _bool = ...,
-    ): ...
+    ) -> None: ...
+    @overload
+    def sort_index(
+        self,
+        *,
+        axis: Axis = ...,
+        level=...,
+        ascending: _bool = ...,
+        inplace: Literal[False] = ...,
+        kind: SortKind = ...,
+        na_position: Literal["first", "last"] = ...,
+        sort_remaining: _bool = ...,
+        ignore_index: _bool = ...,
+    ) -> Self: ...
     def filter(
         self,
         items=...,
@@ -458,32 +436,60 @@ class NDFrame(indexing.IndexingMixin):
         convert_floating: _bool = ...,
         dtype_backend: DtypeBackend = ...,
     ) -> Self: ...
+    @overload
     def fillna(
         self,
         value=...,
         *,
         axis=...,
-        inplace: _bool = ...,
+        inplace: Literal[True],
         limit=...,
         downcast=...,
-    ) -> NDFrame | None: ...
+    ) -> None: ...
+    @overload
+    def fillna(
+        self,
+        value=...,
+        *,
+        axis=...,
+        inplace: Literal[False] = ...,
+        limit=...,
+        downcast=...,
+    ) -> NDFrame: ...
+    @overload
     def replace(
         self,
         to_replace=...,
         value=...,
         *,
-        inplace: _bool = ...,
+        inplace: Literal[True],
         limit=...,
         regex: _bool = ...,
         method: ReplaceMethod = ...,
-    ): ...
+    ) -> None: ...
+    @overload
+    def replace(
+        self,
+        to_replace=...,
+        value=...,
+        *,
+        inplace: Literal[False] = ...,
+        limit=...,
+        regex: _bool = ...,
+        method: ReplaceMethod = ...,
+    ) -> NDFrame: ...
     def asof(self, where, subset=...): ...
     def isna(self) -> NDFrame: ...
     def isnull(self) -> NDFrame: ...
     def notna(self) -> NDFrame: ...
     def notnull(self) -> NDFrame: ...
+    @overload
     def clip(
-        self, lower=..., upper=..., *, axis=..., inplace: _bool = ..., **kwargs
+        self, lower=..., upper=..., *, axis=..., inplace: Literal[True], **kwargs
+    ) -> None: ...
+    @overload
+    def clip(
+        self, lower=..., upper=..., *, axis=..., inplace: Literal[False] = ..., **kwargs
     ) -> Self: ...
     def asfreq(
         self,
@@ -526,24 +532,46 @@ class NDFrame(indexing.IndexingMixin):
         ascending: _bool = ...,
         pct: _bool = ...,
     ) -> NDFrame: ...
+    @overload
     def where(
         self,
         cond,
         other=...,
         *,
-        inplace: _bool = ...,
+        inplace: Literal[True],
         axis=...,
         level=...,
-    ): ...
+    ) -> None: ...
+    @overload
+    def where(
+        self,
+        cond,
+        other=...,
+        *,
+        inplace: Literal[False] = ...,
+        axis=...,
+        level=...,
+    ) -> Self: ...
+    @overload
     def mask(
         self,
         cond,
         other=...,
         *,
-        inplace: _bool = ...,
+        inplace: Literal[True],
         axis=...,
         level=...,
-    ): ...
+    ) -> None: ...
+    @overload
+    def mask(
+        self,
+        cond,
+        other=...,
+        *,
+        inplace: Literal[False] = ...,
+        axis=...,
+        level=...,
+    ) -> Self: ...
     def shift(self, periods=..., freq=..., axis=..., fill_value=...) -> Self: ...
     def truncate(self, before=..., after=..., axis=..., copy: _bool = ...) -> Self: ...
     def tz_convert(self, tz, axis=..., level=..., copy: _bool = ...) -> Self: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -488,11 +488,10 @@ class Series(IndexOpsMixin[S1], NDFrame):
     def index(self) -> Index | MultiIndex: ...
     @index.setter
     def index(self, idx: Index) -> None: ...
-    # TODO: combine Level | Sequence[Level] github.com/python/mypy/issues/14311
     @overload
     def reset_index(
         self,
-        level: Sequence[Level] = ...,
+        level: Sequence[Level] | Level | None = ...,
         *,
         drop: Literal[False] = ...,
         name: Level = ...,
@@ -502,7 +501,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def reset_index(
         self,
-        level: Sequence[Level] = ...,
+        level: Sequence[Level] | Level | None = ...,
         *,
         drop: Literal[True],
         name: Level = ...,
@@ -512,37 +511,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def reset_index(
         self,
-        level: Sequence[Level] = ...,
-        *,
-        drop: bool = ...,
-        name: Level = ...,
-        inplace: Literal[True],
-        allow_duplicates: bool = ...,
-    ) -> None: ...
-    @overload
-    def reset_index(
-        self,
-        level: Level | None = ...,
-        *,
-        drop: Literal[False] = ...,
-        name: Level = ...,
-        inplace: Literal[False] = ...,
-        allow_duplicates: bool = ...,
-    ) -> DataFrame: ...
-    @overload
-    def reset_index(
-        self,
-        level: Level | None = ...,
-        *,
-        drop: Literal[True],
-        name: Level = ...,
-        inplace: Literal[False] = ...,
-        allow_duplicates: bool = ...,
-    ) -> Series[S1]: ...
-    @overload
-    def reset_index(
-        self,
-        level: Level | None = ...,
+        level: Sequence[Level] | Level | None = ...,
         *,
         drop: bool = ...,
         name: Level = ...,
@@ -805,14 +774,6 @@ class Series(IndexOpsMixin[S1], NDFrame):
         inplace: Literal[False] = ...,
         ignore_index: _bool = ...,
     ) -> Series[S1]: ...
-    @overload
-    def drop_duplicates(
-        self,
-        *,
-        keep: NaPosition | Literal[False] = ...,
-        inplace: bool = ...,
-        ignore_index: _bool = ...,
-    ) -> Series[S1] | None: ...
     def duplicated(self, keep: NaPosition | Literal[False] = ...) -> Series[_bool]: ...
     def idxmax(
         self, axis: AxisIndex = ..., skipna: _bool = ..., *args, **kwargs
@@ -935,18 +896,6 @@ class Series(IndexOpsMixin[S1], NDFrame):
         key: Callable | None = ...,
     ) -> Series[S1]: ...
     @overload
-    def sort_values(
-        self,
-        *,
-        axis: Axis = ...,
-        ascending: _bool | Sequence[_bool] = ...,
-        inplace: _bool | None = ...,
-        kind: SortKind = ...,
-        na_position: NaPosition = ...,
-        ignore_index: _bool = ...,
-        key: Callable | None = ...,
-    ) -> Series[S1] | None: ...
-    @overload
     def sort_index(
         self,
         *,
@@ -973,21 +922,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         ignore_index: _bool = ...,
         inplace: Literal[False] = ...,
         key: Callable | None = ...,
-    ) -> Self: ...
-    @overload
-    def sort_index(
-        self,
-        *,
-        axis: Axis = ...,
-        level: Level | list[int] | list[_str] | None = ...,
-        ascending: _bool | Sequence[_bool] = ...,
-        inplace: _bool | None = ...,
-        kind: SortKind = ...,
-        na_position: NaPosition = ...,
-        sort_remaining: _bool = ...,
-        ignore_index: _bool = ...,
-        key: Callable | None = ...,
-    ) -> Series | None: ...
+    ) -> Series[S1]: ...
     def argsort(
         self,
         axis: AxisIndex = ...,
@@ -1116,36 +1051,14 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def rename(
         self,
-        index: Renamer | None = ...,
-        *,
-        axis: Axis | None = ...,
-        copy: bool = ...,
-        inplace: Literal[False] = ...,
-        level: Level | None = ...,
-        errors: IgnoreRaise = ...,
-    ) -> Self: ...
-    @overload
-    def rename(
-        self,
-        index: Hashable | None = ...,
-        *,
-        axis: Axis | None = ...,
-        copy: bool = ...,
-        inplace: Literal[False] = ...,
-        level: Level | None = ...,
-        errors: IgnoreRaise = ...,
-    ) -> Self: ...
-    @overload
-    def rename(
-        self,
         index: Renamer | Hashable | None = ...,
         *,
         axis: Axis | None = ...,
         copy: bool = ...,
-        inplace: bool = ...,
+        inplace: Literal[False] = ...,
         level: Level | None = ...,
         errors: IgnoreRaise = ...,
-    ) -> Series | None: ...
+    ) -> Self: ...
     def reindex_like(
         self,
         other: Series[S1],
@@ -1175,27 +1088,6 @@ class Series(IndexOpsMixin[S1], NDFrame):
         inplace: Literal[False] = ...,
     ) -> Series[S1]: ...
     @overload
-    def fillna(
-        self,
-        value: Scalar | NAType | dict | Series[S1] | DataFrame | None = ...,
-        *,
-        axis: AxisIndex = ...,
-        inplace: _bool = ...,
-        limit: int | None = ...,
-        downcast: dict | None = ...,
-    ) -> Series[S1] | None: ...
-    @overload
-    def replace(
-        self,
-        to_replace: _str | list | dict | Series[S1] | float | None = ...,
-        value: Scalar | NAType | dict | list | _str | None = ...,
-        *,
-        inplace: Literal[False] = ...,
-        limit: int | None = ...,
-        regex=...,
-        method: ReplaceMethod = ...,
-    ) -> Series[S1]: ...
-    @overload
     def replace(
         self,
         to_replace: _str | list | dict | Series[S1] | float | None = ...,
@@ -1212,11 +1104,11 @@ class Series(IndexOpsMixin[S1], NDFrame):
         to_replace: _str | list | dict | Series[S1] | float | None = ...,
         value: Scalar | NAType | dict | list | _str | None = ...,
         *,
-        inplace: _bool = ...,
+        inplace: Literal[False] = ...,
         limit: int | None = ...,
         regex=...,
         method: ReplaceMethod = ...,
-    ) -> Series[S1] | None: ...
+    ) -> Series[S1]: ...
     def shift(
         self,
         periods: int = ...,
@@ -1254,15 +1146,6 @@ class Series(IndexOpsMixin[S1], NDFrame):
         how: Literal["any", "all"] | None = ...,
         ignore_index: _bool = ...,
     ) -> Series[S1]: ...
-    @overload
-    def dropna(
-        self,
-        *,
-        axis: AxisIndex = ...,
-        inplace: _bool = ...,
-        how: Literal["any", "all"] | None = ...,
-        ignore_index: _bool = ...,
-    ) -> Series[S1] | None: ...
     def to_timestamp(
         self,
         freq=...,
@@ -1443,13 +1326,27 @@ class Series(IndexOpsMixin[S1], NDFrame):
         limit_area: Literal["inside", "outside"] | None = ...,
         downcast: dict | None = ...,
     ) -> Series[S1]: ...
+    @overload
     def interpolate(
         self,
         method: InterpolateOptions = ...,
         *,
         axis: AxisIndex | None = ...,
         limit: int | None = ...,
-        inplace: _bool = ...,
+        inplace: Literal[True],
+        limit_direction: Literal["forward", "backward", "both"] | None = ...,
+        limit_area: Literal["inside", "outside"] | None = ...,
+        downcast: Literal["infer"] | None = ...,
+        **kwargs,
+    ) -> None: ...
+    @overload
+    def interpolate(
+        self,
+        method: InterpolateOptions = ...,
+        *,
+        axis: AxisIndex | None = ...,
+        limit: int | None = ...,
+        inplace: Literal[False] = ...,
         limit_direction: Literal["forward", "backward", "both"] | None = ...,
         limit_area: Literal["inside", "outside"] | None = ...,
         downcast: Literal["infer"] | None = ...,
@@ -1460,13 +1357,24 @@ class Series(IndexOpsMixin[S1], NDFrame):
         where: Scalar | Sequence[Scalar],
         subset: _str | Sequence[_str] | None = ...,
     ) -> Scalar | Series[S1]: ...
+    @overload
     def clip(
         self,
         lower: AnyArrayLike | float | None = ...,
         upper: AnyArrayLike | float | None = ...,
         *,
         axis: AxisIndex | None = ...,
-        inplace: _bool = ...,
+        inplace: Literal[True],
+        **kwargs,
+    ) -> None: ...
+    @overload
+    def clip(
+        self,
+        lower: AnyArrayLike | float | None = ...,
+        upper: AnyArrayLike | float | None = ...,
+        *,
+        axis: AxisIndex | None = ...,
+        inplace: Literal[False] = ...,
         **kwargs,
     ) -> Series[S1]: ...
     def asfreq(
@@ -1500,6 +1408,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         ascending: _bool = ...,
         pct: _bool = ...,
     ) -> Series[float]: ...
+    @overload
     def where(
         self,
         cond: (
@@ -1511,10 +1420,27 @@ class Series(IndexOpsMixin[S1], NDFrame):
         ),
         other=...,
         *,
-        inplace: _bool = ...,
+        inplace: Literal[True],
         axis: AxisIndex | None = ...,
         level: Level | None = ...,
-    ) -> Series[S1]: ...
+    ) -> None: ...
+    @overload
+    def where(
+        self,
+        cond: (
+            Series[S1]
+            | Series[_bool]
+            | np.ndarray
+            | Callable[[Series[S1]], Series[bool]]
+            | Callable[[S1], bool]
+        ),
+        other=...,
+        *,
+        inplace: Literal[False] = ...,
+        axis: AxisIndex | None = ...,
+        level: Level | None = ...,
+    ) -> Self: ...
+    @overload
     def mask(
         self,
         cond: (
@@ -1526,7 +1452,23 @@ class Series(IndexOpsMixin[S1], NDFrame):
         ),
         other: Scalar | Series[S1] | DataFrame | Callable | NAType | None = ...,
         *,
-        inplace: _bool = ...,
+        inplace: Literal[True],
+        axis: AxisIndex | None = ...,
+        level: Level | None = ...,
+    ) -> None: ...
+    @overload
+    def mask(
+        self,
+        cond: (
+            Series[S1]
+            | Series[_bool]
+            | np.ndarray
+            | Callable[[Series[S1]], Series[bool]]
+            | Callable[[S1], bool]
+        ),
+        other: Scalar | Series[S1] | DataFrame | Callable | NAType | None = ...,
+        *,
+        inplace: Literal[False] = ...,
         axis: AxisIndex | None = ...,
         level: Level | None = ...,
     ) -> Series[S1]: ...

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1185,7 +1185,7 @@ def test_types_rename() -> None:
     s6: None = pd.Series([1, 2, 3]).rename("A", inplace=True)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[dict-item] # pyright: ignore[reportArgumentType,reportCallIssue]
+        s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
 
 
 def test_types_ne() -> None:


### PR DESCRIPTION
The return value of these methods varies on the `inplace` argument.