### PR TITLE
GH1147 Drop version restriction on matplotlib and prevent test to write to root folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ pyright = ">=1.1.396"
 poethepoet = ">=0.16.5"
 loguru = ">=0.6.0"
 typing-extensions = ">=4.4.0"
-matplotlib = ">=3.5.1,<3.9.0" # TODO https://github.com/pandas-dev/pandas/issues/58851
+matplotlib = ">=3.5.10" # TODO https://github.com/pandas-dev/pandas/issues/58851
 pre-commit = ">=2.19.0"
 black = ">=23.3.0"
 isort = ">=5.12.0"
@@ -231,7 +231,7 @@ filterwarnings = [
   # treat warnings as errors
   "error",
   # until there is a new dateutil release: github.com/dateutil/dateutil/pull/1285
-  "ignore:datetime.datetime.utc:DeprecationWarning",
+  # "ignore:datetime.datetime.utc:DeprecationWarning",
 ]
 
 # Next line needed to avoid poetry complaint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ pyright = ">=1.1.396"
 poethepoet = ">=0.16.5"
 loguru = ">=0.6.0"
 typing-extensions = ">=4.4.0"
-matplotlib = ">=3.5.10" # TODO https://github.com/pandas-dev/pandas/issues/58851
+matplotlib = ">=3.6.3"
 pre-commit = ">=2.19.0"
 black = ">=23.3.0"
 isort = ">=5.12.0"
@@ -230,8 +230,6 @@ ignore-words-list = "indext, mose, sav, ser"
 filterwarnings = [
   # treat warnings as errors
   "error",
-  # until there is a new dateutil release: github.com/dateutil/dateutil/pull/1285
-  # "ignore:datetime.datetime.utc:DeprecationWarning",
 ]
 
 # Next line needed to avoid poetry complaint

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3996,8 +3996,10 @@ def test_hashable_args() -> None:
     df.columns = ["test"]  # type: ignore[assignment]
 
     testDict = {"test": 1}
-    df.to_string("test", col_space=testDict)
-    df.to_string("test", col_space={"test": 1})
+
+    with ensure_clean() as path:
+        df.to_string(path, col_space=testDict)
+        df.to_string(path, col_space={"test": 1})
 
 
 # GH 906

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -605,20 +605,28 @@ def test_grouped_dataframe_boxplot(close_figures):
     check(assert_type(grouped.boxplot(), Series), Series)
     check(assert_type(grouped.boxplot(subplots=True), Series), Series)
 
+
+def test_grouped_dataframe_boxplot_single(close_figures):
+    tuples = [t for t in itertools.product(range(10), range(2))]
+    index = pd.MultiIndex.from_tuples(tuples, names=["lvl0", "lvl1"])
+    df = pd.DataFrame(
+        data=np.random.randn(len(index), 2), columns=["A", "B"], index=index
+    )
+    grouped = df.groupby(level="lvl1")
+
     # a single plot
-    # check(
-    #     assert_type(
-    #         grouped.boxplot(
-    #             subplots=False,
-    #             rot=45,
-    #             fontsize=12,
-    #             figsize=(8, 10),
-    #             orientation="horizontal",
-    #         ),
-    #         Axes,
-    #     ),
-    #     Axes,
-    # )
+    check(
+        assert_type(
+            grouped.boxplot(
+                subplots=False,
+                rot=45,
+                fontsize=12,
+                figsize=(8, 10),
+            ),
+            Axes,
+        ),
+        Axes,
+    )
 
     # not a literal bool
     check(assert_type(grouped.boxplot(subplots=bool(0.5)), Union[Axes, Series]), Series)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -575,7 +575,10 @@ def test_plot_keywords(close_figures):
 
     df = pd.DataFrame(np.random.rand(10, 5), columns=["A", "B", "C", "D", "E"])
     check(
-        assert_type(df.plot(kind="box", vert=False, positions=[1, 4, 5, 6, 8]), Axes),
+        assert_type(
+            df.plot(kind="box", orientation="vertical", positions=[1, 4, 5, 6, 8]),
+            Axes,
+        ),
         Axes,
     )
 
@@ -603,15 +606,19 @@ def test_grouped_dataframe_boxplot(close_figures):
     check(assert_type(grouped.boxplot(subplots=True), Series), Series)
 
     # a single plot
-    check(
-        assert_type(
-            grouped.boxplot(
-                subplots=False, rot=45, fontsize=12, figsize=(8, 10), vert=False
-            ),
-            Axes,
-        ),
-        Axes,
-    )
+    # check(
+    #     assert_type(
+    #         grouped.boxplot(
+    #             subplots=False,
+    #             rot=45,
+    #             fontsize=12,
+    #             figsize=(8, 10),
+    #             orientation="horizontal",
+    #         ),
+    #         Axes,
+    #     ),
+    #     Axes,
+    # )
 
     # not a literal bool
     check(assert_type(grouped.boxplot(subplots=bool(0.5)), Union[Axes, Series]), Series)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -16,7 +16,10 @@ from pandas import Series
 import pytest
 from typing_extensions import assert_type
 
-from tests import check
+from tests import (
+    PD_LTE_22,
+    check,
+)
 
 from pandas.plotting import (
     deregister_matplotlib_converters,
@@ -605,8 +608,31 @@ def test_grouped_dataframe_boxplot(close_figures):
     check(assert_type(grouped.boxplot(), Series), Series)
     check(assert_type(grouped.boxplot(subplots=True), Series), Series)
 
+    # a single plot
+    if not PD_LTE_22:
+        check(
+            assert_type(
+                grouped.boxplot(
+                    subplots=False,
+                    rot=45,
+                    fontsize=12,
+                    figsize=(8, 10),
+                    orientation="horizontal",
+                ),
+                Axes,
+            ),
+            Axes,
+        )
+
 
 def test_grouped_dataframe_boxplot_single(close_figures):
+    """
+    Test with pandas 2.2.3 separated to make it pass.
+
+    With pandas 2.2.3 the passing of certain keywords is broken so this test
+    is put separately to  make sure that we have no Axes already created.
+    It will fail with `orientation="horizontal"`.
+    """
     tuples = [t for t in itertools.product(range(10), range(2))]
     index = pd.MultiIndex.from_tuples(tuples, names=["lvl0", "lvl1"])
     df = pd.DataFrame(
@@ -627,6 +653,21 @@ def test_grouped_dataframe_boxplot_single(close_figures):
         ),
         Axes,
     )
+
+    if not PD_LTE_22:
+        check(
+            assert_type(
+                grouped.boxplot(
+                    subplots=False,
+                    rot=45,
+                    fontsize=12,
+                    figsize=(8, 10),
+                    orientation="horizontal",
+                ),
+                Axes,
+            ),
+            Axes,
+        )
 
     # not a literal bool
     check(assert_type(grouped.boxplot(subplots=bool(0.5)), Union[Axes, Series]), Series)


### PR DESCRIPTION
- [x] Closes #1147 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
