### PR TITLE
Improve parameter types for `DataFrame.pct_change` and `Series.pct_change`

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -8,7 +8,7 @@ from collections.abc import (
     Sequence,
 )
 import datetime
-from datetime import timedelta, tzinfo
+from datetime import tzinfo
 from os import PathLike
 from re import Pattern
 import sys
@@ -843,8 +843,6 @@ IntoColumn: TypeAlias = (
 )
 
 class PctChangeKwargs(TypedDict, total=False):
-    periods: int
-    freq: Frequency | timedelta | None
     axis: AxisIndex
     fill_value: object | None
 

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -8,7 +8,7 @@ from collections.abc import (
     Sequence,
 )
 import datetime
-from datetime import tzinfo
+from datetime import timedelta, tzinfo
 from os import PathLike
 from re import Pattern
 import sys
@@ -841,5 +841,11 @@ TimeZones: TypeAlias = str | tzinfo | None | int
 IntoColumn: TypeAlias = (
     AnyArrayLike | Scalar | Callable[[DataFrame], AnyArrayLike | Scalar]
 )
+
+class PctChangeKwargs(TypedDict, total=False):
+    periods: int
+    freq: Frequency | timedelta | None
+    axis: AxisIndex
+    fill_value: object | None
 
 __all__ = ["npt", "type_t"]

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -15,8 +15,8 @@ from typing import (
     Generic,
     Literal,
     NoReturn,
-    overload,
     Unpack,
+    overload,
 )
 
 from _typing import TimeZones
@@ -1989,10 +1989,10 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     def ne(self, other, axis: Axis = ..., level: Level | None = ...) -> Self: ...
     def pct_change(
         self,
-        periods: int = ...,
+        periods: int = 1,
         fill_method: None = ...,
         limit: int | None = ...,
-        freq=...,
+        freq: Frequency | dt.timedelta | None = None,
         **kwargs: Unpack[PctChangeKwargs],
     ) -> Self: ...
     def pop(self, item: _str) -> Series: ...

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -16,6 +16,7 @@ from typing import (
     Literal,
     NoReturn,
     overload,
+    Unpack,
 )
 
 from _typing import TimeZones
@@ -113,6 +114,7 @@ from pandas._typing import (
     NaPosition,
     NDFrameT,
     ParquetEngine,
+    PctChangeKwargs,
     QuantileInterpolation,
     RandomState,
     ReadBuffer,
@@ -1991,7 +1993,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         fill_method: None = ...,
         limit: int | None = ...,
         freq=...,
-        **kwargs: Any,  # TODO: make more precise https://github.com/pandas-dev/pandas-stubs/issues/1169
+        **kwargs: Unpack[PctChangeKwargs],
     ) -> Self: ...
     def pop(self, item: _str) -> Series: ...
     def pow(

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -22,6 +22,7 @@ from typing import (
     Literal,
     NoReturn,
     overload,
+    Unpack,
 )
 
 from _typing import (
@@ -143,6 +144,7 @@ from pandas._typing import (
     MaskType,
     NaPosition,
     ObjectDtypeArg,
+    PctChangeKwargs,
     QuantileInterpolation,
     RandomState,
     Renamer,
@@ -1552,7 +1554,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         fill_method: _str = ...,
         limit: int | None = ...,
         freq=...,
-        **kwargs: Any,  # TODO: make more precise https://github.com/pandas-dev/pandas-stubs/issues/1169
+        **kwargs: Unpack[PctChangeKwargs],
     ) -> Series[S1]: ...
     def first_valid_index(self) -> Scalar: ...
     def last_valid_index(self) -> Scalar: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -21,8 +21,8 @@ from typing import (
     Generic,
     Literal,
     NoReturn,
-    overload,
     Unpack,
+    overload,
 )
 
 from _typing import (
@@ -1550,10 +1550,10 @@ class Series(IndexOpsMixin[S1], NDFrame):
     ) -> Series[S1]: ...
     def pct_change(
         self,
-        periods: int = ...,
-        fill_method: _str = ...,
+        periods: int = 1,
+        fill_method: None = ...,
         limit: int | None = ...,
-        freq=...,
+        freq: Frequency | timedelta | None = None,
         **kwargs: Unpack[PctChangeKwargs],
     ) -> Series[S1]: ...
     def first_valid_index(self) -> Scalar: ...


### PR DESCRIPTION
This PR does the following for the two functions in the title:
- replace kwargs with keyword-only parameters for `pct_change` based on parameters from `shift`
- replace `...` w/ simple defaults when applicable based on docs: https://pandas.pydata.org/docs/reference/api/pandas.Series.pct_change.html
- make `fill_method` for `Series.pct_change` be `None`, just like `DataFrame.pct_change` since all other values are deprecated

- [ ] Closes #1169
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

cc @MarcoGorelli should these have tests? they're not overloaded so I'm not sure if it's necessary
