### PR TITLE
add missing `| None` to `copy` argument in `concat`

### DIFF
--- a/pandas-stubs/core/reshape/concat.pyi
+++ b/pandas-stubs/core/reshape/concat.pyi
@@ -36,7 +36,7 @@ def concat(  # type: ignore[overload-overlap]
     names: list[HashableT4] | None = ...,
     verify_integrity: bool = ...,
     sort: bool = ...,
-    copy: bool = ...,
+    copy: bool | None = ...,
 ) -> DataFrame: ...
 @overload
 def concat(  # pyright: ignore[reportOverlappingOverload]
@@ -50,7 +50,7 @@ def concat(  # pyright: ignore[reportOverlappingOverload]
     names: list[HashableT4] | None = ...,
     verify_integrity: bool = ...,
     sort: bool = ...,
-    copy: bool = ...,
+    copy: bool | None = ...,
 ) -> Series[S2]: ...
 @overload
 def concat(  # type: ignore[overload-overlap]
@@ -64,7 +64,7 @@ def concat(  # type: ignore[overload-overlap]
     names: list[HashableT4] | None = ...,
     verify_integrity: bool = ...,
     sort: bool = ...,
-    copy: bool = ...,
+    copy: bool | None = ...,
 ) -> Series: ...
 @overload
 def concat(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
@@ -78,7 +78,7 @@ def concat(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappin
     names: list[HashableT4] | None = ...,
     verify_integrity: bool = ...,
     sort: bool = ...,
-    copy: bool = ...,
+    copy: bool | None = ...,
 ) -> DataFrame: ...
 @overload
 def concat(
@@ -92,7 +92,7 @@ def concat(
     names: list[HashableT4] | None = ...,
     verify_integrity: bool = ...,
     sort: bool = ...,
-    copy: bool = ...,
+    copy: bool | None = ...,
 ) -> Never: ...
 @overload
 def concat(  # type: ignore[overload-overlap]
@@ -106,7 +106,7 @@ def concat(  # type: ignore[overload-overlap]
     names: list[HashableT4] | None = ...,
     verify_integrity: bool = ...,
     sort: bool = ...,
-    copy: bool = ...,
+    copy: bool | None = ...,
 ) -> DataFrame: ...
 @overload
 def concat(  # type: ignore[overload-overlap]
@@ -120,7 +120,7 @@ def concat(  # type: ignore[overload-overlap]
     names: list[HashableT4] | None = ...,
     verify_integrity: bool = ...,
     sort: bool = ...,
-    copy: bool = ...,
+    copy: bool | None = ...,
 ) -> Series: ...
 @overload
 def concat(
@@ -137,7 +137,7 @@ def concat(
     names: list[HashableT4] | None = ...,
     verify_integrity: bool = ...,
     sort: bool = ...,
-    copy: bool = ...,
+    copy: bool | None = ...,
 ) -> DataFrame: ...
 
 # Including either of the next 2 overloads causes mypy to complain about


### PR DESCRIPTION
Precursor to extending https://github.com/pandas-dev/pandas-stubs/pull/1318 to keyword-only arguments

🤔 though arguably, `copy` is deprecated on the pandas main branch, so perhaps shouldn't be done?

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value
