### PR TITLE
Remove some unnecessary S1 TypeVars

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -50,7 +50,10 @@ from pandas.core.reshape.pivot import (
     _PivotTableIndexTypes,
     _PivotTableValuesTypes,
 )
-from pandas.core.series import Series
+from pandas.core.series import (
+    Series,
+    UnknownSeries,
+)
 from pandas.core.window import (
     Expanding,
     ExponentialMovingWindow,
@@ -2008,7 +2011,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
             | Callable[[DataFrame], DataFrame]
             | Callable[[Any], _bool]
         ),
-        other: Scalar | Series[S1] | DataFrame | Callable | NAType | None = ...,
+        other: Scalar | UnknownSeries | DataFrame | Callable | NAType | None = ...,
         *,
         inplace: Literal[True],
         axis: Axis | None = ...,
@@ -2024,7 +2027,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
             | Callable[[DataFrame], DataFrame]
             | Callable[[Any], _bool]
         ),
-        other: Scalar | Series[S1] | DataFrame | Callable | NAType | None = ...,
+        other: Scalar | UnknownSeries | DataFrame | Callable | NAType | None = ...,
         *,
         inplace: Literal[False] = ...,
         axis: Axis | None = ...,

--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -19,7 +19,9 @@ import numpy as np
 from pandas import Index
 import pandas.core.indexing as indexing
 from pandas.core.resample import DatetimeIndexResampler
-from pandas.core.series import Series
+from pandas.core.series import (
+    UnknownSeries,
+)
 import sqlalchemy.engine
 from typing_extensions import (
     Concatenate,
@@ -28,7 +30,6 @@ from typing_extensions import (
 
 from pandas._libs.lib import NoDefault
 from pandas._typing import (
-    S1,
     Axis,
     CompressionOptions,
     CSVQuoting,
@@ -81,7 +82,7 @@ class NDFrame(indexing.IndexingMixin):
     def ndim(self) -> int: ...
     @property
     def size(self) -> int: ...
-    def equals(self, other: Series[S1]) -> _bool: ...
+    def equals(self, other: UnknownSeries) -> _bool: ...
     def __neg__(self) -> Self: ...
     def __pos__(self) -> Self: ...
     def __nonzero__(self) -> None: ...


### PR DESCRIPTION
While exploring #1232 I noticed a few places where `S1` is used unnecessarily, because it only appears in one argument and in a method of a class that's not generic in `S1`