### PR TITLE
remove comment about check_array_indexer

### DIFF
--- a/pandas-stubs/core/indexers/utils.pyi
+++ b/pandas-stubs/core/indexers/utils.pyi
@@ -6,7 +6,6 @@ from pandas._typing import (
     np_ndarray_int,
 )
 
-# Docs may not be right. See pandas-dev/pandas#62562
 @overload
 def check_array_indexer(array: AnyArrayLike, indexer: int) -> int: ...
 @overload


### PR DESCRIPTION
The docs for `check_array_indexer` got fixed in https://github.com/pandas-dev/pandas/pull/62573 so we can remove this comment.

Probably the easiest PR ever!!

