### PR TITLE
more bugs in arrow string types for nightly to work

### DIFF
--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -8,6 +8,7 @@ from typing_extensions import assert_type
 
 from tests import (
     PD_LTE_23,
+    TYPE_CHECKING_INVALID_USAGE,
     check,
     np_ndarray_bool,
 )
@@ -50,7 +51,9 @@ def test_string_accessors_boolean_series():
     _check(assert_type(s.str.endswith("e"), "pd.Series[bool]"))
     _check(assert_type(s.str.endswith(("e", "f")), "pd.Series[bool]"))
     _check(assert_type(s.str.fullmatch("apple"), "pd.Series[bool]"))
-    _check(assert_type(s.str.fullmatch(re.compile(r"apple")), "pd.Series[bool]"))
+    if PD_LTE_23:
+        # Bug in 3.0 dev:  https://github.com/pandas-dev/pandas/issues/61952
+        _check(assert_type(s.str.fullmatch(re.compile(r"apple")), "pd.Series[bool]"))
     _check(assert_type(s.str.isalnum(), "pd.Series[bool]"))
     _check(assert_type(s.str.isalpha(), "pd.Series[bool]"))
     _check(assert_type(s.str.isdecimal(), "pd.Series[bool]"))
@@ -61,7 +64,9 @@ def test_string_accessors_boolean_series():
     _check(assert_type(s.str.istitle(), "pd.Series[bool]"))
     _check(assert_type(s.str.isupper(), "pd.Series[bool]"))
     _check(assert_type(s.str.match("pp"), "pd.Series[bool]"))
-    _check(assert_type(s.str.match(re.compile(r"pp")), "pd.Series[bool]"))
+    if PD_LTE_23:
+        # Bug in 3.0 dev:  https://github.com/pandas-dev/pandas/issues/61952
+        _check(assert_type(s.str.match(re.compile(r"pp")), "pd.Series[bool]"))
 
 
 def test_string_accessors_boolean_index():
@@ -84,7 +89,9 @@ def test_string_accessors_boolean_index():
     _check(assert_type(idx.str.endswith("e"), np_ndarray_bool))
     _check(assert_type(idx.str.endswith(("e", "f")), np_ndarray_bool))
     _check(assert_type(idx.str.fullmatch("apple"), np_ndarray_bool))
-    _check(assert_type(idx.str.fullmatch(re.compile(r"apple")), np_ndarray_bool))
+    if PD_LTE_23:
+        # Bug in 3.0 dev:  https://github.com/pandas-dev/pandas/issues/61952
+        _check(assert_type(idx.str.fullmatch(re.compile(r"apple")), np_ndarray_bool))
     _check(assert_type(idx.str.isalnum(), np_ndarray_bool))
     _check(assert_type(idx.str.isalpha(), np_ndarray_bool))
     _check(assert_type(idx.str.isdecimal(), np_ndarray_bool))
@@ -95,7 +102,9 @@ def test_string_accessors_boolean_index():
     _check(assert_type(idx.str.istitle(), np_ndarray_bool))
     _check(assert_type(idx.str.isupper(), np_ndarray_bool))
     _check(assert_type(idx.str.match("pp"), np_ndarray_bool))
-    _check(assert_type(idx.str.match(re.compile(r"pp")), np_ndarray_bool))
+    if PD_LTE_23:
+        # Bug in 3.0 dev:  https://github.com/pandas-dev/pandas/issues/61952
+        _check(assert_type(idx.str.match(re.compile(r"pp")), np_ndarray_bool))
 
 
 def test_string_accessors_integer_series():
@@ -228,10 +237,10 @@ def test_string_accessors_list_series():
 
     # rsplit doesn't accept compiled pattern
     # it doesn't raise at runtime but produces a nan
-    bad_rsplit_result = s.str.rsplit(
-        re.compile(r"a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
-    )
-    assert bad_rsplit_result.isna().all()
+    if TYPE_CHECKING_INVALID_USAGE:
+        bad_rsplit_result = s.str.rsplit(
+            re.compile(r"a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
+        )
 
 
 def test_string_accessors_list_index():
@@ -248,10 +257,10 @@ def test_string_accessors_list_index():
 
     # rsplit doesn't accept compiled pattern
     # it doesn't raise at runtime but produces a nan
-    bad_rsplit_result = idx.str.rsplit(
-        re.compile(r"a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
-    )
-    assert bad_rsplit_result.isna().all()
+    if TYPE_CHECKING_INVALID_USAGE:
+        bad_rsplit_result = idx.str.rsplit(
+            re.compile(r"a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
+        )
 
 
 def test_string_accessors_expanding_series():


### PR DESCRIPTION
Looks like the nightly changed and it uncovered a few more pandas bugs with arrow strings
