### PR TITLE
GH1379 Drop OffsetSeries replacing it with Series[BaseOffset]

### DIFF
--- a/pandas-stubs/_libs/tslibs/period.pyi
+++ b/pandas-stubs/_libs/tslibs/period.pyi
@@ -12,9 +12,6 @@ from pandas import (
     Timedelta,
     TimedeltaIndex,
 )
-from pandas.core.series import (
-    OffsetSeries,
-)
 from typing_extensions import TypeAlias
 
 from pandas._libs.tslibs import NaTType
@@ -97,7 +94,7 @@ class Period(PeriodMixin):
     def __add__(self, other: Index) -> PeriodIndex: ...
     @overload
     def __add__(
-        self, other: OffsetSeries | Series[Timedelta]
+        self, other: Series[BaseOffset] | Series[Timedelta]
     ) -> Series[Period]: ...  # pyrefly: ignore[bad-specialization]
     #  ignore[misc] here because we know all other comparisons
     #  are False, so we use Literal[False]

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -848,7 +848,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
     @overload
     def diff(self: Series[Timedelta], periods: int = ...) -> Series[Timedelta]: ...  # type: ignore[overload-overlap]
     @overload
-    def diff(self: Series[Period], periods: int = ...) -> OffsetSeries: ...  # type: ignore[overload-overlap]
+    def diff(self: Series[Period], periods: int = ...) -> Series[BaseOffset]: ...  # type: ignore[overload-overlap]
     @overload
     def diff(self, periods: int = ...) -> Series[float]: ...
     def autocorr(self, lag: int = 1) -> float: ...
@@ -1061,7 +1061,7 @@ class Series(IndexOpsMixin[S1], NDFrame):
         convertDType: _bool = ...,
         args: tuple = ...,
         **kwargs: Any,
-    ) -> OffsetSeries: ...
+    ) -> Series[BaseOffset]: ...
     @overload
     def apply(
         self,
@@ -2013,6 +2013,10 @@ class Series(IndexOpsMixin[S1], NDFrame):
         self: Series[_str],
         other: _str | Sequence[_str] | np_ndarray_str | Index[_str] | Series[_str],
     ) -> Series[_str]: ...
+    @overload
+    def __radd__(self: Series[BaseOffset], other: Period) -> Series[Period]: ...
+    @overload
+    def __radd__(self: Series[BaseOffset], other: BaseOffset) -> Series[BaseOffset]: ...
     @overload
     def radd(
         self: Series[Never],
@@ -4669,6 +4673,22 @@ class Series(IndexOpsMixin[S1], NDFrame):
         **kwargs,
     ) -> np_1darray[np.int64]: ...
     @overload
+    def to_numpy(
+        self: Series[BaseOffset],
+        dtype: None = None,
+        copy: bool = False,
+        na_value: Scalar = ...,
+        **kwargs,
+    ) -> np_1darray[np.object_]: ...
+    @overload
+    def to_numpy(
+        self: Series[BaseOffset],
+        dtype: type[np.bytes_],
+        copy: bool = False,
+        na_value: Scalar = ...,
+        **kwargs,
+    ) -> np_1darray[np.bytes_]: ...
+    @overload
     def to_numpy(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         dtype: DTypeLike | None = None,
@@ -4761,14 +4781,6 @@ class _SeriesSubclassBase(Series[S1], Generic[S1, GenericT_co]):
         na_value: Scalar = ...,
         **kwargs,
     ) -> np_1darray: ...
-
-class OffsetSeries(_SeriesSubclassBase[BaseOffset, np.object_]):
-    @overload  # type: ignore[override]
-    def __radd__(self, other: Period) -> Series[Period]: ...
-    @overload
-    def __radd__(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self, other: BaseOffset
-    ) -> OffsetSeries: ...
 
 class IntervalSeries(
     _SeriesSubclassBase[Interval[_OrderableT], np.object_], Generic[_OrderableT]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ scipy = { version = ">=1.9.1", python = "<3.14" }
 scipy-stubs = ">=1.15.3.0"
 SQLAlchemy = ">=2.0.39"
 types-python-dateutil = ">=2.8.19"
-beautifulsoup4 = "<=4.13.5"
+beautifulsoup4 = ">=4.13.5"
 html5lib = ">=1.1"
 python-calamine = ">=0.2.0"
 

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -72,8 +72,6 @@ from pandas.tseries.offsets import (
 )
 
 if TYPE_CHECKING:
-    from pandas.core.series import OffsetSeries
-
     from tests import (
         BooleanDtypeArg,
         BytesDtypeArg,
@@ -88,9 +86,6 @@ if TYPE_CHECKING:
         UIntDtypeArg,
         VoidDtypeArg,
     )
-
-else:
-    OffsetSeries: TypeAlias = pd.Series
 
 if not PD_LTE_23:
     from pandas.errors import Pandas4Warning  # type: ignore[attr-defined]  # pyright: ignore  # isort: skip
@@ -3487,7 +3482,7 @@ def test_diff() -> None:
                     pd.Series(
                         pd.period_range(start="2017-01-01", end="2017-02-01", freq="D")
                     ).diff(),
-                    "OffsetSeries",
+                    "pd.Series[BaseOffset]",
                 ),
                 pd.Series,
                 BaseOffset,
@@ -3499,7 +3494,7 @@ def test_diff() -> None:
                 pd.Series(
                     pd.period_range(start="2017-01-01", end="2017-02-01", freq="D")
                 ).diff(),
-                "OffsetSeries",
+                "pd.Series[BaseOffset]",
             ),
             pd.Series,
             BaseOffset,
@@ -3672,7 +3667,9 @@ def test_apply_dateoffset() -> None:
     months = [1, 2, 3]
     s = pd.Series(months)
     check(
-        assert_type(s.apply(lambda x: pd.DateOffset(months=x)), "OffsetSeries"),
+        assert_type(
+            s.apply(lambda x: pd.DateOffset(months=x)), "pd.Series[BaseOffset]"
+        ),
         pd.Series,
         pd.DateOffset,
     )

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -52,7 +52,6 @@ from pandas.tseries.offsets import (
 if TYPE_CHECKING:
     from pandas.core.series import (
         IntervalSeries,
-        OffsetSeries,
     )
 
 if not PD_LTE_23:
@@ -947,7 +946,8 @@ def test_series_types_to_numpy() -> None:
     ts_s = pd.to_datetime(pd.Series(["2020-01-01", "2020-01-02"]))
     p_s = pd.Series(pd.period_range("2012-1-1", periods=10, freq="D"))
     o_s = cast(
-        "OffsetSeries", pd.Series([pd.DateOffset(days=1), pd.DateOffset(days=2)])
+        "pd.Series[BaseOffset]",
+        pd.Series([pd.DateOffset(days=1), pd.DateOffset(days=2)]),
     )
     i_s = cast("IntervalSeries", pd.interval_range(1, 2).to_series())
 


### PR DESCRIPTION
- [x] Closes #1379
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

Also dropped the locking of the version of `beautifulsoup`, it seems like they shipped another version that fixed the issue.
