### PR TITLE
GH1246 Upgrade to pandas 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ ty = "^0.0.1a8"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "1.16.0"
-pandas = "2.2.3"
+pandas = "2.3.0"
 pyarrow = ">=10.0.1"
 pytest = ">=7.1.2"
 pyright = ">=1.1.400"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -50,6 +50,7 @@ else:
 
 TYPE_CHECKING_INVALID_USAGE: Final = TYPE_CHECKING
 WINDOWS = os.name == "nt" or "cygwin" in platform.system().lower()
+PD_LTE_23 = Version(pd.__version__) < Version("2.3.999")
 PD_LTE_22 = Version(pd.__version__) < Version("2.2.999")
 NUMPY20 = np.lib.NumpyVersion(np.__version__) >= "2.0.0"
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,7 +4,7 @@ from pandas import errors
 import pytest
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     WINDOWS,
 )
 
@@ -108,13 +108,13 @@ def test_specification_error() -> None:
 
 
 def test_setting_with_copy_error() -> None:
-    if PD_LTE_22:
+    if PD_LTE_23:
         with pytest.raises(errors.SettingWithCopyError):
             raise errors.SettingWithCopyError()
 
 
 def test_setting_with_copy_warning() -> None:
-    if PD_LTE_22:
+    if PD_LTE_23:
         with pytest.warns(errors.SettingWithCopyWarning):
             warnings.warn("", errors.SettingWithCopyWarning)
 

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -49,6 +49,7 @@ from pandas._typing import Scalar
 
 from tests import (
     PD_LTE_22,
+    PD_LTE_23,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     ensure_clean,
@@ -450,7 +451,7 @@ def test_types_drop_duplicates() -> None:
         pd.DataFrame,
     )
 
-    if not PD_LTE_22:
+    if not PD_LTE_23:
         check(assert_type(df.drop_duplicates({"AAA"}), pd.DataFrame), pd.DataFrame)
         check(
             assert_type(df.drop_duplicates({"AAA": None}), pd.DataFrame), pd.DataFrame
@@ -1602,7 +1603,7 @@ def test_types_groupby_agg() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <built-in function (min|max)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(df.groupby("col1")["col3"].agg(min), pd.Series), pd.Series)
         check(
@@ -1751,7 +1752,7 @@ def test_types_window() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <built-in function (min|max)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(df.rolling(2).agg(max), pd.DataFrame),
@@ -1860,7 +1861,7 @@ def test_types_agg() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <(built-in function (min|max|mean)|function mean at 0x\w+)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(df.agg(min), pd.Series), pd.Series)
         check(assert_type(df.agg([min, max]), pd.DataFrame), pd.DataFrame)
@@ -1887,7 +1888,7 @@ def test_types_aggregate() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <built-in function (min|max)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(df.aggregate(min), pd.Series), pd.Series)
         check(assert_type(df.aggregate([min, max]), pd.DataFrame), pd.DataFrame)
@@ -2020,7 +2021,7 @@ def test_types_resample() -> None:
         FutureWarning,
         "'M' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         df.resample("M", on="date")
@@ -2163,7 +2164,7 @@ def test_pipe() -> None:
         FutureWarning,
         "'M' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         (
@@ -2504,7 +2505,7 @@ def test_types_regressions() -> None:
     tslist = list(pd.to_datetime(["2022-01-01", "2022-01-02"]))
     check(assert_type(tslist, list[pd.Timestamp]), list, pd.Timestamp)
     sseries = pd.Series(tslist)
-    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.2.99"):
+    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.3.99"):
         sseries + pd.Timedelta(1, "d")
 
     check(
@@ -2518,7 +2519,7 @@ def test_types_regressions() -> None:
         FutureWarning,
         "'H' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         pd.date_range(start="2021-12-01", periods=24, freq="H")
@@ -2644,7 +2645,7 @@ def test_read_csv() -> None:
             ),
             pd.DataFrame,
         )
