### PR TITLE
refactor: simplify `pd.concat`

### DIFF
--- a/pandas-stubs/core/reshape/concat.pyi
+++ b/pandas-stubs/core/reshape/concat.pyi
@@ -8,10 +8,9 @@ from typing import (
     overload,
 )
 
-from pandas import (
-    DataFrame,
-    Series,
-)
+from pandas.core.frame import DataFrame
+from pandas.core.generic import NDFrame
+from pandas.core.series import Series
 from typing_extensions import Never
 
 from pandas._typing import (
@@ -25,155 +24,58 @@ from pandas._typing import (
 )
 
 @overload
-def concat(  # type: ignore[overload-overlap]
-    objs: Iterable[DataFrame] | Mapping[HashableT1, DataFrame],
-    *,
-    axis: Axis = ...,
-    join: Literal["inner", "outer"] = ...,
-    ignore_index: bool = ...,
-    keys: Iterable[HashableT2] | None = ...,
-    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = ...,
-    names: list[HashableT4] | None = ...,
-    verify_integrity: bool = ...,
-    sort: bool = ...,
-    copy: bool = ...,
-) -> DataFrame: ...
-@overload
-def concat(  # pyright: ignore[reportOverlappingOverload]
-    objs: Iterable[Series[S2]],
-    *,
-    axis: AxisIndex = ...,
-    join: Literal["inner", "outer"] = ...,
-    ignore_index: bool = ...,
-    keys: Iterable[HashableT2] | None = ...,
-    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = ...,
-    names: list[HashableT4] | None = ...,
-    verify_integrity: bool = ...,
-    sort: bool = ...,
-    copy: bool = ...,
-) -> Series[S2]: ...
-@overload
-def concat(  # type: ignore[overload-overlap]
-    objs: Iterable[Series] | Mapping[HashableT1, Series],
-    *,
-    axis: AxisIndex = ...,
-    join: Literal["inner", "outer"] = ...,
-    ignore_index: bool = ...,
-    keys: Iterable[HashableT2] | None = ...,
-    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = ...,
-    names: list[HashableT4] | None = ...,
-    verify_integrity: bool = ...,
-    sort: bool = ...,
-    copy: bool = ...,
-) -> Series: ...
-@overload
-def concat(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
-    objs: Iterable[Series | DataFrame] | Mapping[HashableT1, Series | DataFrame],
-    *,
-    axis: Axis = ...,
-    join: Literal["inner", "outer"] = ...,
-    ignore_index: bool = ...,
-    keys: Iterable[HashableT2] | None = ...,
-    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = ...,
-    names: list[HashableT4] | None = ...,
-    verify_integrity: bool = ...,
-    sort: bool = ...,
-    copy: bool = ...,
-) -> DataFrame: ...
-@overload
 def concat(
     objs: Iterable[None] | Mapping[HashableT1, None],
     *,
-    axis: Axis = ...,
-    join: Literal["inner", "outer"] = ...,
-    ignore_index: bool = ...,
-    keys: Iterable[HashableT2] | None = ...,
-    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = ...,
-    names: list[HashableT4] | None = ...,
-    verify_integrity: bool = ...,
-    sort: bool = ...,
-    copy: bool = ...,
+    axis: Axis = 0,
+    join: Literal["inner", "outer"] = "outer",
+    ignore_index: bool = False,
+    keys: Iterable[HashableT2] | None = None,
+    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = None,
+    names: list[HashableT4] | None = None,
+    verify_integrity: bool = False,
+    sort: bool = False,
+    copy: bool = True,
 ) -> Never: ...
 @overload
-def concat(  # type: ignore[overload-overlap]
-    objs: Iterable[DataFrame | None] | Mapping[HashableT1, DataFrame | None],
+def concat(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+    objs: Iterable[Series[S2] | None] | Mapping[HashableT1, Series[S2] | None],
     *,
-    axis: Axis = ...,
-    join: Literal["inner", "outer"] = ...,
-    ignore_index: bool = ...,
-    keys: Iterable[HashableT2] | None = ...,
-    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = ...,
-    names: list[HashableT4] | None = ...,
-    verify_integrity: bool = ...,
-    sort: bool = ...,
-    copy: bool = ...,
-) -> DataFrame: ...
+    axis: AxisIndex = 0,
+    join: Literal["inner", "outer"] = "outer",
+    ignore_index: bool = False,
+    keys: Iterable[HashableT2] | None = None,
+    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = None,
+    names: list[HashableT4] | None = None,
+    verify_integrity: bool = False,
+    sort: bool = False,
+    copy: bool = True,
+) -> Series[S2]: ...
 @overload
 def concat(  # type: ignore[overload-overlap]
     objs: Iterable[Series | None] | Mapping[HashableT1, Series | None],
     *,
-    axis: AxisIndex = ...,
-    join: Literal["inner", "outer"] = ...,
-    ignore_index: bool = ...,
-    keys: Iterable[HashableT2] | None = ...,
-    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = ...,
-    names: list[HashableT4] | None = ...,
-    verify_integrity: bool = ...,
-    sort: bool = ...,
-    copy: bool = ...,
+    axis: AxisIndex = 0,
+    join: Literal["inner", "outer"] = "outer",
+    ignore_index: bool = False,
+    keys: Iterable[HashableT2] | None = None,
+    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = None,
+    names: list[HashableT4] | None = None,
+    verify_integrity: bool = False,
+    sort: bool = False,
+    copy: bool = True,
 ) -> Series: ...
 @overload
 def concat(
-    objs: (
-        Iterable[Series | DataFrame | None]
-        | Mapping[HashableT1, Series | DataFrame | None]
-    ),
+    objs: Iterable[NDFrame | None] | Mapping[HashableT1, NDFrame | None],
     *,
-    axis: Axis = ...,
-    join: Literal["inner", "outer"] = ...,
-    ignore_index: bool = ...,
-    keys: Iterable[HashableT2] | None = ...,
-    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = ...,
-    names: list[HashableT4] | None = ...,
-    verify_integrity: bool = ...,
-    sort: bool = ...,
-    copy: bool = ...,
+    axis: Axis = 0,
+    join: Literal["inner", "outer"] = "outer",
+    ignore_index: bool = False,
+    keys: Iterable[HashableT2] | None = None,
+    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = None,
+    names: list[HashableT4] | None = None,
+    verify_integrity: bool = False,
+    sort: bool = False,
+    copy: bool = True,
 ) -> DataFrame: ...
-
-# Including either of the next 2 overloads causes mypy to complain about
-# test_pandas.py:test_types_concat() in assert_type(pd.concat([s, s2]), pd.Series)
-# It thinks that pd.concat([s, s2]) is Any .  May be due to Series being
-# Generic, or the axis argument being unspecified, and then there is partial
-# overlap with the first 2 overloads.
-#
-# @overload
-# def concat(
-#     objs: Union[
-#         Iterable[Union[Series, DataFrame]], Mapping[HashableT, Union[Series, DataFrame]]
-#     ],
-#     axis: Literal[0, "index"] = ...,
-#     join: str = ...,
-#     ignore_index: bool = ...,
-#     keys=...,
-#     levels=...,
-#     names=...,
-#     verify_integrity: bool = ...,
-#     sort: bool = ...,
-#     copy: bool = ...,
-# ) -> DataFrame | Series: ...
-
-# @overload
-# def concat(
-#     objs: Union[
-#         Iterable[Union[Series, DataFrame]], Mapping[HashableT, Union[Series, DataFrame]]
-#     ],
-#     axis: Axis = ...,
-#     join: str = ...,
-#     ignore_index: bool = ...,
-#     keys=...,
-#     levels=...,
-#     names=...,
-#     verify_integrity: bool = ...,
-#     sort: bool = ...,
-#     copy: bool = ...,
-# ) -> DataFrame | Series: ...

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -107,14 +107,20 @@ def test_types_concat_none() -> None:
     series = pd.Series([7, -5, 10])
     df = pd.DataFrame({"a": [7, -5, 10]})
 
-    check(assert_type(pd.concat([None, series]), pd.Series), pd.Series)
+    check(
+        assert_type(pd.concat([None, series]), "pd.Series[int]"), pd.Series, np.integer
+    )
     check(assert_type(pd.concat([None, df]), pd.DataFrame), pd.DataFrame)
     check(
         assert_type(pd.concat([None, series, df], axis=1), pd.DataFrame), pd.DataFrame
     )
     check(assert_type(pd.concat([None, series, df]), pd.DataFrame), pd.DataFrame)
 
-    check(assert_type(pd.concat({"a": None, "b": series}), pd.Series), pd.Series)
+    check(
+        assert_type(pd.concat({"a": None, "b": series}), "pd.Series[int]"),
+        pd.Series,
+        np.integer,
+    )
     check(assert_type(pd.concat({"a": None, "b": df}), pd.DataFrame), pd.DataFrame)
     check(
         assert_type(pd.concat({"a": None, "b": series, "c": df}, axis=1), pd.DataFrame),
@@ -163,18 +169,22 @@ def test_types_concat() -> None:
 
     # Depends on the axis
     check(
-        assert_type(pd.concat({"a": s, "b": s2}), pd.Series),
+        assert_type(pd.concat({"a": s, "b": s2}), "pd.Series[int]"),
         pd.Series,
+        np.integer,
     )
     check(
         assert_type(pd.concat({"a": s, "b": s2}, axis=1), pd.DataFrame),
         pd.DataFrame,
     )
-    check(assert_type(pd.concat({1: s, 2: s2}), pd.Series), pd.Series)
+    check(
+        assert_type(pd.concat({1: s, 2: s2}), "pd.Series[int]"), pd.Series, np.integer
+    )
     check(assert_type(pd.concat({1: s, 2: s2}, axis=1), pd.DataFrame), pd.DataFrame)
     check(
-        assert_type(pd.concat({1: s, None: s2}), pd.Series),
+        assert_type(pd.concat({1: s, None: s2}), "pd.Series[int]"),
         pd.Series,
+        np.integer,
     )
 
     # https://github.com/microsoft/python-type-stubs/issues/69


### PR DESCRIPTION
This PR simplifies `pandas.concat`, gives more typing information and adds default values.
