### PR TITLE
GH1358 Relax index type from DataFrame.from_records

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -549,9 +549,9 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
             | Mapping[str, Any]
             | Mapping[str, SequenceNotStr[Any]]
         ),
-        index: str | SequenceNotStr[Hashable] | None = None,
-        columns: ListLike | None = None,
+        index: str | Axes | None = None,
         exclude: ListLike | None = None,
+        columns: ListLike | None = None,
         coerce_float: bool = False,
         nrows: int | None = None,
     ) -> Self: ...

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -4815,6 +4815,40 @@ def test_from_records() -> None:
         pd.DataFrame,
     )
 
+    # GH1358
+    data, py_l = [[1, 2, 3], [4, 5, 6]], ["a", "b"]
+
+    check(
+        assert_type(pd.DataFrame.from_records(data, pd.Index(py_l)), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(pd.DataFrame.from_records(data, pd.Series(py_l)), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(
+            pd.DataFrame.from_records(data, pd.Series(py_l).array), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(
+            pd.DataFrame.from_records(data, pd.Series(py_l).values), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(pd.DataFrame.from_records(data, np.asarray(py_l)), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(
+            pd.DataFrame.from_records(data, np.asarray(py_l, np.str_)), pd.DataFrame
+        ),
+        pd.DataFrame,
+    )
+
 
 def test_frame_index_setter() -> None:
     """Test DataFrame.index setter property GH1366."""


### PR DESCRIPTION
- [x] Closes #1358
- [x] Tests added: Please use `assert_type()` to assert the type of any return value