-        if PD_LTE_22:
+        if PD_LTE_23:
             parse_dates_2 = {"combined_date": ["Year", "Month", "Day"]}
             with pytest_warns_bounded(
                 FutureWarning,
@@ -3098,7 +3099,7 @@ def test_frame_stack() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "The previous implementation of stack is deprecated",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(
@@ -3113,7 +3114,7 @@ def test_frame_stack() -> None:
             ),
             pd.Series,
         )
-        if PD_LTE_22:
+        if PD_LTE_23:
             check(
                 assert_type(
                     df_multi_level_cols2.stack(0, future_stack=False),
@@ -3145,7 +3146,7 @@ def test_frame_reindex_like() -> None:
         FutureWarning,
         "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
         lower="2.2.99",
-        upper="3.0.99",
+        upper="2.2.99",
     ):
         check(
             assert_type(
@@ -3277,7 +3278,7 @@ def test_groupby_result() -> None:
     index, value = next(iterator)
     assert_type((index, value), tuple[tuple, pd.DataFrame])
 
-    if PD_LTE_22:
+    if PD_LTE_23:
         check(assert_type(index, tuple), tuple, np.integer)
     else:
         check(assert_type(index, tuple), tuple, int)
@@ -3389,7 +3390,7 @@ def test_groupby_result_for_ambiguous_indexes() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "The default of observed=False is deprecated",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         categorical_index = pd.CategoricalIndex(df.a)
         iterator2 = df.groupby(categorical_index).__iter__()
@@ -3448,10 +3449,18 @@ def test_groupby_apply() -> None:
     def sum_mean(x: pd.DataFrame) -> float:
         return x.sum().mean()
 
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.apply operated on the grouping columns.",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            lower="2.2.99",
+            upper="2.3.99",
+        ),
     ):
         check(
             assert_type(df.groupby("col1").apply(sum_mean), pd.Series),
@@ -3459,30 +3468,53 @@ def test_groupby_apply() -> None:
         )
 
     lfunc: Callable[[pd.DataFrame], float] = lambda x: x.sum().mean()
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.apply operated on the grouping columns.",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            lower="2.2.99",
+        ),
     ):
         check(assert_type(df.groupby("col1").apply(lfunc), pd.Series), pd.Series)
 
     def sum_to_list(x: pd.DataFrame) -> list:
         return x.sum().tolist()
 
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.apply operated on the grouping columns.",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            lower="2.2.99",
+            upper="2.3.99",
+        ),
     ):
         check(assert_type(df.groupby("col1").apply(sum_to_list), pd.Series), pd.Series)
 
     def sum_to_series(x: pd.DataFrame) -> pd.Series:
         return x.sum()
 
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.apply operated on the grouping columns.",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            lower="2.2.99",
+            upper="2.3.99",
+        ),
     ):
         check(
             assert_type(df.groupby("col1").apply(sum_to_series), pd.DataFrame),
@@ -3492,10 +3524,18 @@ def test_groupby_apply() -> None:
     def sample_to_df(x: pd.DataFrame) -> pd.DataFrame:
         return x.sample()
 
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.apply operated on the grouping columns.",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.apply operated on the grouping columns.",
+            lower="2.2.99",
+            upper="2.3.99",
+        ),
     ):
         check(
             assert_type(
@@ -3769,7 +3809,7 @@ def test_resample_150_changes() -> None:
         FutureWarning,
         "'M' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         frame.resample("M", group_keys=True)
@@ -3872,7 +3912,7 @@ def test_getattr_and_dataframe_groupby() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <built-in function (min|max)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(df.groupby("col1").col3.agg(min), pd.Series), pd.Series)
         check(
@@ -4390,6 +4430,7 @@ def test_transpose() -> None:
         DeprecationWarning,
         msg,
         lower="2.2.99",
+        upper="2.2.99",
     ):
         check(assert_type(df.transpose(copy=True), pd.DataFrame), pd.DataFrame)
 

--- a/tests/test_groupby.py
+++ b/tests/test_groupby.py
@@ -34,7 +34,7 @@ from pandas.core.window import (
 from typing_extensions import assert_type
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
@@ -77,10 +77,18 @@ def test_frame_groupby_resample() -> None:
     check(assert_type(GB_DF.resample("ME").ax, Index), DatetimeIndex)
 
     # agg funcs
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+            lower="2.2.99",
+            upper="2.3.99",
+        ),
     ):
         check(assert_type(GB_DF.resample("ME").sum(), DataFrame), DataFrame)
         check(assert_type(GB_DF.resample("ME").prod(), DataFrame), DataFrame)
