### PR TITLE
resolving issue 1162 I change Hashable to HashableT in _LocIndexerFrame and it'…

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -185,7 +185,7 @@ class _LocIndexerFrame(_LocIndexer, Generic[_T]):
             IndexType
             | MaskType
             | Callable[[DataFrame], IndexType | MaskType | Sequence[Hashable]]
-            | list[Hashable]
+            | list[HashableT]
             | tuple[
                 IndexType
                 | MaskType

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3585,6 +3585,16 @@ def test_in_columns() -> None:
     check(assert_type(df[cols], pd.DataFrame), pd.DataFrame)
     check(assert_type(df.groupby(by=cols).sum(), pd.DataFrame), pd.DataFrame)
 
+def test_loc_list_str() -> None:
+    # GH 1162 (PR)
+    df = pd.DataFrame([[1, 2], [4, 5], [7, 8]],
+                  index=['cobra', 'viper', 'sidewinder'],
+                  columns=['max_speed', 'shield'])
+
+    result = df.loc[['viper', 'sidewinder']]
+    check(assert_type(result, pd.DataFrame), pd.DataFrame)
+
+
 
 def test_insert_newvalues() -> None:
     df = pd.DataFrame({"a": [1, 2]})

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3585,15 +3585,17 @@ def test_in_columns() -> None:
     check(assert_type(df[cols], pd.DataFrame), pd.DataFrame)
     check(assert_type(df.groupby(by=cols).sum(), pd.DataFrame), pd.DataFrame)
 
+
 def test_loc_list_str() -> None:
     # GH 1162 (PR)
-    df = pd.DataFrame([[1, 2], [4, 5], [7, 8]],
-                  index=['cobra', 'viper', 'sidewinder'],
-                  columns=['max_speed', 'shield'])
+    df = pd.DataFrame(
+        [[1, 2], [4, 5], [7, 8]],
+        index=["cobra", "viper", "sidewinder"],
+        columns=["max_speed", "shield"],
+    )
 
-    result = df.loc[['viper', 'sidewinder']]
+    result = df.loc[["viper", "sidewinder"]]
     check(assert_type(result, pd.DataFrame), pd.DataFrame)
-
 
 
 def test_insert_newvalues() -> None:


### PR DESCRIPTION
This PR resolves [pandas-dev/pandas-stubs#1162](https://github.com/pandas-dev/pandas-stubs/issues/1162) by replacing Hashable with HashableT in _LocIndexerFrame. I also verified the changes using mypy:
```sh
mypy test.py
Success: no issues found in 1 source file
```


- [x] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
