### PR TITLE
GH941 add `UnknownSeries` overload for `Series.map`

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -965,6 +965,12 @@ class Series(IndexOpsMixin[S1], NDFrame):
         na_action: None = ...,
     ) -> Series[S2]: ...
     @overload
+    def map(
+        self,
+        arg: Callable[[Any], Any] | Mapping[Any, Any] | UnknownSeries,
+        na_action: Literal["ignore"] | None = ...,
+    ) -> UnknownSeries: ...
+    @overload
     def aggregate(
         self: Series[int],
         func: Literal["mean"],

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3390,6 +3390,12 @@ def test_map() -> None:
         assert_type(s.map(series, na_action="ignore"), "pd.Series[str]"), pd.Series, str
     )
 
+    unknown_series = pd.Series([1, 0, None])
+    check(
+        assert_type(unknown_series.map({1: True, 0: False, None: None}), "pd.Series"),
+        pd.Series,
+    )
+
 
 def test_map_na() -> None:
     s: pd.Series[int] = pd.Series([1, pd.NA, 3])


### PR DESCRIPTION
Implements the suggested solution + tests in https://github.com/pandas-dev/pandas-stubs/issues/941#issuecomment-2289142525

- [ ] Closes #941
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