@@ -124,15 +132,23 @@ def test_frame_groupby_resample() -> None:
         GB_DF.resample("ME").fillna("ffill")  # type: ignore[operator] # pyright: ignore
 
     # aggregate / apply
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+            lower="2.2.99",
+            upper="2.3.99",
+        ),
     ):
         with pytest_warns_bounded(
             FutureWarning,
             r"The provided callable <function (sum|mean) .*> is currently using ",
-            upper="2.2.99",
+            upper="2.3.99",
         ):
             check(
                 assert_type(GB_DF.resample("ME").aggregate(np.sum), DataFrame),
@@ -172,10 +188,18 @@ def test_frame_groupby_resample() -> None:
     def f(val: DataFrame) -> Series:
         return val.mean()
 
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+            lower="2.2.99",
+            upper="2.3.99",
+        ),
     ):
         check(assert_type(GB_DF.resample("ME").aggregate(f), DataFrame), DataFrame)
 
@@ -189,15 +213,23 @@ def test_frame_groupby_resample() -> None:
     def df2scalar(val: DataFrame) -> float:
         return float(val.mean().mean())
 
-    with pytest_warns_bounded(
-        DeprecationWarning,
-        "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
-        upper="2.99",
+    with (
+        pytest_warns_bounded(
+            DeprecationWarning,
+            "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+            upper="2.2.99",
+        ),
+        pytest_warns_bounded(
+            FutureWarning,
+            "DataFrameGroupBy.(apply|resample) operated on the grouping columns",
+            lower="2.2.99",
+            upper="2.3.99",
+        ),
     ):
         with pytest_warns_bounded(
             FutureWarning,
             r"The provided callable <function (sum|mean) .*> is currently using ",
-            upper="2.2.99",
+            upper="2.3.99",
         ):
             check(GB_DF.resample("ME").aggregate(np.sum), DataFrame)
             check(GB_DF.resample("ME").aggregate([np.mean]), DataFrame)
@@ -250,7 +282,7 @@ def test_frame_groupby_resample() -> None:
         )
 
         # interpolate
-        if PD_LTE_22:
+        if PD_LTE_23:
             check(assert_type(GB_DF.resample("ME").interpolate(), DataFrame), DataFrame)
             check(
                 assert_type(
@@ -377,7 +409,7 @@ def test_series_groupby_resample() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(
@@ -426,7 +458,7 @@ def test_series_groupby_resample() -> None:
     check(assert_type(GB_S.resample("ME").asfreq(-1.0), "Series[float]"), Series, float)
 
     # interpolate
-    if PD_LTE_22:
+    if PD_LTE_23:
         check(
             assert_type(GB_S.resample("ME").interpolate(), "Series[float]"),
             Series,
@@ -475,7 +507,7 @@ def test_series_groupby_resample() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(GB_S.resample("ME").aggregate(np.sum), Series)
         check(GB_S.resample("ME").aggregate([np.mean]), DataFrame)
@@ -501,7 +533,7 @@ def test_frame_groupby_rolling() -> None:
     check(assert_type(GB_DF.rolling(1).obj, DataFrame), DataFrame)
     check(assert_type(GB_DF.rolling(1).on, Union[str, Index, None]), type(None))
     check(assert_type(GB_DF.rolling(1).method, Literal["single", "table"]), str)
-    if PD_LTE_22:
+    if PD_LTE_23:
         check(assert_type(GB_DF.rolling(1).axis, int), int)
 
     # agg funcs
@@ -522,7 +554,7 @@ def test_frame_groupby_rolling() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(GB_DF.rolling(1).aggregate(np.sum), DataFrame), DataFrame)
         check(assert_type(GB_DF.rolling(1).agg(np.sum), DataFrame), DataFrame)
@@ -566,7 +598,7 @@ def test_frame_groupby_rolling() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(GB_DF.rolling(1).aggregate(np.sum), DataFrame)
         check(GB_DF.rolling(1).aggregate([np.mean]), DataFrame)
@@ -644,7 +676,7 @@ def test_series_groupby_rolling() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(GB_S.rolling(1).aggregate("sum"), Series), Series)
         check(assert_type(GB_S.rolling(1).aggregate(np.sum), Series), Series)
@@ -696,7 +728,7 @@ def test_frame_groupby_expanding() -> None:
     check(assert_type(GB_DF.expanding(1).obj, DataFrame), DataFrame)
     check(assert_type(GB_DF.expanding(1).on, Union[str, Index, None]), type(None))
     check(assert_type(GB_DF.expanding(1).method, Literal["single", "table"]), str)
-    if PD_LTE_22:
+    if PD_LTE_23:
         check(assert_type(GB_DF.expanding(1).axis, int), int)
 
     # agg funcs
@@ -717,7 +749,7 @@ def test_frame_groupby_expanding() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(GB_DF.expanding(1).aggregate(np.sum), DataFrame), DataFrame)
         check(assert_type(GB_DF.expanding(1).agg(np.sum), DataFrame), DataFrame)
@@ -763,7 +795,7 @@ def test_frame_groupby_expanding() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(GB_DF.expanding(1).aggregate(np.sum), DataFrame)
         check(GB_DF.expanding(1).aggregate([np.mean]), DataFrame)
@@ -843,7 +875,7 @@ def test_series_groupby_expanding() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(GB_S.expanding(1).aggregate("sum"), Series), Series)
         check(assert_type(GB_S.expanding(1).aggregate(np.sum), Series), Series)
