### PR TITLE
BUG: propagate pandas-dev/pandas#41789

### DIFF
--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -479,7 +479,7 @@ class NDFrame:
     def take(self, indices: TakeIndexer, axis: Axis = 0, **kwargs: Any) -> Self: ...
     def xs(
         self,
-        key: IndexLabel,
+        key: Hashable | tuple[Hashable, ...],
         axis: Axis = 0,
         level: IndexLabel | None = None,
         drop_level: _bool = True,

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -3413,6 +3413,9 @@ def test_xs_frame_new() -> None:
     check(assert_type(s1, pd.Series | pd.DataFrame), pd.DataFrame)
     check(assert_type(s2, pd.Series | pd.DataFrame), pd.Series)
 
+    if TYPE_CHECKING_INVALID_USAGE:
+        df.xs(["mammel"])  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+
 
 def test_align() -> None:
     df0 = pd.DataFrame(

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2679,6 +2679,10 @@ def test_check_xs() -> None:
     s4.xs(0, axis=0)
     check(assert_type(s4, "pd.Series[int]"), pd.Series, np.integer)
 
+    if TYPE_CHECKING_INVALID_USAGE:
+        s4.xs([0])  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+        s4.xs(0, axis=1)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType]
+
 
 def test_types_apply_set() -> None:
     series_of_lists: pd.Series = pd.Series(


### PR DESCRIPTION
Towards #1579

Since pandas-dev/pandas#41789, in `DataFrame.xs` and `Series.xs`, `key` can no longer be a `list`.

- [x] Tests added (Please use `assert_type()` to assert the type of any return value)

