### PR TITLE
GH1158 change type of tuples param for MultiIndex.from_tuples

### DIFF
--- a/pandas-stubs/core/indexes/multi.pyi
+++ b/pandas-stubs/core/indexes/multi.pyi
@@ -1,6 +1,7 @@
 from collections.abc import (
     Callable,
     Hashable,
+    Iterable,
     Sequence,
 )
 from typing import (
@@ -46,7 +47,7 @@ class MultiIndex(Index[Any]):
     @classmethod
     def from_tuples(
         cls,
-        tuples: Sequence[tuple[Hashable, ...]],
+        tuples: Iterable[tuple[Hashable, ...]],
         sortorder: int | None = ...,
         names: SequenceNotStr[Hashable] = ...,
     ) -> Self: ...

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -95,6 +95,10 @@ def test_multiindex_constructors() -> None:
         pd.MultiIndex,
     )
     check(
+        assert_type(pd.MultiIndex.from_tuples(zip([1, 2], [3, 4])), pd.MultiIndex),
+        pd.MultiIndex,
+    )
+    check(
         assert_type(pd.MultiIndex.from_tuples([(1, 3), (2, 4)]), pd.MultiIndex),
         pd.MultiIndex,
     )


### PR DESCRIPTION
- [ ] Closes #1158
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

I think we'll need to wait for https://github.com/pandas-dev/pandas/issues/61357 to be fixed before merging this