### PR TITLE
Include `unit` argument in `timedelta_range` type stub

### DIFF
--- a/pandas-stubs/core/indexes/timedeltas.pyi
+++ b/pandas-stubs/core/indexes/timedeltas.pyi
@@ -83,4 +83,6 @@ def timedelta_range(
     freq: str | DateOffset | Timedelta | dt.timedelta | None = ...,
     name: Hashable | None = ...,
     closed: Literal["left", "right"] | None = ...,
+    *,
+    unit: None | str = ...,
 ) -> TimedeltaIndex: ...

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -1309,6 +1309,18 @@ def test_timedelta_range() -> None:
         ),
         pd.TimedeltaIndex,
     )
+    check(
+        assert_type(
+            pd.timedelta_range(
+                pd.Timedelta(1, unit="D"),
+                pd.Timedelta(10, unit="D"),
+                periods=10,
+                unit="s",
+            ),
+            pd.TimedeltaIndex,
+        ),
+        pd.TimedeltaIndex,
+    )
 
 
 def test_dateoffset_freqstr() -> None:


### PR DESCRIPTION
As of pandas 2.0, `pd.timedelta_range` allows passing a `unit` argument which controls the underlying precision of the returned timedeltas ([link](https://github.com/pandas-dev/pandas/blob/f94b430126efbe4a3078f95e90846a4d6161448a/pandas/core/indexes/timedeltas.py#L240-L272)).  This PR updates the type stub to reflect this.

- [x] Tests added: Please use `assert_type()` to assert the type of any return value