@@ -895,7 +927,7 @@ def test_frame_groupby_ewm() -> None:
     check(assert_type(GB_DF.ewm(1).obj, DataFrame), DataFrame)
     check(assert_type(GB_DF.ewm(1).on, Union[str, Index, None]), type(None))
     check(assert_type(GB_DF.ewm(1).method, Literal["single", "table"]), str)
-    if PD_LTE_22:
+    if PD_LTE_23:
         check(assert_type(GB_DF.ewm(1).axis, int), int)
 
     # agg funcs
@@ -908,11 +940,11 @@ def test_frame_groupby_ewm() -> None:
     check(assert_type(GB_DF.ewm(1).var(), DataFrame), DataFrame)
 
     # aggregate
-    if PD_LTE_22:
+    if PD_LTE_23:
         with pytest_warns_bounded(
             FutureWarning,
             r"The provided callable <function (sum|mean) .*> is currently using ",
-            upper="2.2.99",
+            upper="2.3.99",
         ):
             check(assert_type(GB_DF.ewm(1).aggregate(np.sum), DataFrame), DataFrame)
             check(assert_type(GB_DF.ewm(1).agg(np.sum), DataFrame), DataFrame)
@@ -943,7 +975,7 @@ def test_frame_groupby_ewm() -> None:
         with pytest_warns_bounded(
             FutureWarning,
             r"The provided callable <function (sum|mean) .*> is currently using ",
-            upper="2.2.99",
+            upper="2.3.99",
         ):
             check(GB_DF.ewm(1).aggregate(np.sum), DataFrame)
             check(GB_DF.ewm(1).aggregate([np.mean]), DataFrame)
