### PR TITLE
CLN: `invalid-type-arguments` can now be enabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,7 +342,9 @@ filterwarnings = [
 # Next line needed to avoid poetry complaint
 [tool.setuptools_scm]
 
+[tool.ty.environment]
+python-platform = "all"
+python-version = "3.10"
+
 [tool.ty.rules]
 unresolved-import = "ignore"
-# TODO: report to ty
-invalid-type-arguments = "ignore"


### PR DESCRIPTION
Now that astral-sh/ty#1752 has been resolved, `invalid-type-arguments` can be enabled.