### PR TITLE
Fix nightly with pd.DataFrame.rename calling for MultiIndex.fillna

### DIFF
--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2555,8 +2555,10 @@ def test_types_rename() -> None:
     )
 
     df_multiindex = pd.DataFrame(columns=[("a", 1), ("a", 2)])
-    check(assert_type(df_multiindex.rename(columns={(1, 2): ("b", "a")}), pd.DataFrame), pd.DataFrame)
-
+    check(
+        assert_type(df_multiindex.rename(columns={(1, 2): ("b", "a")}), pd.DataFrame),
+        pd.DataFrame,
+    )
 
 
 def test_types_rename_axis() -> None:


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added: Please use `assert_type()` to assert the type of any return value

PR replaces the `DataFrame.rename` when using a multi index in the replacer while the dataframe only has `Index`.