### PR TITLE
GH1182 Add numpy integer, floating, complex to Scalar

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -518,7 +518,9 @@ IndexIterScalar: TypeAlias = (
     | Timestamp
     | Timedelta
 )
-Scalar: TypeAlias = IndexIterScalar | complex
+Scalar: TypeAlias = (
+    IndexIterScalar | complex | np.integer | np.floating | np.complexfloating
+)
 ScalarT = TypeVar("ScalarT", bound=Scalar)
 # Refine the definitions below in 3.9 to use the specialized type.
 np_ndarray_int64: TypeAlias = npt.NDArray[np.int64]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1531,6 +1531,15 @@ def test_types_to_numpy() -> None:
     # na_value param was added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
     check(assert_type(df.to_numpy(na_value=0), np.ndarray), np.ndarray)
 
+    df = pd.DataFrame(data={"col1": [1, 1, 2]}, dtype=np.complex128)
+    check(assert_type(df.to_numpy(na_value=0), np.ndarray), np.ndarray)
+    check(assert_type(df.to_numpy(na_value=np.int32(4)), np.ndarray), np.ndarray)
+    check(assert_type(df.to_numpy(na_value=np.float16(3.68)), np.ndarray), np.ndarray)
+    check(
+        assert_type(df.to_numpy(na_value=np.complex128(3.8, -493.2)), np.ndarray),
+        np.ndarray,
+    )
+
 
 def test_to_markdown() -> None:
     df = pd.DataFrame(data={"col1": [1, 1, 2], "col2": [3, 4, 5]})

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1749,6 +1749,9 @@ def test_types_to_numpy() -> None:
     check(assert_type(s.to_numpy(), np.ndarray), np.ndarray)
     check(assert_type(s.to_numpy(dtype="str", copy=True), np.ndarray), np.ndarray)
     check(assert_type(s.to_numpy(na_value=0), np.ndarray), np.ndarray)
+    check(assert_type(s.to_numpy(na_value=np.int32(4)), np.ndarray), np.ndarray)
+    check(assert_type(s.to_numpy(na_value=np.float16(4)), np.ndarray), np.ndarray)
+    check(assert_type(s.to_numpy(na_value=np.complex128(4, 7)), np.ndarray), np.ndarray)
 
 
 def test_where() -> None:


### PR DESCRIPTION
- [x] Closes #1182 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
