### PR TITLE
TYP: #1544 all `sys.version`-related changes

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -959,7 +959,10 @@ np_1darray_dt: TypeAlias = np_1darray[np.datetime64]
 np_1darray_td: TypeAlias = np_1darray[np.timedelta64]
 np_2darray: TypeAlias = np.ndarray[tuple[int, int], np.dtype[GenericT]]
 
-NDArrayT = TypeVar("NDArrayT", bound=np.ndarray)
+if sys.version_info >= (3, 11):
+    NDArrayT = TypeVar("NDArrayT", bound=np.ndarray)
+else:
+    NDArrayT = TypeVar("NDArrayT", bound=np.ndarray[Any, Any])
 
 DtypeNp = TypeVar("DtypeNp", bound=np.dtype[np.generic])
 KeysArgType: TypeAlias = Any

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -340,28 +340,23 @@ class _AtIndexerFrame(_AtIndexer):
         value: Scalar | NAType | NaTType | None,
     ) -> None: ...
 
-# With mypy 1.14.1 and python 3.12, the second overload needs a type-ignore statement
-if sys.version_info >= (3, 12):
-    class _GetItemHack:
-        @overload
-        def __getitem__(self, key: Scalar | tuple[Hashable, ...]) -> Series: ...  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+class _GetItemHack:
+    @overload
+    def __getitem__(self, key: Scalar | tuple[Hashable, ...]) -> Series: ...  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+    # With python 3.12+, the second overload needs a type-ignore statement
+    if sys.version_info >= (3, 12):
         @overload
         def __getitem__(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
             self, key: Iterable[Hashable] | slice
         ) -> Self: ...
-        @overload
-        def __getitem__(self, key: Hashable) -> Series: ...
-
-else:
-    class _GetItemHack:
-        @overload
-        def __getitem__(self, key: Scalar | tuple[Hashable, ...]) -> Series: ...  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+    else:
         @overload
         def __getitem__(  # pyright: ignore[reportOverlappingOverload]
             self, key: Iterable[Hashable] | slice
         ) -> Self: ...
-        @overload
-        def __getitem__(self, key: Hashable) -> Series: ...
+
+    @overload
+    def __getitem__(self, key: Hashable) -> Series: ...
 
 _AstypeArgExt: TypeAlias = (
     AstypeArg
@@ -562,16 +557,29 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         coerce_float: bool = False,
         nrows: int | None = None,
     ) -> Self: ...
-    def to_records(
-        self,
-        index: _bool = True,
-        column_dtypes: (
-            _str | npt.DTypeLike | Mapping[HashableT1, npt.DTypeLike] | None
-        ) = None,
-        index_dtypes: (
-            _str | npt.DTypeLike | Mapping[HashableT2, npt.DTypeLike] | None
-        ) = None,
-    ) -> np.recarray: ...
+    if sys.version_info >= (3, 11):
+        def to_records(
+            self,
+            index: _bool = True,
+            column_dtypes: (
+                _str | npt.DTypeLike | Mapping[HashableT1, npt.DTypeLike] | None
+            ) = None,
+            index_dtypes: (
+                _str | npt.DTypeLike | Mapping[HashableT2, npt.DTypeLike] | None
+            ) = None,
+        ) -> np.recarray: ...
+    else:
+        def to_records(
+            self,
+            index: _bool = True,
+            column_dtypes: (
+                _str | npt.DTypeLike | Mapping[HashableT1, npt.DTypeLike] | None
+            ) = None,
+            index_dtypes: (
+                _str | npt.DTypeLike | Mapping[HashableT2, npt.DTypeLike] | None
+            ) = None,
+        ) -> np.recarray[Any, Any]: ...
+
     @overload
     def to_stata(
         self,

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -2998,19 +2998,42 @@ def test_to_xarray() -> None:
 
 def test_to_records() -> None:
     df = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
-    check(assert_type(df.to_records(False, "int8"), np.recarray), np.recarray)
-    check(
-        assert_type(df.to_records(False, index_dtypes=np.int8), np.recarray),
-        np.recarray,
-    )
-    check(
-        assert_type(
-            df.to_records(False, {"col1": np.int8, "col2": np.int16}), np.recarray
-        ),
-        np.recarray,
-    )
     dtypes = {"col1": np.int8, "col2": np.int16}
-    check(assert_type(df.to_records(False, dtypes), np.recarray), np.recarray)
+    if sys.version_info >= (3, 11):
+        check(assert_type(df.to_records(False, "int8"), np.recarray), np.recarray)
+        check(
+            assert_type(df.to_records(False, index_dtypes=np.int8), np.recarray),
+            np.recarray,
+        )
+        check(
+            assert_type(
+                df.to_records(False, {"col1": np.int8, "col2": np.int16}), np.recarray
+            ),
+            np.recarray,
+        )
+        check(assert_type(df.to_records(False, dtypes), np.recarray), np.recarray)
+    else:
+        check(
+            assert_type(df.to_records(False, "int8"), np.recarray[Any, Any]),
+            np.recarray,
+        )
+        check(
+            assert_type(
+                df.to_records(False, index_dtypes=np.int8), np.recarray[Any, Any]
+            ),
+            np.recarray,
+        )
+        check(
+            assert_type(
+                df.to_records(False, {"col1": np.int8, "col2": np.int16}),
+                np.recarray[Any, Any],
+            ),
+            np.recarray,
+        )
+        check(
+            assert_type(df.to_records(False, dtypes), np.recarray[Any, Any]),
+            np.recarray,
+        )
 
 
 def test_to_dict_simple() -> None:

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -1719,9 +1719,15 @@ def test_index_view() -> None:
         # - pyright: ndarray[tuple[Any, ...], dtype[Any]]
         check(assert_type(ind.view(np.ndarray), np.ndarray), np.ndarray)  # type: ignore[assert-type]
     else:
-        check(assert_type(ind.view(np.ndarray), np.ndarray), np.ndarray)
+        check(assert_type(ind.view(np.ndarray), np.ndarray[Any, Any]), np.ndarray)
 
-    class MyArray(np.ndarray): ...
+    if sys.version_info >= (3, 11):
+
+        class MyArray(np.ndarray): ...
+
+    else:
+
+        class MyArray(np.ndarray[Any, Any]): ...
 
     check(assert_type(ind.view(MyArray), MyArray), MyArray)
 


### PR DESCRIPTION
Towards #1544 .

These are all changes required in #1544 that depends on Python version. It will make #1544 smaller.