### PR TITLE
Make `pandas.ExcelFile(...)` in stubs consistent with the run time version.

### DIFF
--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -245,9 +245,10 @@ class ExcelFile:
     io: FilePath | ReadBuffer[bytes] | bytes = ...
     def __init__(
         self,
-        io: FilePath | ReadBuffer[bytes] | bytes,
+        path_or_buffer: FilePath | ReadBuffer[bytes] | bytes,
         engine: ExcelReadEngine | None = ...,
         storage_options: StorageOptions = ...,
+        engine_kwargs: dict[str, Any] | None = ...,
     ) -> None: ...
     def __fspath__(self): ...
     @overload

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1116,6 +1116,14 @@ def test_excel_reader():
             check(assert_type(ef, pd.ExcelFile), pd.ExcelFile)
             check(assert_type(pd.read_excel(ef), pd.DataFrame), pd.DataFrame)
 
+        with pd.ExcelFile(
+            path_or_buffer=path,
+            engine="openpyxl",
+            engine_kwargs={"data_only": True},
+        ) as ef:
+            check(assert_type(ef, pd.ExcelFile), pd.ExcelFile)
+            check(assert_type(pd.read_excel(ef), pd.DataFrame), pd.DataFrame)
+
 
 def test_excel_writer():
     with ensure_clean(".xlsx") as path:


### PR DESCRIPTION
- [ ] Closes #1116
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
- [x] I have run the `pytest` in my local environment.

## Introduction

The changes make the signature of

https://github.com/pandas-dev/pandas-stubs/blob/4976e11dbdbaf740ea5a7059d330a7f0a5305f2e/pandas-stubs/io/excel/_base.pyi#L246-L251

consistent with the run time version:

https://github.com/pandas-dev/pandas/blob/0691c5cf90477d3503834d983f69350f250a6ff7/pandas/io/excel/_base.py#L1507-L1513

## Fixes

* The first argument name should be `path_or_buffer`, not `io`. (The property `ExcelFile(...).io` is correct. No need to change this.)
* The keyword `engine_kwargs` is added.
* ~~The keyword `storage_options` should allow a `None` value.~~ Sorry, I found that `None` case has been included [here](https://github.com/pandas-dev/pandas-stubs/blob/4976e11dbdbaf740ea5a7059d330a7f0a5305f2e/pandas-stubs/_typing.pyi#L614). No need to make changes for this.