### PR TITLE
Clean up timefuncs tests, fix nightly due to new errors

### DIFF
--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -98,6 +98,10 @@ else:
     TimestampSeries: TypeAlias = pd.Series
     OffsetSeries: TypeAlias = pd.Series
 
+if not PD_LTE_23:
+    from pandas.errors import Pandas4Warning  # type: ignore[attr-defined]  # pyright: ignore  # isort: skip
+else:
+    Pandas4Warning: TypeAlias = FutureWarning  # type: ignore[no-redef]
 
 # Tests will use numpy 2.1 in python 3.10 or later
 # From Numpy 2.1 __init__.pyi
@@ -3863,7 +3867,7 @@ def test_series_reindex_like() -> None:
             upper="2.99",
         ),
         pytest_warns_bounded(
-            Warning,  # should be Pandas4Warning but only exposed starting pandas 3.0.0
+            Pandas4Warning,
             "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
             lower="2.99",
             upper="3.0.99",

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -72,6 +72,11 @@ if TYPE_CHECKING:
 else:
     _PandasNamedTuple: TypeAlias = tuple
 
+if not PD_LTE_23:
+    from pandas.errors import Pandas4Warning  # type: ignore[attr-defined]  # pyright: ignore  # isort: skip
+else:
+    Pandas4Warning: TypeAlias = FutureWarning  # type: ignore[no-redef]
+
 DF = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
 
 
@@ -3262,7 +3267,7 @@ def test_frame_reindex_like() -> None:
             upper="2.99",
         ),
         pytest_warns_bounded(
-            Warning,  # should be Pandas4Warning but only exposed starting pandas 3.0.0
+            Pandas4Warning,
             "the 'method' keyword is deprecated and will be removed in a future version. Please take steps to stop the use of 'method'",
             lower="2.99",
             upper="3.0.99",

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -1372,9 +1372,8 @@ def test_datetimeindex_shift() -> None:
 
 def test_timedeltaindex_shift() -> None:
     ind = pd.date_range("1/1/2021", "1/5/2021") - pd.Timestamp("1/3/2019")
-    if PD_LTE_23:
-        # cannot shift with no freq starting in pandas 3.0.0
-        check(assert_type(ind.shift(1), pd.TimedeltaIndex), pd.TimedeltaIndex)
+    # broken on 3.0.0.dev0 as of 20250813, fix with pandas-dev/pandas/issues/62094
+    check(assert_type(ind.shift(1), pd.TimedeltaIndex), pd.TimedeltaIndex)
 
 
 def test_index_insert() -> None:

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -56,6 +56,11 @@ if TYPE_CHECKING:
 else:
     TimestampSeries: TypeAlias = pd.Series
 
+if not PD_LTE_23:
+    from pandas.errors import Pandas4Warning  # type: ignore[attr-defined]  # pyright: ignore  # isort: skip
+else:
+    Pandas4Warning: TypeAlias = FutureWarning  # type: ignore[no-redef]
+
 from tests import np_ndarray_bool
 
 
@@ -549,7 +554,7 @@ def test_series_dt_accessors() -> None:
             upper="2.99",
         ),
         pytest_warns_bounded(
-            Warning,  # should be Pandas4Warning but only exposed starting pandas 3.0.0
+            Pandas4Warning,  # should be Pandas4Warning but only exposed starting pandas 3.0.0
             "The behavior of TimedeltaProperties.to_pytimedelta is deprecated",
             lower="2.99",
             upper="3.0.99",


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added: Please use `assert_type()` to assert the type of any return value

Some of the new error names from https://github.com/pandas-dev/pandas/pull/61468.
Nightly run is passing, see https://github.com/pandas-dev/pandas-stubs/actions/runs/16948579852.