@@ -1016,10 +1048,10 @@ def test_series_groupby_ewm() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(GB_S.ewm(1).aggregate("sum"), Series), Series)
-        if PD_LTE_22:
+        if PD_LTE_23:
             check(assert_type(GB_S.ewm(1).aggregate(np.sum), Series), Series)
             check(assert_type(GB_S.ewm(1).agg(np.sum), Series), Series)
             check(

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from tests import Dtype  # noqa: F401
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
@@ -356,7 +356,7 @@ def test_interval_range():
         FutureWarning,
         "'M' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         check(
@@ -680,7 +680,7 @@ def test_interval_index_arrays():
         FutureWarning,
         "'Y' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         pd.Series(pd.date_range("2000-01-01", "2003-01-01", freq="Y"))
@@ -984,7 +984,7 @@ def test_getitem() -> None:
     check(
         assert_type(iri[[0, 2, 4]], pd.Index),
         pd.Index,
-        np.integer if PD_LTE_22 else int,
+        np.integer if PD_LTE_23 else int,
     )
 
     mi = pd.MultiIndex.from_product([["a", "b"], ["c", "d"]], names=["ab", "cd"])
@@ -1123,7 +1123,7 @@ def test_iter() -> None:
         FutureWarning,
         "'H' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         for ts in pd.date_range(start="1/1/2023", end="1/08/2023", freq="6H"):

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -30,7 +30,7 @@ from typing_extensions import (
 from pandas._typing import Scalar
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
@@ -293,7 +293,7 @@ def test_concat_args() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         "The copy keyword is deprecated and will be removed in a future version.",
-        lower="2.2.99",
+        lower="2.3.99",
     ):
         check(assert_type(pd.concat([df, df2], copy=True), pd.DataFrame), pd.DataFrame)
     check(assert_type(pd.concat([df, df2], join="inner"), pd.DataFrame), pd.DataFrame)
@@ -560,11 +560,11 @@ def test_unique() -> None:
     )
     check(
         assert_type(pd.unique(pd.Index(["a", "b", "c", "a"])), np.ndarray),
-        np.ndarray if PD_LTE_22 else pd.Index,
+        np.ndarray if PD_LTE_23 else pd.Index,
     )
     check(
         assert_type(pd.unique(pd.RangeIndex(0, 10)), np.ndarray),
-        np.ndarray if PD_LTE_22 else pd.Index,
+        np.ndarray if PD_LTE_23 else pd.Index,
     )
     check(
         assert_type(pd.unique(pd.Categorical(["a", "b", "c", "a"])), pd.Categorical),
@@ -582,7 +582,7 @@ def test_unique() -> None:
             pd.unique(pd.timedelta_range(start="1 day", periods=4)),
             np.ndarray,
         ),
-        np.ndarray if PD_LTE_22 else pd.Index,
+        np.ndarray if PD_LTE_23 else pd.Index,
     )
 
 
@@ -900,15 +900,15 @@ def test_index_unqiue() -> None:
 
     check(assert_type(pd.unique(ci), pd.CategoricalIndex), pd.CategoricalIndex)
     check(
-        assert_type(pd.unique(dti), np.ndarray), np.ndarray if PD_LTE_22 else pd.Index
+        assert_type(pd.unique(dti), np.ndarray), np.ndarray if PD_LTE_23 else pd.Index
     )
-    check(assert_type(pd.unique(i), np.ndarray), np.ndarray if PD_LTE_22 else pd.Index)
+    check(assert_type(pd.unique(i), np.ndarray), np.ndarray if PD_LTE_23 else pd.Index)
     check(assert_type(pd.unique(pi), pd.PeriodIndex), pd.PeriodIndex)
-    check(assert_type(pd.unique(ri), np.ndarray), np.ndarray if PD_LTE_22 else pd.Index)
+    check(assert_type(pd.unique(ri), np.ndarray), np.ndarray if PD_LTE_23 else pd.Index)
     check(
-        assert_type(pd.unique(tdi), np.ndarray), np.ndarray if PD_LTE_22 else pd.Index
+        assert_type(pd.unique(tdi), np.ndarray), np.ndarray if PD_LTE_23 else pd.Index
     )
