### PR TITLE
GHXXX Simple maintenance with new hook for ruff and updated version of ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,9 +11,9 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.12.3
     hooks:
-    -   id: ruff
+    -   id: ruff-check
         args: [
           --exit-non-zero-on-fix,
           --target-version, py39,


### PR DESCRIPTION
Simple maintenance of the pre-commit stages to realign ruff with latest and change the endpoint (ruff became ruff-check).

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
