### PR TITLE
TYP: Fix np.double dtype inference for numpy 2.4.0

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -454,16 +454,6 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         copy: bool | None = None,
     ) -> Series[Interval[_OrderableT]]: ...
     @overload
-    def __new__(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
-        cls,
-        data: Scalar | _DataLike | dict[HashableT1, Any] | None,
-        index: AxesData | None = None,
-        *,
-        dtype: type[S1],
-        name: Hashable = None,
-        copy: bool | None = None,
-    ) -> Self: ...
-    @overload
     def __new__(  # pyright: ignore[reportOverlappingOverload]
         cls,
         data: Sequence[bool | np.bool],
@@ -509,6 +499,16 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         name: Hashable = None,
         copy: bool | None = None,
     ) -> Series[float]: ...
+    @overload
+    def __new__(
+        cls,
+        data: Scalar | _DataLike | dict[HashableT1, Any] | None,
+        index: AxesData | None = None,
+        *,
+        dtype: type[S1],
+        name: Hashable = None,
+        copy: bool | None = None,
+    ) -> Self: ...
     @overload
     def __new__(
         cls,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ exclude = [ "pandas-stubs/__init__.py" ]
 [tool.poetry.dependencies]
 python = ">=3.10"
 types-pytz = ">=2022.1.1"
-numpy = ">=1.23.5, <= 2.3.5"
+numpy = ">=1.23.5"
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=1.19.1"


### PR DESCRIPTION
- [x] Closes #1590 
- [x] Tests added (existing test at `tests/series/test_series_float.py:81`)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

# PR: Fix type inference for `np.double` dtype with numpy 2.4.0

## Problem

With numpy 2.4.0, `pd.Series([1.0], dtype=np.double)` infers `Series[float64]` instead of `Series[float]`.

## Cause

numpy 2.4.0 changed `double` from abstract type alias to concrete class reference:
```python
# numpy 2.3.5
double: TypeAlias = floating[_NBitDouble]

# numpy 2.4.0
double = float64  # float64 is a concrete class
```

This causes the generic `dtype: type[S1]` overload to match before `dtype: FloatDtypeArg`.

## Solution

Reorder `Series.__new__` overloads: move `dtype: type[S1]` after `dtype: FloatDtypeArg`.

This matches the existing order in `Index.__new__` which doesn't have this issue.

## Testing

Passed on both numpy 2.3.5 and 2.4.0.