-    check(assert_type(pd.unique(mi), np.ndarray), np.ndarray if PD_LTE_22 else pd.Index)
+    check(assert_type(pd.unique(mi), np.ndarray), np.ndarray if PD_LTE_23 else pd.Index)
     check(
         assert_type(pd.unique(interval_i), "pd.IntervalIndex[pd.Interval[int]]"),
         pd.IntervalIndex,
@@ -1588,7 +1588,7 @@ def test_crosstab_args() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(pd.crosstab(a, b, values=values, aggfunc=np.sum), pd.DataFrame),
@@ -1816,7 +1816,7 @@ def test_pivot_table() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function sum .*> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(
@@ -1852,7 +1852,7 @@ def test_pivot_table() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function sum .*> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(
@@ -1920,7 +1920,7 @@ def test_pivot_table() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function sum .*> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(
@@ -1947,7 +1947,7 @@ def test_pivot_table() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function sum .*> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(
@@ -2048,7 +2048,7 @@ def test_pivot_table() -> None:
         FutureWarning,
         "'M' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         check(
@@ -2064,7 +2064,7 @@ def test_pivot_table() -> None:
         FutureWarning,
         "'(M|A)' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         check(

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -17,7 +17,7 @@ import pytest
 from typing_extensions import assert_type
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     check,
 )
 
@@ -609,7 +609,7 @@ def test_grouped_dataframe_boxplot(close_figures):
     check(assert_type(grouped.boxplot(subplots=True), Series), Series)
 
     # a single plot
-    if not PD_LTE_22:
+    if not PD_LTE_23:
         check(
             assert_type(
                 grouped.boxplot(
@@ -654,7 +654,7 @@ def test_grouped_dataframe_boxplot_single(close_figures):
         Axes,
     )
 
-    if not PD_LTE_22:
+    if not PD_LTE_23:
         check(
             assert_type(
                 grouped.boxplot(

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -21,7 +21,7 @@ from pandas.core.resample import DatetimeIndexResampler
 from typing_extensions import assert_type
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
@@ -96,7 +96,7 @@ def test_aggregate() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(DF.resample("ME").aggregate(np.sum), DataFrame), DataFrame)
         check(assert_type(DF.resample("ME").agg(np.sum), DataFrame), DataFrame)
@@ -149,7 +149,7 @@ def test_interpolate() -> None:
 
 
 def test_interpolate_inplace() -> None:
-    if PD_LTE_22:
+    if PD_LTE_23:
         # Bug in main see https://github.com/pandas-dev/pandas/issues/58690
         check(
             assert_type(DF.resample("ME").interpolate(inplace=True), None), type(None)
@@ -328,7 +328,7 @@ def test_aggregate_series() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(S.resample("ME").aggregate(np.sum), _AggRetType), Series)
         check(assert_type(S.resample("ME").agg(np.sum), _AggRetType), Series)
@@ -365,7 +365,7 @@ def test_interpolate_series() -> None:
 
 
 def test_interpolate_inplace_series() -> None:
-    if PD_LTE_22:
+    if PD_LTE_23:
         # Bug in main see https://github.com/pandas-dev/pandas/issues/58690
         check(assert_type(S.resample("ME").interpolate(inplace=True), None), type(None))
 
@@ -407,7 +407,7 @@ def test_aggregate_series_combinations() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(S.resample("ME").aggregate(np.sum), Series)
         check(S.resample("ME").aggregate([np.mean]), DataFrame)
@@ -432,7 +432,7 @@ def test_aggregate_frame_combinations() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(DF.resample("ME").aggregate(np.sum), DataFrame)
         check(DF.resample("ME").aggregate([np.mean]), DataFrame)

--- a/tests/test_scalars.py
+++ b/tests/test_scalars.py
@@ -386,10 +386,10 @@ def test_interval_cmp():
 
 def test_timedelta_construction() -> None:
     check(assert_type(pd.Timedelta(1, "W"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.2.99"):
+    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.3.99"):
         check(assert_type(pd.Timedelta(1, "w"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta(1, "D"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.2.99"):
+    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.3.99"):
         check(assert_type(pd.Timedelta(1, "d"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta(1, "days"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta(1, "day"), pd.Timedelta), pd.Timedelta)
@@ -423,10 +423,10 @@ def test_timedelta_construction() -> None:
     check(assert_type(pd.Timedelta(1, "nanosecond"), pd.Timedelta), pd.Timedelta)
 
     check(assert_type(pd.Timedelta("1 W"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.2.99"):
+    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.3.99"):
         check(assert_type(pd.Timedelta("1 w"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta("1 D"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.2.99"):
+    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.3.99"):
         check(assert_type(pd.Timedelta("1 d"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta("1 days"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta("1 day"), pd.Timedelta), pd.Timedelta)
@@ -1573,7 +1573,7 @@ def test_timestamp_misc_methods() -> None:
         FutureWarning,
         "'H' is deprecated ",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         check(
@@ -1614,7 +1614,7 @@ def test_timestamp_misc_methods() -> None:
         FutureWarning,
         "'H' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         check(
@@ -1654,7 +1654,7 @@ def test_timestamp_misc_methods() -> None:
         FutureWarning,
         "'H' is deprecated",
         lower="2.1.99",
-        upper="2.2.99",
+        upper="2.3.99",
         upper_exception=ValueError,
     ):
         check(

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -49,7 +49,7 @@ from pandas._typing import (
 )
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     TYPE_CHECKING_INVALID_USAGE,
     WINDOWS,
     check,
@@ -186,7 +186,7 @@ def test_types_copy() -> None:
 
 def test_types_select() -> None:
     s = pd.Series(data={"row1": 1, "row2": 2})
-    if PD_LTE_22:
+    if PD_LTE_23:
         # Not valid in 3.0
         with pytest_warns_bounded(
             FutureWarning,
@@ -926,7 +926,7 @@ def test_groupby_result() -> None:
     index, value = next(iterator)
     assert_type((index, value), tuple[tuple, "pd.Series[int]"])
 
-    if PD_LTE_22:
+    if PD_LTE_23:
         check(assert_type(index, tuple), tuple, np.integer)
     else:
         check(assert_type(index, tuple), tuple, int)
@@ -1055,7 +1055,7 @@ def test_groupby_result_for_ambiguous_indexes() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "The default of observed=False is deprecated",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         categorical_index = pd.CategoricalIndex(s.index)
         iterator2 = s.groupby(categorical_index).__iter__()
@@ -1076,7 +1076,7 @@ def test_types_groupby_agg() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <built-in function (min|sum)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(s.groupby(level=0).agg(sum), pd.Series), pd.Series)
         check(
@@ -1094,7 +1094,7 @@ def test_types_groupby_aggregate() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <built-in function (min|sum)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(s.groupby(level=0).aggregate(sum), pd.Series), pd.Series)
         check(
@@ -1150,7 +1150,7 @@ def test_types_window() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <built-in function (min|max|sum)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(s.rolling(2).agg(sum), pd.Series),
@@ -1220,9 +1220,9 @@ def test_types_agg() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <(built-in function (min|max|mean)|function mean at 0x\w+)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
-        check(assert_type(s.agg(min), int), np.integer if PD_LTE_22 else int)
+        check(assert_type(s.agg(min), int), np.integer if PD_LTE_23 else int)
         check(assert_type(s.agg([min, max]), pd.Series), pd.Series, np.integer)
         check(assert_type(s.agg({0: min}), pd.Series), pd.Series, np.integer)
         check(
@@ -1244,9 +1244,9 @@ def test_types_aggregate() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <built-in function (min|max)> is currently using",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
-        check(assert_type(s.aggregate(min), int), np.integer if PD_LTE_22 else int)
+        check(assert_type(s.aggregate(min), int), np.integer if PD_LTE_23 else int)
         check(
             assert_type(s.aggregate([min, max]), pd.Series),
             pd.Series,
@@ -1972,7 +1972,7 @@ def test_bitwise_operators() -> None:
     check(assert_type(s ^ s2, "pd.Series[int]"), pd.Series, np.integer)
     check(assert_type(s2 ^ s, "pd.Series[int]"), pd.Series, np.integer)
 
-    if PD_LTE_22:
+    if PD_LTE_23:
         with pytest_warns_bounded(
             FutureWarning,
             r"Logical ops \(and, or, xor\) between Pandas objects and dtype-less sequences "
@@ -2020,7 +2020,7 @@ def test_logical_operators() -> None:
 
     check(assert_type(True ^ (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
 
-    if PD_LTE_22:
+    if PD_LTE_23:
         with pytest_warns_bounded(
             FutureWarning,
             r"Logical ops \(and, or, xor\) between Pandas objects and dtype-less sequences "
@@ -3752,7 +3752,7 @@ def test_series_reindex_like() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
-        lower="2.2.99",
+        lower="2.3.99",
         upper="3.0.99",
     ):
         check(
@@ -3791,7 +3791,7 @@ def test_align() -> None:
     with pytest_warns_bounded(
         DeprecationWarning,
         msg,
-        lower="2.2.99",
+        lower="2.3.99",
     ):
         aligned_s0, aligned_s1 = s0.align(s1, fill_value=0, axis=0, level=0, copy=False)
 

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -30,7 +30,7 @@ from typing_extensions import (
 from pandas._typing import TimeUnit
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
@@ -416,11 +416,11 @@ def test_series_dt_accessors() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "The behavior of DatetimeProperties.to_pydatetime is deprecated",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(
             assert_type(s0.dt.to_pydatetime(), np.ndarray),
-            np.ndarray if PD_LTE_22 else pd.Series,
+            np.ndarray if PD_LTE_23 else pd.Series,
             dt.datetime,
         )
     s0_local = s0.dt.tz_localize("UTC")
@@ -541,7 +541,7 @@ def test_series_dt_accessors() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "The behavior of TimedeltaProperties.to_pytimedelta is deprecated",
-        lower="2.2.99",
+        lower="2.3.99",
     ):
         check(assert_type(s2.dt.to_pytimedelta(), np.ndarray), np.ndarray)
     check(assert_type(s2.dt.total_seconds(), "pd.Series[float]"), pd.Series, float)
@@ -867,10 +867,10 @@ def test_types_to_numpy() -> None:
 
 def test_to_timedelta_units() -> None:
     check(assert_type(pd.to_timedelta(1, "W"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.2.99"):
+    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.3.99"):
         check(assert_type(pd.to_timedelta(1, "w"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.to_timedelta(1, "D"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.2.99"):
+    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.3.99"):
         check(assert_type(pd.to_timedelta(1, "d"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.to_timedelta(1, "days"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.to_timedelta(1, "day"), pd.Timedelta), pd.Timedelta)

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -15,7 +15,7 @@ from pandas.core.window import (
 from typing_extensions import assert_type
 
 from tests import (
-    PD_LTE_22,
+    PD_LTE_23,
     check,
     pytest_warns_bounded,
 )
@@ -101,7 +101,7 @@ def test_rolling_aggregate() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(DF.rolling(10).aggregate(np.mean), DataFrame), DataFrame)
         check(
@@ -126,7 +126,7 @@ def test_rolling_aggregate() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(DF.rolling(10).aggregate([np.mean]), DataFrame), DataFrame)
         check(
@@ -196,7 +196,7 @@ def test_rolling_aggregate_series() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function mean .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(S.rolling(10).aggregate(np.mean), Series), Series)
 
@@ -260,7 +260,7 @@ def test_expanding_aggregate() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(DF.expanding(10).aggregate(np.mean), DataFrame), DataFrame)
         check(
@@ -314,7 +314,7 @@ def test_expanding_aggregate_series() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         r"The provided callable <function (sum|mean) .*> is currently using ",
-        upper="2.2.99",
+        upper="2.3.99",
     ):
         check(assert_type(S.expanding(10).aggregate(np.mean), Series), Series)
         check(
@@ -340,11 +340,11 @@ def test_ewm_basic_math() -> None:
 
 
 def test_ewm_aggregate() -> None:
-    if PD_LTE_22:
+    if PD_LTE_23:
         with pytest_warns_bounded(
             FutureWarning,
             r"The provided callable <function (sum|mean) .*> is currently using ",
-            upper="2.2.99",
+            upper="2.3.99",
         ):
             check(assert_type(DF.ewm(span=10).aggregate(np.mean), DataFrame), DataFrame)
             check(
@@ -371,11 +371,11 @@ def test_ewm_basic_math_series() -> None:
 
 
 def test_ewm_aggregate_series() -> None:
-    if PD_LTE_22:
+    if PD_LTE_23:
         with pytest_warns_bounded(
             FutureWarning,
             r"The provided callable <function (sum|mean) .*> is currently using ",
-            upper="2.2.99",
+            upper="2.3.99",
         ):
             check(assert_type(S.ewm(span=10).aggregate(np.mean), Series), Series)
             check(


### PR DESCRIPTION
- [x] Closes #1246 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
