### PR TITLE
fix overload defaults for `as_index` in `groupby`

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1145,7 +1145,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         errors: IgnoreRaise = "ignore",
     ) -> None: ...
     @overload
-    def groupby(  # pyright: ignore reportOverlappingOverload
+    def groupby(
         self,
         by: Scalar,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
@@ -1162,14 +1162,15 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         by: Scalar,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
         level: IndexLabel | None = ...,
-        as_index: Literal[False] = ...,
+        *,
+        as_index: Literal[False],
         sort: _bool = ...,
         group_keys: _bool = ...,
         observed: _bool | _NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Scalar, Literal[False]]: ...
     @overload
-    def groupby(  # pyright: ignore reportOverlappingOverload
+    def groupby(
         self,
         by: DatetimeIndex,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
@@ -1181,19 +1182,20 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Timestamp, Literal[True]]: ...
     @overload
-    def groupby(  # pyright: ignore reportOverlappingOverload
+    def groupby(
         self,
         by: DatetimeIndex,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
         level: IndexLabel | None = ...,
-        as_index: Literal[False] = ...,
+        *,
+        as_index: Literal[False],
         sort: _bool = ...,
         group_keys: _bool = ...,
         observed: _bool | _NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Timestamp, Literal[False]]: ...
     @overload
-    def groupby(  # pyright: ignore reportOverlappingOverload
+    def groupby(
         self,
         by: TimedeltaIndex,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
@@ -1210,14 +1212,15 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         by: TimedeltaIndex,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
         level: IndexLabel | None = ...,
-        as_index: Literal[False] = ...,
+        *,
+        as_index: Literal[False],
         sort: _bool = ...,
         group_keys: _bool = ...,
         observed: _bool | _NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Timedelta, Literal[False]]: ...
     @overload
-    def groupby(  # pyright: ignore reportOverlappingOverload
+    def groupby(
         self,
         by: PeriodIndex,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
@@ -1234,14 +1237,15 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         by: PeriodIndex,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
         level: IndexLabel | None = ...,
-        as_index: Literal[False] = ...,
+        *,
+        as_index: Literal[False],
         sort: _bool = ...,
         group_keys: _bool = ...,
         observed: _bool | _NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Period, Literal[False]]: ...
     @overload
-    def groupby(  # pyright: ignore reportOverlappingOverload
+    def groupby(
         self,
         by: IntervalIndex[IntervalT],
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
@@ -1258,14 +1262,15 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         by: IntervalIndex[IntervalT],
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
         level: IndexLabel | None = ...,
-        as_index: Literal[False] = ...,
+        *,
+        as_index: Literal[False],
         sort: _bool = ...,
         group_keys: _bool = ...,
         observed: _bool | _NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[IntervalT, Literal[False]]: ...
     @overload
-    def groupby(  # type: ignore[overload-overlap] # pyright: ignore reportOverlappingOverload
+    def groupby(
         self,
         by: MultiIndex | GroupByObjectNonScalar | None = ...,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
@@ -1277,19 +1282,20 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[tuple, Literal[True]]: ...
     @overload
-    def groupby(  # type: ignore[overload-overlap]
+    def groupby(
         self,
         by: MultiIndex | GroupByObjectNonScalar | None = ...,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
         level: IndexLabel | None = ...,
-        as_index: Literal[False] = ...,
+        *,
+        as_index: Literal[False],
         sort: _bool = ...,
         group_keys: _bool = ...,
         observed: _bool | _NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[tuple, Literal[False]]: ...
     @overload
-    def groupby(  # pyright: ignore reportOverlappingOverload
+    def groupby(
         self,
         by: Series[SeriesByT],
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
@@ -1306,7 +1312,8 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         by: Series[SeriesByT],
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
         level: IndexLabel | None = ...,
-        as_index: Literal[False] = ...,
+        *,
+        as_index: Literal[False],
         sort: _bool = ...,
         group_keys: _bool = ...,
         observed: _bool | _NoDefaultDoNotUse = ...,
@@ -1330,7 +1337,8 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         by: CategoricalIndex | Index | Series,
         axis: AxisIndex | _NoDefaultDoNotUse = ...,
         level: IndexLabel | None = ...,
-        as_index: Literal[False] = ...,
+        *,
+        as_index: Literal[False],
         sort: _bool = ...,
         group_keys: _bool = ...,
         observed: _bool | _NoDefaultDoNotUse = ...,

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -689,8 +689,8 @@ def test_types_mean() -> None:
         pd.Series,
     )
     if TYPE_CHECKING_INVALID_USAGE:
-        df3: pd.DataFrame = df.groupby(axis=1, level=0).mean()  # type: ignore[call-overload] # pyright: ignore[reportArgumentType, reportCallIssue]
-        df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).mean()  # type: ignore[call-overload] # pyright: ignore[reportArgumentType, reportCallIssue]
+        df3: pd.DataFrame = df.groupby(axis=1, level=0).mean()  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
+        df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).mean()  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
 
 
 def test_types_median() -> None:
@@ -703,8 +703,8 @@ def test_types_median() -> None:
         pd.Series,
     )
     if TYPE_CHECKING_INVALID_USAGE:
-        df3: pd.DataFrame = df.groupby(axis=1, level=0).median()  # type: ignore[call-overload] # pyright: ignore[reportArgumentType, reportCallIssue]
-        df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).median()  # type: ignore[call-overload] # pyright: ignore[reportArgumentType, reportCallIssue]
+        df3: pd.DataFrame = df.groupby(axis=1, level=0).median()  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
+        df4: pd.DataFrame = df.groupby(axis=1, level=0, dropna=True).median()  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
 
 
 def test_types_iterrows() -> None:


### PR DESCRIPTION
These overloads currently show `as_index: Literal[False] = ...`, but that's not quite correct because the default is `True`

https://github.com/pandas-dev/pandas/blob/9597c0397962b228f00805e0750b91d0e5272ce9/pandas/core/frame.py#L9375

If `as_index: Literal[False]` were to be used instead, then mypy would complain that a non-default parameter (`as_index`) follows a default one (`level` / `axis`). Fixing this would require making an extra overload: one for when `as_index` is passed positionally and one for when it's passed by name

Given that:
- groupby already has 16 (!) overloads
- `as_index` is boolean, [so arguably it's a best practice to pass it by name anyway](https://docs.astral.sh/ruff/rules/boolean-positional-value-in-call/)

Is it OK to just type if it if it's passed by name? The alternative would be...to bring the number of overloads to 24 🤯 Certainly doable, my preference would be to keep them down and encourage passing `as_index` by name