### PR TITLE
GH1221 Fix typing module exposure in pandas.api

### DIFF
--- a/pandas-stubs/api/__init__.pyi
+++ b/pandas-stubs/api/__init__.pyi
@@ -3,4 +3,5 @@ from pandas.api import (
     indexers as indexers,
     interchange as interchange,
     types as types,
+    typing as typing,
 )

--- a/pandas-stubs/api/typing/__init__.pyi
+++ b/pandas-stubs/api/typing/__init__.pyi
@@ -2,6 +2,7 @@ from pandas.core.groupby import (
     DataFrameGroupBy as DataFrameGroupBy,
     SeriesGroupBy as SeriesGroupBy,
 )
+from pandas.core.indexes.frozen import FrozenList as FrozenList
 from pandas.core.resample import (
     DatetimeIndexResamplerGroupby as DatetimeIndexResamplerGroupby,
     PeriodIndexResamplerGroupby as PeriodIndexResamplerGroupby,
@@ -20,6 +21,7 @@ from pandas.core.window import (
 )
 
 from pandas._libs import NaTType as NaTType
+from pandas._libs.lib import NoDefault as NoDefault
 from pandas._libs.missing import NAType as NAType
 
 from pandas.io.json._json import JsonReader as JsonReader

--- a/pandas-stubs/core/arrays/datetimes.pyi
+++ b/pandas-stubs/core/arrays/datetimes.pyi
@@ -1,6 +1,5 @@
 from datetime import tzinfo
 
-from _typing import TimeZones
 import numpy as np
 from pandas.core.arrays.datetimelike import (
     DatelikeOps,
@@ -11,6 +10,7 @@ from pandas.core.arrays.datetimelike import (
 from pandas._typing import (
     TimeAmbiguous,
     TimeNonexistent,
+    TimeZones,
 )
 
 from pandas.core.dtypes.dtypes import DatetimeTZDtype as DatetimeTZDtype

--- a/pandas-stubs/core/dtypes/dtypes.pyi
+++ b/pandas-stubs/core/dtypes/dtypes.pyi
@@ -5,7 +5,6 @@ from typing import (
     TypeVar,
 )
 
-from _typing import TimeZones
 import numpy as np
 from pandas.core.indexes.base import Index
 from pandas.core.series import Series
@@ -18,6 +17,7 @@ from pandas._libs.tslibs.offsets import (
 )
 from pandas._typing import (
     Ordered,
+    TimeZones,
     npt,
 )
 

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -18,10 +18,6 @@ from typing import (
     overload,
 )
 
-from _typing import (
-    FloatFormatType,
-    TimeZones,
-)
 from matplotlib.axes import Axes as PlotAxes
 import numpy as np
 from pandas import (
@@ -97,6 +93,7 @@ from pandas._typing import (
     Dtype,
     FilePath,
     FillnaOptions,
+    FloatFormatType,
     FormattersType,
     GroupByObjectNonScalar,
     HashableT,
@@ -147,6 +144,7 @@ from pandas._typing import (
     TimeAmbiguous,
     TimeNonexistent,
     TimeUnit,
+    TimeZones,
     ToStataByteorder,
     ToTimestampHow,
     UpdateJoin,

--- a/pandas-stubs/core/indexes/accessors.pyi
+++ b/pandas-stubs/core/indexes/accessors.pyi
@@ -9,7 +9,6 @@ from typing import (
     TypeVar,
 )
 
-from _typing import TimeZones
 import numpy as np
 import numpy.typing as npt
 from pandas import (
@@ -40,6 +39,7 @@ from pandas._typing import (
     TimeNonexistent,
     TimestampConvention,
     TimeUnit,
+    TimeZones,
     np_ndarray_bool,
 )
 

--- a/pandas-stubs/core/indexes/datetimes.pyi
+++ b/pandas-stubs/core/indexes/datetimes.pyi
@@ -9,11 +9,6 @@ from datetime import (
 )
 from typing import overload
 
-from _typing import (
-    AxesData,
-    Frequency,
-    TimeZones,
-)
 import numpy as np
 from pandas import (
     DataFrame,
@@ -31,10 +26,13 @@ from pandas.core.series import (
 from typing_extensions import Self
 
 from pandas._typing import (
+    AxesData,
     DateAndDatetimeLike,
     Dtype,
+    Frequency,
     IntervalClosedType,
     TimeUnit,
+    TimeZones,
 )
 
 from pandas.core.dtypes.dtypes import DatetimeTZDtype

--- a/pandas-stubs/core/indexes/multi.pyi
+++ b/pandas-stubs/core/indexes/multi.pyi
@@ -9,7 +9,6 @@ from typing import (
     overload,
 )
 
-from _typing import SequenceNotStr
 import numpy as np
 import pandas as pd
 from pandas.core.indexes.base import Index
@@ -23,6 +22,7 @@ from pandas._typing import (
     DtypeArg,
     HashableT,
     MaskType,
+    SequenceNotStr,
     np_ndarray_anyint,
     np_ndarray_bool,
 )

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -24,13 +24,6 @@ from typing import (
     overload,
 )
 
-from _typing import (
-    FloatFormatType,
-    Label,
-    ReplaceValue,
-    Suffixes,
-    TimeZones,
-)
 from matplotlib.axes import (
     Axes as PlotAxes,
     SubplotBase,
@@ -130,6 +123,7 @@ from pandas._typing import (
     FilePath,
     FillnaOptions,
     FloatDtypeArg,
+    FloatFormatType,
     GroupByObjectNonScalar,
     HashableT1,
     IgnoreRaise,
@@ -143,6 +137,7 @@ from pandas._typing import (
     JoinHow,
     JSONSerializable,
     JsonSeriesOrient,
+    Label,
     Level,
     ListLike,
     ListLikeU,
@@ -154,6 +149,7 @@ from pandas._typing import (
     RandomState,
     ReindexMethod,
     Renamer,
+    ReplaceValue,
     Scalar,
     ScalarT,
     SequenceNotStr,
@@ -161,11 +157,13 @@ from pandas._typing import (
     SortKind,
     StrDtypeArg,
     StrLike,
+    Suffixes,
     T,
     TimeAmbiguous,
     TimedeltaDtypeArg,
     TimestampDtypeArg,
     TimeUnit,
+    TimeZones,
     ToTimestampHow,
     UIntDtypeArg,
     ValueKeyFunc,


### PR DESCRIPTION
- [x] Closes #1221
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
