### PR TITLE
Align AnyArrayLike with pandas._typing definition

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -56,7 +56,7 @@ from pandas.io.formats.format import EngFormatter
 Incomplete: TypeAlias = Any
 
 ArrayLike: TypeAlias = ExtensionArray | np.ndarray[Any, Any]
-AnyArrayLike: TypeAlias = Index[Any] | Series[Any] | np.ndarray[Any, Any]
+AnyArrayLike: TypeAlias = ArrayLike | Index[Any] | Series[Any]
 PythonScalar: TypeAlias = str | bool | complex
 DatetimeLikeScalar = TypeVar("DatetimeLikeScalar", bound=Period | Timestamp | Timedelta)
 PandasScalar: TypeAlias = bytes | datetime.date | datetime.datetime | datetime.timedelta

--- a/pandas-stubs/core/indexes/datetimes.pyi
+++ b/pandas-stubs/core/indexes/datetimes.pyi
@@ -30,7 +30,6 @@ from pandas.core.series import (
 
 from pandas._typing import (
     AnyArrayLike,
-    ArrayLike,
     DateAndDatetimeLike,
     Dtype,
     IntervalClosedType,
@@ -44,7 +43,7 @@ from pandas.tseries.offsets import BaseOffset
 class DatetimeIndex(DatetimeTimedeltaMixin[Timestamp], DatetimeIndexProperties):
     def __init__(
         self,
-        data: ArrayLike | AnyArrayLike | list | tuple,
+        data: AnyArrayLike | list | tuple,
         freq: Frequency = ...,
         tz: TimeZones = ...,
         ambiguous: str = ...,


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

This came up in another PR (https://github.com/pandas-dev/pandas-stubs/pull/1107#discussion_r1946700293)

It seems that the definitions have slightly drifted - OK to align them?