### PR TITLE
fix nightly runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ numpy = ">= 1.23.5"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "1.17.0"
-pandas = "2.3.0"
+pandas = "2.3.1"
 pyarrow = ">=10.0.1"
 pytest = ">=7.1.2"
 pyright = ">=1.1.400"

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2949,7 +2949,10 @@ def test_dataframe_replace() -> None:
     check(assert_type(df.replace(regex=pattern, value="x"), pd.DataFrame), pd.DataFrame)
 
     check(assert_type(df.replace(["a"], ["x"]), pd.DataFrame), pd.DataFrame)
-    check(assert_type(df.replace([pattern], ["x"]), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.replace([pattern], ["x"], regex=True), pd.DataFrame),
+        pd.DataFrame,
+    )
     check(assert_type(df.replace(regex=["a"], value=["x"]), pd.DataFrame), pd.DataFrame)
     check(
         assert_type(df.replace(regex=[pattern], value=["x"]), pd.DataFrame),
@@ -2958,7 +2961,9 @@ def test_dataframe_replace() -> None:
 
     check(assert_type(df.replace({"a": "x"}), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.replace(replace_dict_scalar), pd.DataFrame), pd.DataFrame)
-    check(assert_type(df.replace({pattern: "x"}), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.replace({pattern: "x"}, regex=True), pd.DataFrame), pd.DataFrame
+    )
     check(assert_type(df.replace(pd.Series({"a": "x"})), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.replace(regex={"a": "x"}), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.replace(regex={pattern: "x"}), pd.DataFrame), pd.DataFrame)
@@ -3003,7 +3008,9 @@ def test_dataframe_replace() -> None:
         pd.DataFrame,
     )
     check(
-        assert_type(df.replace({"col1": [pattern]}, {"col1": ["x"]}), pd.DataFrame),
+        assert_type(
+            df.replace({"col1": [pattern]}, {"col1": ["x"]}, regex=True), pd.DataFrame
+        ),
         pd.DataFrame,
     )
     check(
@@ -3037,7 +3044,10 @@ def test_dataframe_replace() -> None:
 
     check(assert_type(df.replace({"col1": {"a": "x"}}), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.replace(replace_dict_per_column), pd.DataFrame), pd.DataFrame)
-    check(assert_type(df.replace({"col1": {pattern: "x"}}), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.replace({"col1": {pattern: "x"}}, regex=True), pd.DataFrame),
+        pd.DataFrame,
+    )
     check(
         assert_type(df.replace({"col1": pd.Series({"a": "x"})}), pd.DataFrame),
         pd.DataFrame,
@@ -3168,7 +3178,7 @@ def test_frame_reindex_like() -> None:
     with pytest_warns_bounded(
         FutureWarning,
         "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
-        lower="2.3.0",
+        lower="2.3.99",
     ):
         check(
             assert_type(

--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -6,6 +6,7 @@ import pandas as pd
 from typing_extensions import assert_type
 
 from tests import (
+    PD_LTE_23,
     check,
     np_ndarray_bool,
 )
@@ -38,9 +39,13 @@ def test_string_accessors_boolean_series():
     _check(
         assert_type(s.str.contains("a"), "pd.Series[bool]"),
     )
-    _check(
-        assert_type(s.str.contains(re.compile(r"a")), "pd.Series[bool]"),
-    )
+    if PD_LTE_23:
+        # Bug in pandas 3.0 dev  https://github.com/pandas-dev/pandas/issues/61942
+        _check(
+            assert_type(
+                s.str.contains(re.compile(r"a"), regex=True), "pd.Series[bool]"
+            ),
+        )
     _check(assert_type(s.str.endswith("e"), "pd.Series[bool]"))
     _check(assert_type(s.str.endswith(("e", "f")), "pd.Series[bool]"))
     _check(assert_type(s.str.fullmatch("apple"), "pd.Series[bool]"))
@@ -66,9 +71,13 @@ def test_string_accessors_boolean_index():
     _check(
         assert_type(idx.str.contains("a"), np_ndarray_bool),
     )
-    _check(
-        assert_type(idx.str.contains(re.compile(r"a")), np_ndarray_bool),
-    )
+    if PD_LTE_23:
+        # Bug in pandas 3.0 dev  https://github.com/pandas-dev/pandas/issues/61942
+        _check(
+            assert_type(
+                idx.str.contains(re.compile(r"a"), regex=True), np_ndarray_bool
+            ),
+        )
     _check(assert_type(idx.str.endswith("e"), np_ndarray_bool))
     _check(assert_type(idx.str.endswith(("e", "f")), np_ndarray_bool))
     _check(assert_type(idx.str.fullmatch("apple"), np_ndarray_bool))


### PR DESCRIPTION
NIghtly runs failed due to tests related to passing in compiled regex when using pyarrow.  This also identified a couple of bugs in pandas with the new string Dtype

@twoertwein also thanks for reviews while I was on vacation!