### PR TITLE
GH1139 Series.rename inplace

### DIFF
--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -67,7 +67,7 @@ class Index(IndexOpsMixin[S1]):
     __hash__: ClassVar[None]  # type: ignore[assignment]
     # overloads with additional dtypes
     @overload
-    def __new__(  # pyright: ignore[reportOverlappingOverload]
+    def __new__(
         cls,
         data: Sequence[int | np.integer] | IndexOpsMixin[int] | np_ndarray_anyint,
         *,

--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -67,7 +67,7 @@ class Index(IndexOpsMixin[S1]):
     __hash__: ClassVar[None]  # type: ignore[assignment]
     # overloads with additional dtypes
     @overload
-    def __new__(
+    def __new__(  # pyright: ignore[reportOverlappingOverload]
         cls,
         data: Sequence[int | np.integer] | IndexOpsMixin[int] | np_ndarray_anyint,
         *,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1041,9 +1041,9 @@ class Series(IndexOpsMixin[S1], NDFrame):
         broadcast_axis: AxisIndex | None = ...,
     ) -> tuple[Series, Series]: ...
     @overload
-    def rename(  # pyright: ignore[reportOverlappingOverload]
+    def rename(
         self,
-        index: Hashable = ...,
+        index: Hashable,
         *,
         axis: Axis | None = ...,
         copy: bool = ...,
@@ -1052,7 +1052,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         errors: IgnoreRaise = ...,
     ) -> Self: ...
     @overload
-    def rename(  # type: ignore[overload-cannot-match]
+    def rename(
         self,
         index: Renamer | None = ...,
         *,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1043,6 +1043,17 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def rename(
         self,
+        index: None = ...,
+        *,
+        axis: Axis | None = ...,
+        copy: bool = ...,
+        inplace: Literal[True],
+        level: Level | None = ...,
+        errors: IgnoreRaise = ...,
+    ) -> None: ...
+    @overload
+    def rename(
+        self,
         index: Hashable,
         *,
         axis: Axis | None = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1043,18 +1043,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def rename(
         self,
-        index: None = ...,
-        *,
-        axis: Axis | None = ...,
-        copy: bool = ...,
-        inplace: Literal[True],
-        level: Level | None = ...,
-        errors: IgnoreRaise = ...,
-    ) -> None: ...
-    @overload
-    def rename(
-        self,
-        index: Hashable,
+        index: Hashable | None,
         *,
         axis: Axis | None = ...,
         copy: bool = ...,
@@ -1065,7 +1054,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def rename(
         self,
-        index: Renamer | None = ...,
+        index: Renamer = ...,
         *,
         axis: Axis | None = ...,
         copy: bool = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -249,7 +249,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         copy: bool = ...,
     ) -> Series[float]: ...
     @overload
-    def __new__(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+    def __new__(  # type: ignore[overload-overlap]
         cls,
         data: Sequence[Never],
         index: Axes | None = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -249,7 +249,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         copy: bool = ...,
     ) -> Series[float]: ...
     @overload
-    def __new__(  # type: ignore[overload-overlap]
+    def __new__(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
         cls,
         data: Sequence[Never],
         index: Axes | None = ...,
@@ -1041,9 +1041,20 @@ class Series(IndexOpsMixin[S1], NDFrame):
         broadcast_axis: AxisIndex | None = ...,
     ) -> tuple[Series, Series]: ...
     @overload
-    def rename(
+    def rename(  # pyright: ignore[reportOverlappingOverload]
         self,
-        index: Renamer | Hashable | None = ...,
+        index: Hashable = ...,
+        *,
+        axis: Axis | None = ...,
+        copy: bool = ...,
+        inplace: Literal[True],
+        level: Level | None = ...,
+        errors: IgnoreRaise = ...,
+    ) -> Self: ...
+    @overload
+    def rename(  # type: ignore[overload-cannot-match]
+        self,
+        index: Renamer | None = ...,
         *,
         axis: Axis | None = ...,
         copy: bool = ...,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -25,6 +25,7 @@ from typing import (
 )
 
 from _typing import (
+    Label,
     ReplaceValue,
     TimeZones,
 )
@@ -1041,7 +1042,29 @@ class Series(IndexOpsMixin[S1], NDFrame):
         broadcast_axis: AxisIndex | None = ...,
     ) -> tuple[Series, Series]: ...
     @overload
+    def rename(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+        self,
+        index: Callable[[Any], Label],
+        *,
+        axis: Axis | None = ...,
+        copy: bool = ...,
+        inplace: Literal[True],
+        level: Level | None = ...,
+        errors: IgnoreRaise = ...,
+    ) -> None: ...
+    @overload
     def rename(
+        self,
+        index: Mapping[Any, Label],
+        *,
+        axis: Axis | None = ...,
+        copy: bool = ...,
+        inplace: Literal[True],
+        level: Level | None = ...,
+        errors: IgnoreRaise = ...,
+    ) -> None: ...
+    @overload
+    def rename(  # type: ignore[overload-overlap]
         self,
         index: Hashable | None,
         *,
@@ -1051,17 +1074,6 @@ class Series(IndexOpsMixin[S1], NDFrame):
         level: Level | None = ...,
         errors: IgnoreRaise = ...,
     ) -> Self: ...
-    @overload
-    def rename(
-        self,
-        index: Renamer = ...,
-        *,
-        axis: Axis | None = ...,
-        copy: bool = ...,
-        inplace: Literal[True],
-        level: Level | None = ...,
-        errors: IgnoreRaise = ...,
-    ) -> None: ...
     @overload
     def rename(
         self,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1042,7 +1042,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         broadcast_axis: AxisIndex | None = ...,
     ) -> tuple[Series, Series]: ...
     @overload
-    def rename(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+    def rename(
         self,
         index: Callable[[Any], Label],
         *,
@@ -1064,9 +1064,9 @@ class Series(IndexOpsMixin[S1], NDFrame):
         errors: IgnoreRaise = ...,
     ) -> None: ...
     @overload
-    def rename(  # type: ignore[overload-overlap]
+    def rename(
         self,
-        index: Hashable | None,
+        index: Scalar | tuple[Hashable, ...] | None = None,
         *,
         axis: Axis | None = ...,
         copy: bool = ...,
@@ -1077,7 +1077,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def rename(
         self,
-        index: Renamer | Hashable | None = ...,
+        index: Renamer | Scalar | tuple[Hashable, ...] | None = ...,
         *,
         axis: Axis | None = ...,
         copy: bool = ...,

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1182,7 +1182,7 @@ def test_types_rename_axis() -> None:
 
 def test_types_values() -> None:
     check(
-        assert_type(pd.Series([1, 2, 3]).values, "np.ndarray | ExtensionArray"),
+        assert_type(pd.Series([1, 2, 3]).values, "ExtensionArray | np.ndarray"),
         np.ndarray,
     )
     check(
@@ -1244,11 +1244,13 @@ def test_types_rename() -> None:
         pd.Series,
         np.integer,
     )
-    s6 = pd.Series([1, 2, 3])
-    check(assert_type(s6.rename(lambda x: x**2, inplace=True), None), type(None))
+    check(
+        assert_type(pd.Series([1, 2, 3]).rename(lambda x: x**2, inplace=True), None),
+        type(None),
+    )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+        s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[dict-item] # pyright: ignore[reportArgumentType]
 
 
 def test_types_ne() -> None:

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1138,6 +1138,7 @@ def test_types_set_flags() -> None:
 
 def test_types_getitem() -> None:
     s = pd.Series({"key": [0, 1, 2, 3]})
+    check(assert_type(s["key"], Any), list)
     s2 = pd.Series([0, 1, 2, 3])
     check(assert_type(s2[0], int), np.integer)
     check(assert_type(s[:2], pd.Series), pd.Series)
@@ -1227,11 +1228,19 @@ def test_types_rename() -> None:
     s5 = pd.Series([1, 2, 3]).rename({1: 10})
     check(assert_type(s5, "pd.Series[int]"), pd.Series, np.integer)
     # inplace
-    # TODO fix issue with inplace=True returning a Series, cf pandas #60942
     check(
         assert_type(pd.Series([1, 2, 3]).rename("A", inplace=True), "pd.Series[int]"),
         pd.Series,
+        np.integer,
     )
+    check(
+        assert_type(pd.Series([1, 2, 3]).rename({1: 4, 2: 5}, inplace=True), None),
+        type(None),
+    )
+    # TODO this should not raise an error, the lambda is matched with Hashable
+    # check(
+    #     assert_type(pd.Series([1, 2, 3]).rename(lambda x: x**2, inplace=True), None), type(None)
+    # )
 
     if TYPE_CHECKING_INVALID_USAGE:
         s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1244,10 +1244,8 @@ def test_types_rename() -> None:
         pd.Series,
         np.integer,
     )
-    # TODO this should not raise an error, the lambda is matched with Hashable
-    # check(
-    #     assert_type(pd.Series([1, 2, 3]).rename(lambda x: x**2, inplace=True), None), type(None)
-    # )
+    s6 = pd.Series([1, 2, 3])
+    check(assert_type(s6.rename(lambda x: x**2, inplace=True), None), type(None))
 
     if TYPE_CHECKING_INVALID_USAGE:
         s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -70,6 +70,7 @@ else:
     TimedeltaSeries: TypeAlias = pd.Series
     TimestampSeries: TypeAlias = pd.Series
     OffsetSeries: TypeAlias = pd.Series
+    ExtensionArray: TypeAlias = np.ndarray
 
 if TYPE_CHECKING:
     from pandas._typing import (
@@ -1137,7 +1138,6 @@ def test_types_set_flags() -> None:
 
 def test_types_getitem() -> None:
     s = pd.Series({"key": [0, 1, 2, 3]})
-    key: list[int] = s["key"]
     s2 = pd.Series([0, 1, 2, 3])
     check(assert_type(s2[0], int), np.integer)
     check(assert_type(s[:2], pd.Series), pd.Series)
@@ -1180,12 +1180,28 @@ def test_types_rename_axis() -> None:
 
 
 def test_types_values() -> None:
-    n1: np.ndarray | ExtensionArray = pd.Series([1, 2, 3]).values
-    n2: np.ndarray | ExtensionArray = pd.Series(list("aabc")).values
-    n3: np.ndarray | ExtensionArray = pd.Series(list("aabc")).astype("category").values
-    n4: np.ndarray | ExtensionArray = pd.Series(
-        pd.date_range("20130101", periods=3, tz="US/Eastern")
-    ).values
+    check(
+        assert_type(pd.Series([1, 2, 3]).values, "np.ndarray | ExtensionArray"),
+        np.ndarray,
+    )
+    check(
+        assert_type(pd.Series(list("aabc")).values, " np.ndarray | ExtensionArray "),
+        np.ndarray,
+    )
+    check(
+        assert_type(
+            pd.Series(list("aabc")).astype("category").values,
+            "np.ndarray | ExtensionArray",
+        ),
+        pd.Categorical,
+    )
+    check(
+        assert_type(
+            pd.Series(pd.date_range("20130101", periods=3, tz="US/Eastern")).values,
+            "np.ndarray | ExtensionArray",
+        ),
+        np.ndarray,
+    )
 
 
 def test_types_rename() -> None:
@@ -1212,7 +1228,10 @@ def test_types_rename() -> None:
     check(assert_type(s5, "pd.Series[int]"), pd.Series, np.integer)
     # inplace
     # TODO fix issue with inplace=True returning a Series, cf pandas #60942
-    s6: None = pd.Series([1, 2, 3]).rename("A", inplace=True)
+    check(
+        assert_type(pd.Series([1, 2, 3]).rename("A", inplace=True), "pd.Series[int]"),
+        pd.Series,
+    )
 
     if TYPE_CHECKING_INVALID_USAGE:
         s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1237,6 +1237,10 @@ def test_types_rename() -> None:
         assert_type(pd.Series([1, 2, 3]).rename({1: 4, 2: 5}, inplace=True), None),
         type(None),
     )
+    check(
+        assert_type(pd.Series([1, 2, 3]).rename(index=None, inplace=True), None),
+        type(None),
+    )
     # TODO this should not raise an error, the lambda is matched with Hashable
     # check(
     #     assert_type(pd.Series([1, 2, 3]).rename(lambda x: x**2, inplace=True), None), type(None)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1238,8 +1238,11 @@ def test_types_rename() -> None:
         type(None),
     )
     check(
-        assert_type(pd.Series([1, 2, 3]).rename(index=None, inplace=True), None),
-        type(None),
+        assert_type(
+            pd.Series([1, 2, 3]).rename(index=None, inplace=True), "pd.Series[int]"
+        ),
+        pd.Series,
+        np.integer,
     )
     # TODO this should not raise an error, the lambda is matched with Hashable
     # check(

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -70,7 +70,6 @@ else:
     TimedeltaSeries: TypeAlias = pd.Series
     TimestampSeries: TypeAlias = pd.Series
     OffsetSeries: TypeAlias = pd.Series
-    ExtensionArray: TypeAlias = np.ndarray
 
 if TYPE_CHECKING:
     from pandas._typing import (
@@ -1182,24 +1181,24 @@ def test_types_rename_axis() -> None:
 
 def test_types_values() -> None:
     check(
-        assert_type(pd.Series([1, 2, 3]).values, "ExtensionArray | np.ndarray"),
+        assert_type(pd.Series([1, 2, 3]).values, Union[ExtensionArray, np.ndarray]),
         np.ndarray,
     )
     check(
-        assert_type(pd.Series(list("aabc")).values, " np.ndarray | ExtensionArray "),
+        assert_type(pd.Series(list("aabc")).values, Union[np.ndarray, ExtensionArray]),
         np.ndarray,
     )
     check(
         assert_type(
             pd.Series(list("aabc")).astype("category").values,
-            "np.ndarray | ExtensionArray",
+            Union[np.ndarray, ExtensionArray],
         ),
         pd.Categorical,
     )
     check(
         assert_type(
             pd.Series(pd.date_range("20130101", periods=3, tz="US/Eastern")).values,
-            "np.ndarray | ExtensionArray",
+            Union[np.ndarray, ExtensionArray],
         ),
         np.ndarray,
     )


### PR DESCRIPTION
- [x] Closes #1139 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

Added some test framework migration as this was how I originally found the issue with `rename`