### PR TITLE
Fix series creation from dict views

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -2,15 +2,16 @@ from builtins import (
     bool as _bool,
     str as _str,
 )
-from collections import dict_keys  # type: ignore[attr-defined]
 from collections.abc import (
     Callable,
     Hashable,
     Iterable,
     Iterator,
+    KeysView,
     Mapping,
     MutableMapping,
     Sequence,
+    ValuesView,
 )
 from datetime import (
     date,
@@ -406,7 +407,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def __new__(
         cls,
-        data: S1 | _ListLike[S1] | dict[HashableT1, S1] | dict_keys[S1, Any],
+        data: S1 | _ListLike[S1] | dict[HashableT1, S1] | KeysView[S1] | ValuesView[S1],
         index: AxesData | None = ...,
         dtype: Dtype = ...,
         name: Hashable = ...,

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -3801,13 +3801,11 @@ def test_series_bool_fails() -> None:
         pass
 
 
-def test_series_dict() -> None:
+def test_series_from_dict_views() -> None:
     # GH 812
-    check(
-        assert_type(pd.Series({"a": 1, "b": 2}.keys()), "pd.Series[str]"),
-        pd.Series,
-        str,
-    )
+    d = {"a": 1, "b": 2}
+    check(assert_type(pd.Series(d.keys()), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(pd.Series(d.values()), "pd.Series[int]"), pd.Series, np.integer)
 
 
 def test_series_keys_type() -> None:


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

`collections.dict_views` does not exist neither at runtime nor in the stubs, the correct type to use is `KeysView` from `collections.abc`. While fixing this I noticed that values views is not supported so I added it. Note that values views is more relevant  to the series class as it is NOT set-like but IS sequence-like.