### PR TITLE
add `scipy-stubs` to the `dev` dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ xarray = ">=22.6.0"
 tabulate = ">=0.8.10"
 jinja2 = ">=3.1"
 scipy = { version = ">=1.9.1", python = "<3.14" }
+scipy-stubs = ">=1.15.3.0"
 SQLAlchemy = ">=2.0.39"
 types-python-dateutil = ">=2.8.19"
 beautifulsoup4 = ">=4.12.2"


### PR DESCRIPTION
I figured that since scipy is a dependency, and we like static typing around here, it would probably help to add some stubs for it too :). See https://github.com/scipy/scipy-stubs for details.
