### PR TITLE
type dataframe.insert

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -720,7 +720,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     def insert(
         self,
         loc: int,
-        column,
+        column: Hashable,
         value: Scalar | ListLikeU | None,
         allow_duplicates: _bool = ...,
     ) -> None: ...


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

this one's already tested

https://github.com/pandas-dev/pandas-stubs/blob/f7a1b8365c2d9818b66f14db725c15ae267a88b4/tests/test_frame.py#L3585-L3591

`column` just wasn't typed