### PR TITLE
Update mypy to 1.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ types-pytz = ">= 2022.1.1"
 numpy = ">= 1.23.5"
 
 [tool.poetry.group.dev.dependencies]
-mypy = "1.16.0"
+mypy = "1.17.0"
 pandas = "2.3.0"
 pyarrow = ">=10.0.1"
 pytest = ">=7.1.2"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,7 +64,7 @@ def check(
     if not isinstance(actual, klass):
         raise RuntimeError(f"Expected type '{klass}' but got '{type(actual)}'")
     if dtype is None:
-        return actual  # type: ignore[return-value]
+        return actual
 
     if isinstance(actual, pd.Series):
         value = actual.iloc[index_to_check_for_type]
@@ -82,7 +82,7 @@ def check(
 
     if not isinstance(value, dtype):
         raise RuntimeError(f"Expected type '{dtype}' but got '{type(value)}'")
-    return actual  # type: ignore[return-value]
+    return actual
 
 
 def pytest_warns_bounded(


### PR DESCRIPTION
Update mypy to latest version and drop two ignores that have become unnecessary.

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
