### PR TITLE
GH1307 Add Timedelta for tolerance arg in DataFrame/Series.reindex

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -816,7 +816,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         level: int | _str = ...,
         fill_value: Scalar | None = ...,
         limit: int | None = None,
-        tolerance: float | None = ...,
+        tolerance: float | Timedelta | None = ...,
     ) -> Self: ...
     @overload
     def rename(

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1234,7 +1234,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         level: int | _str | None = None,
         fill_value: Scalar | None = None,
         limit: int | None = None,
-        tolerance: float | None = None,
+        tolerance: float | Timedelta | None = None,
     ) -> Series[S1]: ...
     def filter(
         self,

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -3826,8 +3826,30 @@ def test_series_int_float() -> None:
 
 
 def test_series_reindex() -> None:
+    """Test Series.reindex without any arguments and with tolerance."""
     s = pd.Series([1, 2, 3], index=[0, 1, 2])
     check(assert_type(s.reindex([2, 1, 0]), "pd.Series[int]"), pd.Series, np.integer)
+    check(
+        assert_type(
+            s.reindex([2, 1, 0], method="backfill", tolerance=1), "pd.Series[int]"
+        ),
+        pd.Series,
+        np.integer,
+    )
+
+    sr = pd.Series([1, 2], pd.to_datetime(["2023-01-01", "2023-01-02"]))
+    check(
+        assert_type(
+            sr.reindex(
+                index=pd.to_datetime(["2023-01-02", "2023-01-03"]),
+                method="ffill",
+                tolerance=pd.Timedelta("1D"),
+            ),
+            "pd.Series[int]",
+        ),
+        pd.Series,
+        np.integer,
+    )
 
 
 def test_series_reindex_like() -> None:

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3178,9 +3178,29 @@ def test_frame_stack() -> None:
 
 
 def test_frame_reindex() -> None:
+    """Test DataFrame.reindex with different arguments."""
     # GH 84
     df = pd.DataFrame({"a": [1, 2, 3]}, index=[0, 1, 2])
     check(assert_type(df.reindex([2, 1, 0]), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.reindex([2, 1, 0], method="pad", tolerance=2.3), pd.DataFrame),
+        pd.DataFrame,
+    )
+
+    # GH1307
+    sr = pd.Series([1, 2], pd.to_datetime(["2023-01-01", "2023-01-02"]))
+    df = sr.to_frame()
+    check(
+        assert_type(
+            df.reindex(
+                index=pd.to_datetime(["2023-01-02", "2023-01-03"]),
+                method="ffill",
+                tolerance=pd.Timedelta("1D"),
+            ),
+            pd.DataFrame,
+        ),
+        pd.DataFrame,
+    )
 
 
 def test_frame_reindex_like() -> None:


### PR DESCRIPTION
- [x] Closes #1307
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
