### PR TITLE
with conda, use sys.executable to find python with ty

### DIFF
--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -154,7 +154,13 @@ def released_mypy():
 
 
 def ty():
-    cmd = ["ty", "check", "pandas-stubs"]
+    cmd = [
+        "ty",
+        "check",
+        "pandas-stubs",
+        "--python",
+        sys.executable,
+    ]
     subprocess.run(cmd, check=True)
 
 


### PR DESCRIPTION
I've been having trouble doing `poe ty` or `poe test` because `ty` is failing to find the python environment, and I use conda.  Fails for me on Windows and Linux. 

This fixes it for me.  I don't think it will break it for others.

@loicdiridollou can you review this by seeing if this change works on your system?

If you approve it, then I'll do the merge.

