### PR TITLE
fix: assign Sequences

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -998,8 +998,8 @@ TimeZones: TypeAlias = str | tzinfo | None | int
 IntoColumn: TypeAlias = (
     AnyArrayLike
     | Scalar
-    | Callable[[DataFrame], AnyArrayLike | Scalar | list[Scalar] | range]
-    | list[Scalar]
+    | Callable[[DataFrame], AnyArrayLike | Scalar | Sequence[Scalar] | range]
+    | Sequence[Scalar]
     | range
     | None
 )

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -317,7 +317,11 @@ def test_types_assign() -> None:
     df = pd.DataFrame({"a": [1, 2, 3]})
     check(
         assert_type(
-            df.assign(b=lambda df: range(len(df)), c=lambda _: [10, 20, 30]),
+            df.assign(
+                b=lambda df: range(len(df)),
+                c=lambda _: [10, 20, 30],
+                d=lambda _: (10, 20, 30),
+            ),
             pd.DataFrame,
         ),
         pd.DataFrame,
@@ -326,6 +330,9 @@ def test_types_assign() -> None:
         assert_type(df.assign(b=range(len(df)), c=[10, 20, 30]), pd.DataFrame),
         pd.DataFrame,
     )
+
+    df = pd.DataFrame()
+    check(assert_type(df.assign(a=[], b=()), pd.DataFrame), pd.DataFrame)
 
 
 def test_assign() -> None:


### PR DESCRIPTION
# Describe the bug

Following #1250, `DataFrame.assign()` should allow `Sequence`s, e.g. `tuple`s

# To Reproduce

```py
import pandas as pd
df = pd.DataFrame({"a": (1,2,3)})
df = df.assign(d=lambda df: (10,20,30))
```
 
Need to update `IntoColumn` in `_typing.pyi` to include `Sequence[Scalar]`

# Please complete the following information
- OS: Windows 11
- python version: 3.10
- `mypy` 1.16.0
- version of installed `pandas-stubs` :  development version

- [x] Tests added: Please use `assert_type()` to assert the type of any return value
