### PR TITLE
GH1149 Add testing for pd.Series.str behavior

### DIFF
--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3977,7 +3977,7 @@ def test_timedelta_index_cumprod() -> None:
         assert_type(as_period_series.cumprod(), Never)
 
 
-def test_series_str_upper() -> None:
+def test_series_str_methods() -> None:
     """Test the returns of StringMethods match the type of the input series GH1149."""
     s_str = pd.Series(["a", "b"])
     check(assert_type(s_str, "pd.Series[str]"), pd.Series, str)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3979,7 +3979,7 @@ def test_timedelta_index_cumprod() -> None:
 
 def test_series_str_upper() -> None:
     """Test the returns of StringMethods match the type of the input series GH1149."""
-    s_str = pd.Series(['a', 'b'])
+    s_str = pd.Series(["a", "b"])
     check(assert_type(s_str, "pd.Series[str]"), pd.Series, str)
     check(assert_type(s_str.str.upper(), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s_str.str.lower(), "pd.Series[str]"), pd.Series, str)

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -3975,3 +3975,11 @@ def test_timedelta_index_cumprod() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         assert_type(as_period_series.cumprod(), Never)
+
+
+def test_series_str_upper() -> None:
+    """Test the returns of StringMethods match the type of the input series GH1149."""
+    s_str = pd.Series(['a', 'b'])
+    check(assert_type(s_str, "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s_str.str.upper(), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s_str.str.lower(), "pd.Series[str]"), pd.Series, str)


### PR DESCRIPTION
- [x] Closes #1149 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

@cmp0xff noticed that the wrong behavior (pd.Series[Any]) was not the case anymore so this PR only adds tests to ensure the behavior.