### PR TITLE
Add `index` and `columns`  as properties to Styler

### DIFF
--- a/pandas-stubs/io/formats/style.pyi
+++ b/pandas-stubs/io/formats/style.pyi
@@ -13,6 +13,7 @@ from matplotlib.colors import Colormap
 import numpy as np
 from pandas.core.frame import DataFrame
 from pandas.core.series import Series
+from pandas import Index
 
 from pandas._typing import (
     Axis,
@@ -52,6 +53,10 @@ class _DataFrameFunc(Protocol):
     ) -> npt.NDArray | DataFrame: ...
 
 class Styler(StylerRenderer):
+    @property
+    def columns(self) -> Index[Any]: ...
+    @property
+    def index(self) -> Index[Any]: ...
     def __init__(
         self,
         data: DataFrame | Series,

--- a/pandas-stubs/io/formats/style.pyi
+++ b/pandas-stubs/io/formats/style.pyi
@@ -11,9 +11,9 @@ from typing import (
 
 from matplotlib.colors import Colormap
 import numpy as np
+from pandas import Index
 from pandas.core.frame import DataFrame
 from pandas.core.series import Series
-from pandas import Index
 
 from pandas._typing import (
     Axis,

--- a/tests/test_styler.py
+++ b/tests/test_styler.py
@@ -13,8 +13,8 @@ import numpy as np
 import numpy.typing as npt
 from pandas import (
     DataFrame,
+    Index,
     Series,
-    Index
 )
 from pandas._testing import ensure_clean
 import pytest

--- a/tests/test_styler.py
+++ b/tests/test_styler.py
@@ -14,13 +14,13 @@ import numpy.typing as npt
 from pandas import (
     DataFrame,
     Series,
+    Index
 )
 from pandas._testing import ensure_clean
 import pytest
 from typing_extensions import assert_type
 
 from pandas._typing import Scalar
-from pandas import Index
 
 from tests import check
 

--- a/tests/test_styler.py
+++ b/tests/test_styler.py
@@ -20,6 +20,7 @@ import pytest
 from typing_extensions import assert_type
 
 from pandas._typing import Scalar
+from pandas import Index
 
 from tests import check
 
@@ -224,3 +225,9 @@ def test_subset() -> None:
     check(assert_type(DF.style.highlight_min(subset=IndexSlice[1:2]), Styler), Styler)
     check(assert_type(DF.style.highlight_min(subset=[1]), Styler), Styler)
     check(assert_type(DF.style.highlight_min(subset=DF.columns[1:]), Styler), Styler)
+
+
+def test_styler_columns_and_index() -> None:
+    styler = DF.style
+    check(assert_type(styler.columns, Index), Index)
+    check(assert_type(styler.index, Index), Index)


### PR DESCRIPTION
- [x] Closes #1102  
- [x] Tests added: `test_styler_columns_and_index` in `tests/test_styler.py`.
- [x] Tested with `pytest tests/test_styler.py` and `mypy tests/test_styler.py` 

## Changes As Per [Discussion](https://github.com/pandas-dev/pandas-stubs/issues/1102#issuecomment-2678701042) 
- Addition of `index` and `columns` to Styler in `style.pyi`
- Addition of tests in tests/test_style.py for testing `index` and `columns`

## Related Issues and PRs
- https://github.com/pandas-dev/pandas/issues/60815
- https://github.com/pandas-dev/pandas/pull/60979

## Also See [Source: [link](https://github.com/pandas-dev/pandas-stubs/issues/1102#issue-2817103087) ]
```
from typing_extensions import reveal_type
import pandas as pd
from pandas.io.formats import style as pd_style


def f(s: pd_style.Styler) -> pd_style.Styler:
    print(s.columns)
    fmt = "{:.2%}"
    return s.format(fmt)


df = pd.DataFrame({"a": [1, 2, 3]})
df2 = df.style.pipe(f)
reveal_type(df2)
```

**Output:**
```
$ mypy pandas-stubs/mytest/t.py
pandas-stubs/mytest/t.py:14: note: Revealed type is "pandas.io.formats.style.Styler"
Success: no issues found in 1 source file
```
## Additional Comments
First PR on pandas-stubs, your feedback will be highly valuable to me, Thanks!