### PR TITLE
FIX: #1508 numpy 1darrays in tests

### DIFF
--- a/pandas-stubs/core/base.pyi
+++ b/pandas-stubs/core/base.pyi
@@ -10,6 +10,7 @@ from typing import (
     Literal,
     Protocol,
     TypeAlias,
+    TypeVar,
     final,
     overload,
     type_check_only,
@@ -52,6 +53,8 @@ from pandas._typing import (
     np_ndarray_td,
 )
 from pandas.util._decorators import cache_readonly
+
+T_INTERVAL_NP = TypeVar("T_INTERVAL_NP", bound=np.bytes_ | np.str_)
 
 class NoNewAttributesMixin:
     def __setattr__(self, key: str, value: Any) -> None: ...

--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -32,6 +32,7 @@ import numpy as np
 from pandas.core.arrays.boolean import BooleanArray
 from pandas.core.arrays.floating import FloatingArray
 from pandas.core.base import (
+    T_INTERVAL_NP,
     ArrayIndexTimedeltaNoSeq,
     ElementOpsMixin,
     IndexComplex,
@@ -1191,6 +1192,14 @@ class Index(IndexOpsMixin[S1], ElementOpsMixin[S1]):
 class _IndexSubclassBase(Index[S1], Generic[S1, GenericT_co]):
     @overload
     def to_numpy(
+        self: _IndexSubclassBase[Interval],
+        dtype: type[T_INTERVAL_NP],
+        copy: bool = False,
+        na_value: Scalar = ...,
+        **kwargs: Any,
+    ) -> np_1darray: ...
+    @overload
+    def to_numpy(
         self,
         dtype: None = None,
         copy: bool = False,
@@ -1206,7 +1215,7 @@ class _IndexSubclassBase(Index[S1], Generic[S1, GenericT_co]):
         **kwargs: Any,
     ) -> np_1darray[GenericT]: ...
     @overload
-    def to_numpy(
+    def to_numpy(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         dtype: DTypeLike,
         copy: bool = False,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -29,7 +29,6 @@ from typing import (
     NoReturn,
     Protocol,
     TypeAlias,
-    TypeVar,
     final,
     overload,
     type_check_only,
@@ -71,6 +70,7 @@ from pandas.core.arrays.datetimes import DatetimeArray
 from pandas.core.arrays.floating import FloatingArray
 from pandas.core.arrays.timedeltas import TimedeltaArray
 from pandas.core.base import (
+    T_INTERVAL_NP,
     ArrayIndexSeriesTimedeltaNoSeq,
     ArrayIndexTimedeltaNoSeq,
     ElementOpsMixin,
@@ -189,6 +189,7 @@ from pandas._typing import (
     MaskType,
     NaPosition,
     NsmallestNlargestKeep,
+    NumpyStrDtypeArg,
     ObjectDtypeArg,
     PandasAstypeComplexDtypeArg,
     PandasAstypeFloatDtypeArg,
@@ -250,8 +251,6 @@ from pandas.core.dtypes.base import ExtensionDtype
 from pandas.core.dtypes.dtypes import CategoricalDtype
 
 from pandas.plotting import PlotAccessor
-
-_T_INTERVAL_NP = TypeVar("_T_INTERVAL_NP", bound=np.bytes_ | np.str_)
 
 @type_check_only
 class _SupportsAdd(Protocol[_T_co]):
@@ -4503,7 +4502,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         copy: bool = False,
         na_value: Scalar = ...,
         **kwargs: Any,
-    ) -> np_1darray_bytes: ...
+    ) -> np_1darray: ...
     @overload
     def to_numpy(
         self: Series[Interval],
@@ -4515,11 +4514,11 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def to_numpy(
         self: Series[Interval],
-        dtype: type[_T_INTERVAL_NP],
+        dtype: type[T_INTERVAL_NP],
         copy: bool = False,
         na_value: Scalar = ...,
         **kwargs: Any,
-    ) -> np_1darray[_T_INTERVAL_NP]: ...
+    ) -> np_1darray: ...
     @overload
     def to_numpy(
         self: Series[int],
@@ -4555,11 +4554,27 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def to_numpy(
         self: Series[_str],
-        dtype: DTypeLike | None = None,
+        dtype: NumpyStrDtypeArg,
         copy: bool = False,
         na_value: Scalar = ...,
         **kwargs: Any,
     ) -> np_1darray_str: ...
+    @overload
+    def to_numpy(
+        self: Series[_str],
+        dtype: DTypeLike,
+        copy: bool = False,
+        na_value: Scalar = ...,
+        **kwargs: Any,
+    ) -> np_1darray: ...
+    @overload
+    def to_numpy(
+        self: Series[_str],
+        dtype: None = None,
+        copy: bool = False,
+        na_value: Scalar = ...,
+        **kwargs: Any,
+    ) -> np_1darray_object: ...
     @overload
     def to_numpy(
         self: Series[bytes],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -439,11 +439,11 @@ else:
     _S = TypeVar("_S", bound=tuple[int, ...])
     # Separately define here so pytest works
     np_1darray: TypeAlias = np.ndarray[tuple[int], np.dtype[_G]]
-    np_1darray_bool: TypeAlias = np.ndarray[tuple[int], np.bool_]
-    np_1darray_str: TypeAlias = np.ndarray[tuple[int], np.str_]
-    np_1darray_bytes: TypeAlias = np.ndarray[tuple[int], np.bytes_]
-    np_1darray_complex: TypeAlias = np.ndarray[tuple[int], np.complexfloating]
-    np_1darray_object: TypeAlias = np.ndarray[tuple[int], np.object_]
+    np_1darray_bool: TypeAlias = np_1darray[np.bool_]
+    np_1darray_str: TypeAlias = np_1darray[np.str_]
+    np_1darray_bytes: TypeAlias = np_1darray[np.bytes_]
+    np_1darray_complex: TypeAlias = np_1darray[np.complexfloating]
+    np_1darray_object: TypeAlias = np_1darray[np.object_]
     np_1darray_intp: TypeAlias = np_1darray[np.intp]
     np_1darray_int64: TypeAlias = np_1darray[np.int64]
     np_1darray_anyint: TypeAlias = np_1darray[np.integer]

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -73,7 +73,6 @@ from tests import (
     np_1darray_dt,
     np_1darray_float,
     np_1darray_object,
-    np_1darray_str,
     np_1darray_td,
     np_ndarray_num,
     pytest_warns_bounded,
@@ -2004,18 +2003,22 @@ def test_dtype_type() -> None:
 
 def test_types_to_numpy() -> None:
     s = pd.Series(["a", "b", "c"], dtype=str)
-    check(assert_type(s.to_numpy(), np_1darray_str), np_1darray_str)
-    check(
-        assert_type(s.to_numpy(dtype="str", copy=True), np_1darray_str), np_1darray_str
+    check(assert_type(s.to_numpy(), np_1darray_object), np_1darray_object)
+    check(  # <U1, not str_
+        assert_type(s.to_numpy(dtype="str", copy=True), np_1darray), np_1darray
     )
-    check(assert_type(s.to_numpy(na_value=0), np_1darray_str), np_1darray_str)
-    check(assert_type(s.to_numpy(na_value=np.int32(4)), np_1darray_str), np_1darray_str)
+    check(assert_type(s.to_numpy(na_value=0), np_1darray_object), np_1darray_object)
     check(
-        assert_type(s.to_numpy(na_value=np.float16(4)), np_1darray_str), np_1darray_str
+        assert_type(s.to_numpy(na_value=np.int32(4)), np_1darray_object),
+        np_1darray_object,
     )
     check(
-        assert_type(s.to_numpy(na_value=np.complex128(4, 7)), np_1darray_str),
-        np_1darray_str,
+        assert_type(s.to_numpy(na_value=np.float16(4)), np_1darray_object),
+        np_1darray_object,
+    )
+    check(
+        assert_type(s.to_numpy(na_value=np.complex128(4, 7)), np_1darray_object),
+        np_1darray_object,
     )
 
     check(assert_type(pd.Series().to_numpy(), np_1darray), np_1darray)
@@ -2024,7 +2027,7 @@ def test_types_to_numpy() -> None:
 def test_to_numpy() -> None:
     """Test Series.to_numpy for different types."""
     s_str = pd.Series(["a", "b", "c"], dtype=str)
-    check(assert_type(s_str.to_numpy(), np_1darray_str), np_1darray_str)
+    check(assert_type(s_str.to_numpy(), np_1darray_object), np_1darray_object)
 
     s_bytes = pd.Series(["a", "b", "c"]).astype(bytes)
     check(assert_type(s_bytes.to_numpy(), np_1darray_bytes), np_1darray, np.bytes_)

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -30,11 +30,9 @@ from tests import (
     check,
     np_1darray,
     np_1darray_bool,
-    np_1darray_bytes,
     np_1darray_dt,
     np_1darray_int64,
     np_1darray_object,
-    np_1darray_str,
     np_1darray_td,
     pytest_warns_bounded,
 )
@@ -956,14 +954,8 @@ def test_series_types_to_numpy() -> None:
         np_1darray,
         dtype=np.integer,
     )
-    check(
-        assert_type(o_s.to_numpy(dtype="bytes", copy=True), np_1darray),
-        np_1darray_bytes,
-    )
-    check(
-        assert_type(i_s.to_numpy(dtype="bytes", copy=True), np_1darray),
-        np_1darray_bytes,
-    )
+    check(assert_type(o_s.to_numpy(dtype="bytes", copy=True), np_1darray), np_1darray)
+    check(assert_type(i_s.to_numpy(dtype="bytes", copy=True), np_1darray), np_1darray)
 
     # passed dtype-like with statically known generic
     check(
@@ -991,13 +983,12 @@ def test_series_types_to_numpy() -> None:
         np_1darray,
         np.int64,
     )
-    check(
-        assert_type(o_s.to_numpy(dtype=np.bytes_), np_1darray_bytes), np_1darray_bytes
-    )
-    check(
-        assert_type(i_s.to_numpy(dtype=np.bytes_), np_1darray_bytes), np_1darray_bytes
-    )
-    check(assert_type(i_s.to_numpy(dtype=np.str_), np_1darray_str), np_1darray_str)
+    # |S20, not bytes_
+    check(assert_type(o_s.to_numpy(dtype=np.bytes_), np_1darray), np_1darray)
+    # |S6, not bytes_
+    check(assert_type(i_s.to_numpy(dtype=np.bytes_), np_1darray), np_1darray)
+    # <U6, not str_
+    check(assert_type(i_s.to_numpy(dtype=np.str_), np_1darray), np_1darray)
 
 
 def test_index_types_to_numpy() -> None:
@@ -1056,10 +1047,8 @@ def test_index_types_to_numpy() -> None:
         np_1darray,
         dtype=np.integer,
     )
-    check(
-        assert_type(i_i.to_numpy(dtype="bytes", copy=True), np_1darray),
-        np_1darray_bytes,
-    )
+    # |S6, not bytes_
+    check(assert_type(i_i.to_numpy(dtype="bytes", copy=True), np_1darray), np_1darray)
 
     # passed dtype-like with statically known generic
     check(
@@ -1077,9 +1066,8 @@ def test_index_types_to_numpy() -> None:
         np_1darray,
         np.int64,
     )
-    check(
-        assert_type(i_i.to_numpy(dtype=np.bytes_), np_1darray_bytes), np_1darray_bytes
-    )
+    # |S6, not bytes_
+    check(assert_type(i_i.to_numpy(dtype=np.bytes_), np_1darray), np_1darray)
 
 
 def test_to_timedelta_units() -> None:


### PR DESCRIPTION
In #1508 I realised that `np_1darray_*` in `tests` has been incorrect. The fixes seem to be independent of #1503, hence I am separating them here.

- [x] Tests added
