### PR TITLE
refactor(ruff): switch from `select` to `ignore`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,6 @@ minimum_pre_commit_version: 2.15.0
 ci:
     autofix_prs: false
 repos:
--   repo: https://github.com/psf/black
-    rev: 25.9.0
-    hooks:
-    -   id: black
--   repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
-    hooks:
-    -   id: isort
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.3
     hooks:
@@ -21,3 +13,11 @@ repos:
     - id: codespell
       additional_dependencies: [ tomli ]
       args: [-L, "THIRDPARTY"]
+-   repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+    -   id: isort
+-   repo: https://github.com/psf/black
+    rev: 25.9.0
+    hooks:
+    -   id: black

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,11 @@
+from collections.abc import Generator
 import gc
 
 import pytest
 
 
 @pytest.fixture
-def mpl_cleanup():
+def mpl_cleanup() -> Generator[None, None, None]:
     """
     Ensure Matplotlib is cleaned up around a test.
 

--- a/pandas-stubs/_libs/tslibs/__init__.pyi
+++ b/pandas-stubs/_libs/tslibs/__init__.pyi
@@ -1,14 +1,14 @@
 __all__ = [
-    "Period",
-    "Timestamp",
-    "Timedelta",
+    "BaseOffset",
     "NaT",
     "NaTType",
+    "OutOfBoundsDatetime",
+    "Period",
+    "Tick",
+    "Timedelta",
+    "Timestamp",
     "iNaT",
     "nat_strings",
-    "BaseOffset",
-    "Tick",
-    "OutOfBoundsDatetime",
 ]
 from pandas._libs.tslibs.nattype import (
     NaT,

--- a/pandas-stubs/core/groupby/__init__.pyi
+++ b/pandas-stubs/core/groupby/__init__.pyi
@@ -8,8 +8,8 @@ from pandas.core.groupby.grouper import Grouper as Grouper
 
 __all__ = [
     "DataFrameGroupBy",
-    "NamedAgg",
-    "SeriesGroupBy",
     "GroupBy",
     "Grouper",
+    "NamedAgg",
+    "SeriesGroupBy",
 ]

--- a/pandas-stubs/testing.pyi
+++ b/pandas-stubs/testing.pyi
@@ -8,6 +8,6 @@ from pandas._testing import (
 __all__ = [
     "assert_extension_array_equal",
     "assert_frame_equal",
-    "assert_series_equal",
     "assert_index_equal",
+    "assert_series_equal",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,16 +176,48 @@ fix = true
 
 
 [tool.ruff.lint]
-extend-select = ["B007", "B018", "PYI", "UP", "RUF100", "RUF059"]
+extend-select = ["ALL"]
 ignore = [
-  "E501",   # https://docs.astral.sh/ruff/rules/line-too-long/
-  "E731",   # https://docs.astral.sh/ruff/rules/lambda-assignment/
-  "PYI042", # https://docs.astral.sh/ruff/rules/snake-case-type-alias/
+  # The following rules are ignored permanently for good reasons
+  "COM",     # https://docs.astral.sh/ruff/rules/#flake8-commas-com
+  "D",       # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+  "E501",    # handled by black https://docs.astral.sh/ruff/rules/line-too-long/
+  "EM",      # https://docs.astral.sh/ruff/rules/#flake8-errmsg-em
+  "FBT",     # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
+  "I",       # handled by isort
 ]
 
 
 [tool.ruff.lint.per-file-ignores]
-"_*.pyi" = ["PYI001"]
+"*.pyi" = [
+  # The following rules are ignored permanently for good reasons
+  "A001",    # https://docs.astral.sh/ruff/rules/builtin-variable-shadowing/
+  "A002",    # https://docs.astral.sh/ruff/rules/builtin-argument-shadowing/
+  "A004",    # https://docs.astral.sh/ruff/rules/builtin-import-shadowing/
+  "N",       # https://docs.astral.sh/ruff/rules/#pep8-naming-n
+  "PYI001",  # https://docs.astral.sh/ruff/rules/unprefixed-type-param/
+  "PYI042",  # https://docs.astral.sh/ruff/rules/snake-case-type-alias/
+  "TD002",   # https://docs.astral.sh/ruff/rules/missing-todo-author/
+  # The following rules are ignored temporarily. Either fix them or move to the permanent list above.
+  "ERA", "S", "ANN", "FIX002", "TD003", "TD004", "PLR0402", "PLC0105"
+  ]
+"scripts/*" = [
+  # The following rules are ignored permanently for good reasons
+  "S603",    # https://docs.astral.sh/ruff/rules/subprocess-without-shell-equals-true/
+  # The following rules are ignored temporarily. Either fix them or move to the permanent list above.
+  "TRY", "PT", "BLE"
+]
+"tests/*" = [
+  # The following rules are ignored permanently for good reasons
+  "E731",    # https://docs.astral.sh/ruff/rules/lambda-assignment/
+  "PD",      # Pandas is here
+  "PLC0415", # https://docs.astral.sh/ruff/rules/import-outside-top-level/
+  "S101",    # https://docs.astral.sh/ruff/rules/assert/
+  "S301",    # https://docs.astral.sh/ruff/rules/suspicious-pickle-usage/
+  "SLF001",  # https://docs.astral.sh/ruff/rules/private-member-access/
+  # The following rules are ignored temporarily. Either fix them or move to the permanent list above.
+  "ANN", "ARG", "ERA", "RUF", "SIM", "TRY", "PT", "NPY", "N", "DTZ", "PLR", "TC", "PGH", "PTH", "S311", "C901", "FIX", "TD", "A001", "PYI042", "ANN201"
+]
 
 
 [tool.mypy]

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -51,7 +51,7 @@ def stubtest(allowlist: str, check_missing: bool, nightly: bool) -> None:
     steps = _DIST_STEPS[:2]
     if nightly:
         steps.append(_step.nightly)
-    run_job(steps + [stubtest])
+    run_job([*steps, stubtest])
 
 
 def pytest(nightly: bool) -> None:
@@ -59,9 +59,9 @@ def pytest(nightly: bool) -> None:
     pytest_step = _step.pytest
     if nightly:
         setup_steps = [_step.nightly]
-    run_job(setup_steps + [pytest_step])
+    run_job([*setup_steps, pytest_step])
 
 
 def mypy_src(mypy_nightly: bool) -> None:
     steps = [_step.mypy_nightly] if mypy_nightly else []
-    run_job(steps + [_step.mypy_src])
+    run_job([*steps, _step.mypy_src])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -87,8 +87,7 @@ def check(
             and get_origin(shape_type) is tuple
             and (tuple_args := get_args(shape_type))
             and ... not in tuple_args  # fixed-length tuple
-            and (arr_ndim := getattr(actual, "ndim"))
-            != (expected_ndim := len(tuple_args))
+            and (arr_ndim := actual.ndim) != (expected_ndim := len(tuple_args))
         ):
             raise RuntimeError(
                 f"Array has wrong dimension {arr_ndim}, expected {expected_ndim}"
@@ -100,7 +99,7 @@ def check(
             and (dtype_args := get_args(dtype_type))
             and isinstance((expected_dtype := dtype_args[0]), type)
             and issubclass(expected_dtype, np.generic)
-            and (arr_dtype := getattr(actual, "dtype")) != expected_dtype
+            and (arr_dtype := actual.dtype) != expected_dtype
         ):
             raise RuntimeError(
                 f"Array has wrong dtype {arr_dtype}, expected {expected_dtype.__name__}"
@@ -208,8 +207,6 @@ def pytest_warns_bounded(
         current = Version(version_str)
     if lb < current < ub:
         return pytest.warns(warning, match=match)
-    else:
-        if upper_exception is None:
-            return nullcontext()
-        else:
-            return suppress(upper_exception)
+    if upper_exception is None:
+        return nullcontext()
+    return suppress(upper_exception)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -87,7 +87,7 @@ def check(
             and get_origin(shape_type) is tuple
             and (tuple_args := get_args(shape_type))
             and ... not in tuple_args  # fixed-length tuple
-            and (arr_ndim := actual.ndim) != (expected_ndim := len(tuple_args))
+            and (arr_ndim := actual.ndim) != (expected_ndim := len(tuple_args))  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
         ):
             raise RuntimeError(
                 f"Array has wrong dimension {arr_ndim}, expected {expected_ndim}"
@@ -99,7 +99,7 @@ def check(
             and (dtype_args := get_args(dtype_type))
             and isinstance((expected_dtype := dtype_args[0]), type)
             and issubclass(expected_dtype, np.generic)
-            and (arr_dtype := actual.dtype) != expected_dtype
+            and (arr_dtype := actual.dtype) != expected_dtype  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]
         ):
             raise RuntimeError(
                 f"Array has wrong dtype {arr_dtype}, expected {expected_dtype.__name__}"

--- a/tests/extension/decimal/array.py
+++ b/tests/extension/decimal/array.py
@@ -150,21 +150,18 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
         def reconstruct(x):
             if isinstance(x, (decimal.Decimal, numbers.Number)):
                 return x
-            else:
-                return DecimalArray._from_sequence(x)
+            return DecimalArray._from_sequence(x)
 
         if ufunc.nout > 1:
             return tuple(reconstruct(x) for x in result)
-        else:
-            return reconstruct(result)
+        return reconstruct(result)
 
     def __getitem__(self, item):
         if isinstance(item, numbers.Integral):
             return self._data[item]
-        else:
-            # array, slice.
-            item = check_array_indexer(self, item)
-            return type(self)(self._data[item])
+        # array, slice.
+        item = check_array_indexer(self, item)
+        return type(self)(self._data[item])
 
     def take(
         self, indexer: TakeIndexer, *, allow_fill: bool = False, fill_value=None
@@ -208,10 +205,9 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
     def __contains__(self, item) -> bool | np.bool_:
         if not isinstance(item, decimal.Decimal):
             return False
-        elif item.is_nan():
+        if item.is_nan():
             return self.isna().any()
-        else:
-            return super().__contains__(item)
+        return super().__contains__(item)
 
     @property
     def nbytes(self) -> int:
@@ -270,7 +266,7 @@ class DecimalArray(OpsMixin, ExtensionScalarOpsMixin, ExtensionArray):
 
         # If the operator is not defined for the underlying objects,
         # a TypeError should be raised
-        res = [op(a, b) for (a, b) in zip(lvalues, rvalues)]
+        res = [op(a, b) for (a, b) in zip(lvalues, rvalues, strict=False)]
 
         return np.asarray(res, dtype=bool)
 

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -120,7 +120,9 @@ def test_multiindex_constructors() -> None:
         pd.MultiIndex,
     )
     check(
-        assert_type(pd.MultiIndex.from_tuples(zip([1, 2], [3, 4])), pd.MultiIndex),
+        assert_type(
+            pd.MultiIndex.from_tuples(zip([1, 2], [3, 4], strict=False)), pd.MultiIndex
+        ),
         pd.MultiIndex,
     )
     check(

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -154,10 +154,10 @@ def test_column_contains() -> None:
     # https://github.com/microsoft/python-type-stubs/issues/199
     df = pd.DataFrame({"A": [1, 2], "B": ["c", "d"], "E": [3, 4]})
 
-    collist = [column for column in df.columns]
+    collist = list(df.columns)
     check(assert_type(collist, list[str]), list, str)
 
-    collist2 = [column for column in df.columns[df.columns.str.contains("A|B")]]
+    collist2 = list(df.columns[df.columns.str.contains("A|B")])
     check(assert_type(collist2, list[str]), list, str)
 
     length = len(df.columns[df.columns.str.contains("A|B")])

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1910,7 +1910,7 @@ def test_resample() -> None:
     # GH 181
     N = 10
     index = pd.date_range("1/1/2000", periods=N, freq="min")
-    x = [x for x in range(N)]
+    x = list(range(N))
     s = pd.Series(x, index=index, dtype=float)
     check(assert_type(s.resample("2min").std(), "pd.Series[float]"), pd.Series, float)
     check(assert_type(s.resample("2min").var(), "pd.Series[float]"), pd.Series, float)
@@ -2976,7 +2976,7 @@ def test_astype_other() -> None:
 
 def test_all_astype_args_tested() -> None:
     """Check that all relevant numpy type aliases are tested."""
-    NUMPY_ALIASES: set[str] = {k for k in np.sctypeDict}
+    NUMPY_ALIASES: set[str] = set(np.sctypeDict)
     EXCLUDED_ALIASES = {
         "datetime64",
         "m",
@@ -3631,7 +3631,7 @@ def test_series_unique_timedelta() -> None:
 def test_slice_timestamp() -> None:
     dti = pd.date_range("1/1/2025", "2/28/2025")
 
-    s = pd.Series([i for i in range(len(dti))], index=dti)
+    s = pd.Series(list(range(len(dti))), index=dti)
 
     # For `s1`, see discussion in GH 397.  Needs mypy fix.
     # s1 = s.loc["2025-01-15":"2025-01-20"]
@@ -3708,7 +3708,7 @@ def test_series_bool_fails() -> None:
         if s == "foo":  # pyright: ignore[reportGeneralTypeIssues]
             # Next line is unreachable.
             _a = s[0]
-            assert False
+            raise AssertionError
     except ValueError:
         pass
 

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2141,7 +2141,7 @@ def test_pandera_generic() -> None:
 def test_change_to_dict_return_type() -> None:
     id = [1, 2, 3]
     value = ["a", "b", "c"]
-    df = pd.DataFrame(zip(id, value), columns=["id", "value"])
+    df = pd.DataFrame(zip(id, value, strict=False), columns=["id", "value"])
     fd = df.set_index("id")["value"].to_dict()
     check(assert_type(fd, dict[Any, Any]), dict)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -19,7 +19,7 @@ def test_abstract_method_error() -> None:
 
 def test_dtype_warning() -> None:
     with pytest.warns(errors.DtypeWarning):
-        warnings.warn("", errors.DtypeWarning)
+        warnings.warn("", errors.DtypeWarning, stacklevel=2)
 
 
 def test_duplicate_label_error() -> None:
@@ -29,7 +29,7 @@ def test_duplicate_label_error() -> None:
 
 def test_empry_data_error() -> None:
     with pytest.raises(errors.EmptyDataError):
-        raise errors.EmptyDataError()
+        raise errors.EmptyDataError
 
 
 def test_in_casting_nan_error() -> None:
@@ -59,69 +59,69 @@ def test_numba_util_error() -> None:
 
 def test_option_error() -> None:
     with pytest.raises(errors.OptionError):
-        raise errors.OptionError()
+        raise errors.OptionError
 
 
 def test_out_of_bounds_datetime() -> None:
     with pytest.raises(errors.OutOfBoundsDatetime):
-        raise errors.OutOfBoundsDatetime()
+        raise errors.OutOfBoundsDatetime
 
 
 def test_out_of_bounds_timedelta() -> None:
     with pytest.raises(errors.OutOfBoundsTimedelta):
-        raise errors.OutOfBoundsTimedelta()
+        raise errors.OutOfBoundsTimedelta
 
 
 def test_parser_error() -> None:
     with pytest.raises(errors.ParserError):
-        raise errors.ParserError()
+        raise errors.ParserError
 
 
 def test_parser_warning() -> None:
     with pytest.warns(errors.ParserWarning):
-        warnings.warn("", errors.ParserWarning)
+        warnings.warn("", errors.ParserWarning, stacklevel=2)
 
 
 def test_performance_warning() -> None:
     with pytest.warns(errors.PerformanceWarning):
-        warnings.warn("", errors.PerformanceWarning)
+        warnings.warn("", errors.PerformanceWarning, stacklevel=2)
 
 
 def test_unsorted_index_error() -> None:
     with pytest.raises(errors.UnsortedIndexError):
-        raise errors.UnsortedIndexError()
+        raise errors.UnsortedIndexError
 
 
 def test_unsupported_function_call() -> None:
     with pytest.raises(errors.UnsupportedFunctionCall):
-        raise errors.UnsupportedFunctionCall()
+        raise errors.UnsupportedFunctionCall
 
 
 def test_data_error() -> None:
     with pytest.raises(errors.DataError):
-        raise errors.DataError()
+        raise errors.DataError
 
 
 def test_specification_error() -> None:
     with pytest.raises(errors.SpecificationError):
-        raise errors.SpecificationError()
+        raise errors.SpecificationError
 
 
 def test_setting_with_copy_error() -> None:
     if PD_LTE_23:
         with pytest.raises(errors.SettingWithCopyError):
-            raise errors.SettingWithCopyError()
+            raise errors.SettingWithCopyError
 
 
 def test_setting_with_copy_warning() -> None:
     if PD_LTE_23:
         with pytest.warns(errors.SettingWithCopyWarning):
-            warnings.warn("", errors.SettingWithCopyWarning)
+            warnings.warn("", errors.SettingWithCopyWarning, stacklevel=2)
 
 
 def test_numexpr_clobbering_error() -> None:
     with pytest.raises(errors.NumExprClobberingError):
-        raise errors.NumExprClobberingError()
+        raise errors.NumExprClobberingError
 
 
 def test_undefined_variable_error() -> None:
@@ -131,12 +131,12 @@ def test_undefined_variable_error() -> None:
 
 def test_indexing_error() -> None:
     with pytest.raises(errors.IndexingError):
-        raise errors.IndexingError()
+        raise errors.IndexingError
 
 
 def test_pyperclip_exception() -> None:
     with pytest.raises(errors.PyperclipException):
-        raise errors.PyperclipException()
+        raise errors.PyperclipException
 
 
 @pytest.mark.skipif(not WINDOWS, reason="Windows only")
@@ -147,59 +147,59 @@ def test_pyperclip_windows_exception() -> None:
 
 def test_css_warning() -> None:
     with pytest.warns(errors.CSSWarning):
-        warnings.warn("", errors.CSSWarning)
+        warnings.warn("", errors.CSSWarning, stacklevel=2)
 
 
 def test_possible_data_loss_error() -> None:
     with pytest.raises(errors.PossibleDataLossError):
-        raise errors.PossibleDataLossError()
+        raise errors.PossibleDataLossError
 
 
 def test_closed_file_error() -> None:
     with pytest.raises(errors.ClosedFileError):
-        raise errors.ClosedFileError()
+        raise errors.ClosedFileError
 
 
 def test_incompatibility_warning() -> None:
     with pytest.warns(errors.IncompatibilityWarning):
-        warnings.warn("", errors.IncompatibilityWarning)
+        warnings.warn("", errors.IncompatibilityWarning, stacklevel=2)
 
 
 def test_attribute_conflict_warning() -> None:
     with pytest.warns(errors.AttributeConflictWarning):
-        warnings.warn("", errors.AttributeConflictWarning)
+        warnings.warn("", errors.AttributeConflictWarning, stacklevel=2)
 
 
 def test_database_error() -> None:
     with pytest.raises(errors.DatabaseError):
-        raise errors.DatabaseError()
+        raise errors.DatabaseError
 
 
 def test_possible_precision_loss() -> None:
     with pytest.warns(errors.PossiblePrecisionLoss):
-        warnings.warn("", errors.PossiblePrecisionLoss)
+        warnings.warn("", errors.PossiblePrecisionLoss, stacklevel=2)
 
 
 def test_value_label_type_mismatch() -> None:
     with pytest.warns(errors.ValueLabelTypeMismatch):
-        warnings.warn("", errors.ValueLabelTypeMismatch)
+        warnings.warn("", errors.ValueLabelTypeMismatch, stacklevel=2)
 
 
 def test_invalid_column_name() -> None:
     with pytest.warns(errors.InvalidColumnName):
-        warnings.warn("", errors.InvalidColumnName)
+        warnings.warn("", errors.InvalidColumnName, stacklevel=2)
 
 
 def test_categorical_conversion_warning() -> None:
     with pytest.warns(errors.CategoricalConversionWarning):
-        warnings.warn("", errors.CategoricalConversionWarning)
+        warnings.warn("", errors.CategoricalConversionWarning, stacklevel=2)
 
 
 def test_invalid_version() -> None:
     with pytest.raises(errors.InvalidVersion):
-        raise errors.InvalidVersion()
+        raise errors.InvalidVersion
 
 
 def test_no_buffer_present() -> None:
     with pytest.raises(errors.NoBufferPresent):
-        raise errors.NoBufferPresent()
+        raise errors.NoBufferPresent

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -437,7 +437,7 @@ def test_types_filter() -> None:
     check(assert_type(df.filter(like="1"), pd.DataFrame), pd.DataFrame)
     # GH964 Docs state `items` is `list-like`
     check(
-        assert_type(df.filter(items=("col2", "col2", 1, tuple([4]))), pd.DataFrame),
+        assert_type(df.filter(items=("col2", "col2", 1, (4,))), pd.DataFrame),
         pd.DataFrame,
     )
 
@@ -3637,9 +3637,9 @@ def test_groupby_apply() -> None:
 def test_resample() -> None:
     # GH 181
     N = 10
-    x = [x for x in range(N)]
+    x = list(range(N))
     index = pd.date_range("1/1/2000", periods=N, freq="min")
-    x = [x for x in range(N)]
+    x = list(range(N))
     df = pd.DataFrame({"a": x, "b": x, "c": x}, index=index)
     check(assert_type(df.resample("2min").std(), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.resample("2min").var(), pd.DataFrame), pd.DataFrame)
@@ -4129,11 +4129,10 @@ def test_loc_callable() -> None:
 def test_npint_loc_indexer() -> None:
     # GH 508
 
-    df = pd.DataFrame(dict(x=[1, 2, 3]), index=np.array([10, 20, 30], dtype="uint64"))
+    df = pd.DataFrame({"x": [1, 2, 3]}, index=np.array([10, 20, 30], dtype="uint64"))
 
     def get_NDArray(df: pd.DataFrame, key: npt.NDArray[np.uint64]) -> pd.DataFrame:
-        df2 = df.loc[key]
-        return df2
+        return df.loc[key]
 
     a: npt.NDArray[np.uint64] = np.array([10, 30], dtype="uint64")
     check(assert_type(get_NDArray(df, a), pd.DataFrame), pd.DataFrame)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -3894,7 +3894,7 @@ def test_mask() -> None:
 def test_setitem_loc() -> None:
     # GH 254
     df = pd.DataFrame.from_dict(
-        {view: (True, True, True) for view in ["A", "B", "C"]}, orient="index"
+        dict.fromkeys(["A", "B", "C"], (True, True, True)), orient="index"
     )
     df.loc[["A", "C"]] = False
     my_arr = ["A", "C"]

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -241,9 +241,7 @@ def test_types_concat() -> None:
     check(assert_type(pd.concat({1: df, None: df2}), pd.DataFrame), pd.DataFrame)
 
     check(
-        assert_type(
-            pd.concat(map(lambda _: s2, ["some_value", 3]), axis=1), pd.DataFrame
-        ),
+        assert_type(pd.concat((s2 for _ in ["some_value", 3]), axis=1), pd.DataFrame),
         pd.DataFrame,
     )
     adict = {"a": df, 2: df2}

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -828,7 +828,7 @@ def test_wide_to_long() -> None:
             "A1980": {0: "d", 1: "e", 2: "f"},
             "B1970": {0: 2.5, 1: 1.2, 2: 0.7},
             "B1980": {0: 3.2, 1: 1.3, 2: 0.1},
-            "X": dict(zip(range(3), np.random.randn(3))),
+            "X": dict(zip(range(3), np.random.randn(3), strict=False)),
         }
     )
     df["id"] = df.index

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -594,7 +594,7 @@ def test_plot_subplot_changes_150() -> None:
 
 
 def test_grouped_dataframe_boxplot(close_figures) -> None:
-    tuples = [t for t in itertools.product(range(10), range(2))]
+    tuples = list(itertools.product(range(10), range(2)))
     index = pd.MultiIndex.from_tuples(tuples, names=["lvl0", "lvl1"])
     df = pd.DataFrame(
         data=np.random.randn(len(index), 2), columns=["A", "B"], index=index
@@ -630,7 +630,7 @@ def test_grouped_dataframe_boxplot_single(close_figures) -> None:
     is put separately to  make sure that we have no Axes already created.
     It will fail with `orientation="horizontal"`.
     """
-    tuples = [t for t in itertools.product(range(10), range(2))]
+    tuples = list(itertools.product(range(10), range(2)))
     index = pd.MultiIndex.from_tuples(tuples, names=["lvl0", "lvl1"])
     df = pd.DataFrame(
         data=np.random.randn(len(index), 2), columns=["A", "B"], index=index

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -1186,7 +1186,7 @@ def test_to_timedelta_index() -> None:
     ]
     arg2 = tuple(arg0)
     arg3 = tuple(arg1)
-    arg4 = range(0, 10)
+    arg4 = range(10)
     arg5 = np.arange(10)
     arg6 = pd.Index(arg5)
     check(


### PR DESCRIPTION
`ruff` rules usually improve the code quality. By specifying `ignore` rather than `select`, we get better hints how to comply to more rules.

In many cases this reduces errors in `pyright` strict, hence contributing to pandas-dev/pandas-stubs#1171.

For example, if we comply to [`ANN201`](https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/), test functions will be foreced to have `-> None`, which reduces `pyright` strict errors. This was discussed in https://github.com/pandas-dev/pandas-stubs/pull/1405#issuecomment-3368485010.