### PR TITLE
stubs: add pandas.io.sql.get_schema to fix Pylance reportAttributeAcc…

### DIFF
--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -10,6 +10,7 @@ from typing import (
     Literal,
     TypeAlias,
     overload,
+    Sequence,
 )
 
 from pandas.core.frame import DataFrame
@@ -162,6 +163,15 @@ class PandasSQL:
         engine: str = "auto",
         **engine_kwargs: Any,
     ) -> int | None: ...
+
+def get_schema(
+    frame: DataFrame,
+    name: str,
+    keys: str | Sequence[str] | None = ...,
+    con: _SQLConnection = ...,
+    dtype: DtypeArg | None = ...,
+    schema: str | None = ...,
+) -> str: ...
 
 class SQLTable:
     name: str


### PR DESCRIPTION
### Summary
Add a stub for `pandas.io.sql.get_schema`. The function exists at runtime but
is missing from the `pandas-stubs`, causing Pylance/Pyright to report:

> "get_schema" is unknown import symbol (reportAttributeAccessIssue)

### Rationale
- Improves developer experience in VS Code / Pyright without changing pandas runtime.
- Keeps pandas’ API policy unchanged (no need to modify pandas or `__all__`).

### Signature
```py
def get_schema(
    frame: DataFrame,
    name: str,
    keys: str | Sequence[str] | None = ...,
    con: Any = ...,
    dtype: DtypeArg | None = ...,
    schema: str | None = ...,
) -> str: ...
