### PR TITLE
Replace aliases to builtins with imports

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1,3 +1,7 @@
+from builtins import (
+    bool as _bool,
+    str as _str,
+)
 from collections.abc import (
     Callable,
     Hashable,
@@ -160,9 +164,6 @@ from pandas._typing import (
 
 from pandas.io.formats.style import Styler
 from pandas.plotting import PlotAccessor
-
-_str = str
-_bool = bool
 
 class _iLocIndexerFrame(_iLocIndexer, Generic[_T]):
     @overload
@@ -2148,7 +2149,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     def reindex_like(
         self,
         other: DataFrame,
-        method: _str | FillnaOptions | Literal["nearest"] | None = ...,
+        method: FillnaOptions | Literal["nearest"] | None = ...,
         copy: _bool = ...,
         limit: int | None = ...,
         tolerance: Scalar | AnyArrayLike | Sequence[Scalar] = ...,

--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -1,3 +1,7 @@
+from builtins import (
+    bool as _bool,
+    str as _str,
+)
 from collections.abc import (
     Callable,
     Hashable,
@@ -59,9 +63,6 @@ from pandas._typing import (
 
 from pandas.io.pytables import HDFStore
 from pandas.io.sql import SQLTable
-
-_bool = bool
-_str = str
 
 class NDFrame(indexing.IndexingMixin):
     __hash__: ClassVar[None]  # type: ignore[assignment] # pyright: ignore[reportIncompatibleMethodOverride]

--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -1,3 +1,4 @@
+from builtins import str as _str
 from collections.abc import (
     Callable,
     Hashable,
@@ -65,8 +66,6 @@ from pandas._typing import (
 )
 
 class InvalidIndexError(Exception): ...
-
-_str = str
 
 class Index(IndexOpsMixin[S1]):
     __hash__: ClassVar[None]  # type: ignore[assignment]

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1,3 +1,7 @@
+from builtins import (
+    bool as _bool,
+    str as _str,
+)
 from collections import dict_keys  # type: ignore[attr-defined]
 from collections.abc import (
     Callable,
@@ -178,9 +182,6 @@ from pandas.core.dtypes.base import ExtensionDtype
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 from pandas.plotting import PlotAccessor
-
-_bool: TypeAlias = bool
-_str: TypeAlias = str
 
 class _iLocIndexerSeries(_iLocIndexer, Generic[S1]):
     # get item
@@ -1078,7 +1079,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     def reindex_like(
         self,
         other: Series[S1],
-        method: _str | FillnaOptions | Literal["nearest"] | None = ...,
+        method: FillnaOptions | Literal["nearest"] | None = ...,
         copy: _bool = ...,
         limit: int | None = ...,
         tolerance: Scalar | AnyArrayLike | Sequence[Scalar] = ...,

--- a/pandas-stubs/core/strings.pyi
+++ b/pandas-stubs/core/strings.pyi
@@ -1,4 +1,5 @@
 # pyright: strict
+from builtins import slice as _slice
 from collections.abc import (
     Callable,
     Sequence,
@@ -8,7 +9,6 @@ from typing import (
     Any,
     Generic,
     Literal,
-    TypeAlias,
     TypeVar,
     overload,
 )
@@ -46,8 +46,6 @@ _T_BYTES = TypeVar("_T_BYTES", bound=Series[bytes] | Index[bytes])
 _T_STR = TypeVar("_T_STR", bound=Series[str] | Index[str])
 # Used for the result of str.partition
 _T_OBJECT = TypeVar("_T_OBJECT", bound=Series[type[object]] | Index[type[object]])
-
-_slice: TypeAlias = slice
 
 class StringMethods(
     NoNewAttributesMixin,


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

These aliases are not needed as they are there to avoid name collisions with methods defined in the class. Name collisions can be avoided by importing these symbols from `builtins` under a different name. This has no functional change to type checkers but has two tiny advantages:
1. IDEs now display the type as builtin type instead of an alias that doesn't exist at runtime
2. Linters like ruff can now understand that the symbol used is exactly the builtin one and can detect more bad usages (see the comment below)