### PR TITLE
type bins in seriesgroupby.value_counts

### DIFF
--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -101,7 +101,7 @@ class SeriesGroupBy(GroupBy[Series[S1]], Generic[S1, ByT]):
         normalize: Literal[False] = ...,
         sort: bool = ...,
         ascending: bool = ...,
-        bins=...,
+        bins: int | Sequence[int] | None = ...,
         dropna: bool = ...,
     ) -> Series[int]: ...
     @overload
@@ -110,7 +110,7 @@ class SeriesGroupBy(GroupBy[Series[S1]], Generic[S1, ByT]):
         normalize: Literal[True],
         sort: bool = ...,
         ascending: bool = ...,
-        bins=...,
+        bins: int | Sequence[int] | None = ...,
         dropna: bool = ...,
     ) -> Series[float]: ...
     def fillna(

--- a/tests/test_groupby.py
+++ b/tests/test_groupby.py
@@ -1062,3 +1062,30 @@ def test_groupby_getitem() -> None:
     df = DataFrame(np.random.random((3, 4)), columns=["a", "b", "c", "d"])
     check(assert_type(df.groupby("a")["b"].sum(), Series), Series, float)
     check(assert_type(df.groupby("a")[["b", "c"]].sum(), DataFrame), DataFrame)
+
+
+def test_series_value_counts() -> None:
+    df = DataFrame({"a": [1, 1, 2], "b": [4, 5, 6]})
+    check(
+        assert_type(df.groupby("a")["b"].value_counts(), "Series[int]"),
+        Series,
+        np.int64,
+    )
+    check(
+        assert_type(df.groupby("a")["b"].value_counts(bins=[3, 5, 7]), "Series[int]"),
+        Series,
+        np.int64,
+    )
+    check(
+        assert_type(df.groupby("a")["b"].value_counts(normalize=True), "Series[float]"),
+        Series,
+        np.float64,
+    )
+    check(
+        assert_type(
+            df.groupby("a")["b"].value_counts(bins=(3, 5, 7), normalize=True),
+            "Series[float]",
+        ),
+        Series,
+        np.float64,
+    )


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
