### PR TITLE
GH1089Fix nightly for pandas 3.0.0 due to future warnings

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2674,14 +2674,16 @@ def test_frame_reindex_like() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
+        lower="2.2.99",
         upper="3.0.99",
     ):
         check(
-        assert_type(
-            df.reindex_like(other, method="nearest", tolerance=[0.5, 0.2]), pd.DataFrame
-        ),
-        pd.DataFrame,
-    )
+            assert_type(
+                df.reindex_like(other, method="nearest", tolerance=[0.5, 0.2]),
+                pd.DataFrame,
+            ),
+            pd.DataFrame,
+        )
 
 
 def test_frame_ndarray_assignmment() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2670,7 +2670,13 @@ def test_frame_reindex_like() -> None:
     # GH 84
     df = pd.DataFrame({"a": [1, 2, 3]}, index=[0, 1, 2])
     other = pd.DataFrame({"a": [1, 2]}, index=[1, 0])
-    check(
+
+    with pytest_warns_bounded(
+        FutureWarning,
+        "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
+        upper="3.0.99",
+    ):
+        check(
         assert_type(
             df.reindex_like(other, method="nearest", tolerance=[0.5, 0.2]), pd.DataFrame
         ),

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3577,16 +3577,17 @@ def test_series_reindex_like() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
+        lower="2.2.99",
         upper="3.0.99",
     ):
         check(
-        assert_type(
-            s.reindex_like(other, method="nearest", tolerance=[0.5, 0.2]),
-            "pd.Series[int]",
-        ),
-        pd.Series,
-        np.integer,
-    )
+            assert_type(
+                s.reindex_like(other, method="nearest", tolerance=[0.5, 0.2]),
+                "pd.Series[int]",
+            ),
+            pd.Series,
+            np.integer,
+        )
 
 
 def test_info() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3574,7 +3574,12 @@ def test_series_reindex() -> None:
 def test_series_reindex_like() -> None:
     s = pd.Series([1, 2, 3], index=[0, 1, 2])
     other = pd.Series([1, 2], index=[1, 0])
-    check(
+    with pytest_warns_bounded(
+        FutureWarning,
+        "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
+        upper="3.0.99",
+    ):
+        check(
         assert_type(
             s.reindex_like(other, method="nearest", tolerance=[0.5, 0.2]),
             "pd.Series[int]",


### PR DESCRIPTION
- [x] Closes #1089 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
