### PR TITLE
Add "typing: stubs" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
+[![Typing: stubs](https://img.shields.io/pypi/types/pandas-stubs)](https://pypi.org/project/pandas-stubs/)
 
 ## What is it?
 


### PR DESCRIPTION
Since https://github.com/pandas-dev/pandas-stubs/pull/1092, this badge shows up as green, so I think it could be added to the README now?

Badge info: https://shields.io/badges/py-pi-types

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
