### PR TITLE
GH1352 Add passing a dict with integer for pd.to_datetime

### DIFF
--- a/pandas-stubs/core/tools/datetimes.pyi
+++ b/pandas-stubs/core/tools/datetimes.pyi
@@ -38,7 +38,7 @@ DatetimeScalar: TypeAlias = Scalar | datetime | np.datetime64 | date
 
 DatetimeScalarOrArrayConvertible: TypeAlias = DatetimeScalar | ArrayConvertible
 
-DatetimeDictArg: TypeAlias = list[Scalar] | tuple[Scalar, ...] | AnyArrayLike
+DatetimeDictArg: TypeAlias = list[Scalar] | tuple[Scalar, ...] | AnyArrayLike | int
 
 class YearMonthDayDict(TypedDict, total=True):
     year: DatetimeDictArg

--- a/tests/test_scalars.py
+++ b/tests/test_scalars.py
@@ -24,6 +24,7 @@ from pandas._libs.tslibs.timedeltas import Components
 from pandas._typing import TimeUnit
 
 from tests import (
+    PD_LTE_23,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     np_1darray,
@@ -44,12 +45,16 @@ if TYPE_CHECKING:
         TimedeltaSeries,
         TimestampSeries,
     )
-
 else:
     TimedeltaSeries: TypeAlias = pd.Series
     TimestampSeries: TypeAlias = pd.Series
     PeriodSeries: TypeAlias = pd.Series
     OffsetSeries: TypeAlias = pd.Series
+
+if not PD_LTE_23:
+    from pandas.errors import Pandas4Warning  # type: ignore[attr-defined]  # pyright: ignore  # isort: skip
+else:
+    Pandas4Warning: TypeAlias = FutureWarning  # type: ignore[no-redef]
 
 
 def test_interval() -> None:
@@ -369,10 +374,15 @@ def test_interval_cmp():
 
 def test_timedelta_construction() -> None:
     check(assert_type(pd.Timedelta(1, "W"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.3.99"):
+    with pytest_warns_bounded(
+        Pandas4Warning,  # should be Pandas4Warning but only exposed starting pandas 3.0.0
+        "'w' is deprecated and will",
+        lower="2.3.99",
+        upper="3.0.99",
+    ):
         check(assert_type(pd.Timedelta(1, "w"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta(1, "D"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.3.99"):
+    with pytest_warns_bounded(Pandas4Warning, "'d' is deprecated", lower="2.3.99"):
         check(assert_type(pd.Timedelta(1, "d"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta(1, "days"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta(1, "day"), pd.Timedelta), pd.Timedelta)
@@ -406,10 +416,10 @@ def test_timedelta_construction() -> None:
     check(assert_type(pd.Timedelta(1, "nanosecond"), pd.Timedelta), pd.Timedelta)
 
     check(assert_type(pd.Timedelta("1 W"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.3.99"):
+    with pytest_warns_bounded(Pandas4Warning, "'w' is deprecated", lower="2.3.99"):
         check(assert_type(pd.Timedelta("1 w"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta("1 D"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.3.99"):
+    with pytest_warns_bounded(Pandas4Warning, "'d' is deprecated", lower="2.3.99"):
         check(assert_type(pd.Timedelta("1 d"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta("1 days"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.Timedelta("1 day"), pd.Timedelta), pd.Timedelta)

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -1108,10 +1108,10 @@ def test_index_types_to_numpy() -> None:
 
 def test_to_timedelta_units() -> None:
     check(assert_type(pd.to_timedelta(1, "W"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'w' is deprecated", lower="2.3.99"):
+    with pytest_warns_bounded(Pandas4Warning, "'w' is deprecated", lower="2.3.99"):
         check(assert_type(pd.to_timedelta(1, "w"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.to_timedelta(1, "D"), pd.Timedelta), pd.Timedelta)
-    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.3.99"):
+    with pytest_warns_bounded(Pandas4Warning, "'d' is deprecated", lower="2.3.99"):
         check(assert_type(pd.to_timedelta(1, "d"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.to_timedelta(1, "days"), pd.Timedelta), pd.Timedelta)
     check(assert_type(pd.to_timedelta(1, "day"), pd.Timedelta), pd.Timedelta)
@@ -1871,7 +1871,7 @@ def test_timestamp_to_list_add() -> None:
     tslist = list(pd.to_datetime(["2022-01-01", "2022-01-02"]))
     check(assert_type(tslist, list[pd.Timestamp]), list, pd.Timestamp)
     sseries = pd.Series(tslist)
-    with pytest_warns_bounded(FutureWarning, "'d' is deprecated", lower="2.3.99"):
+    with pytest_warns_bounded(Pandas4Warning, "'d' is deprecated", lower="2.3.99"):
         sseries + pd.Timedelta(1, "d")
 
     check(

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -1334,6 +1334,23 @@ def test_to_datetime_series() -> None:
     check(assert_type(pd.to_datetime(d), "TimestampSeries"), pd.Series)
     check(assert_type(pd.to_datetime(d_ex), "TimestampSeries"), pd.Series)
 
+    # GH1352
+    ts = pd.date_range("2023-10-01", "2024-05-01", freq="1h")
+    check(
+        assert_type(
+            pd.to_datetime(
+                {
+                    "year": ts.year,
+                    "month": ts.month,
+                    "day": 1,
+                }
+            ),
+            "TimestampSeries",
+        ),
+        pd.Series,
+        pd.Timestamp,
+    )
+
 
 def test_to_datetime_array() -> None:
     check(assert_type(pd.to_datetime([1, 2, 3]), pd.DatetimeIndex), pd.DatetimeIndex)


### PR DESCRIPTION
- [x] Closes #1352 
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

+ fix for the nightly CI with pandas