### PR TITLE
BUG: rename to `NoDefaultDoNotUse`

### DIFF
--- a/pandas-stubs/_libs/lib.pyi
+++ b/pandas-stubs/_libs/lib.pyi
@@ -12,7 +12,7 @@ class _NoDefault(Enum):
     no_default = "NO_DEFAULT"
 
 no_default: Final = _NoDefault.no_default
-NoDefault: TypeAlias = Literal[_NoDefault.no_default]
+NoDefaultDoNotUse: TypeAlias = Literal[_NoDefault.no_default]
 
 def infer_dtype(value: object, skipna: bool = True) -> str: ...
 def is_iterator(obj: object) -> bool: ...

--- a/pandas-stubs/_testing/__init__.pyi
+++ b/pandas-stubs/_testing/__init__.pyi
@@ -26,7 +26,7 @@ from pandas.arrays import (
 )
 from pandas.core.arrays.base import ExtensionArray
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     AnyArrayLike,
     T,
@@ -106,14 +106,14 @@ def assert_series_equal(
     check_index_type: bool | Literal["equiv"] = "equiv",
     check_series_type: bool = True,
     check_names: bool = True,
-    check_exact: bool | NoDefault = ...,
+    check_exact: bool | NoDefaultDoNotUse = ...,
     check_datetimelike_compat: bool = False,
     check_categorical: bool = True,
     check_category_order: bool = True,
     check_freq: bool = True,
     check_flags: bool = True,
-    rtol: float | NoDefault = ...,
-    atol: float | NoDefault = ...,
+    rtol: float | NoDefaultDoNotUse = ...,
+    atol: float | NoDefaultDoNotUse = ...,
     obj: str = "Series",
     *,
     check_index: Literal[False],
@@ -127,14 +127,14 @@ def assert_series_equal(
     check_index_type: bool | Literal["equiv"] = "equiv",
     check_series_type: bool = True,
     check_names: bool = True,
-    check_exact: bool | NoDefault = ...,
+    check_exact: bool | NoDefaultDoNotUse = ...,
     check_datetimelike_compat: bool = False,
     check_categorical: bool = True,
     check_category_order: bool = True,
     check_freq: bool = True,
     check_flags: bool = True,
-    rtol: float | NoDefault = ...,
-    atol: float | NoDefault = ...,
+    rtol: float | NoDefaultDoNotUse = ...,
+    atol: float | NoDefaultDoNotUse = ...,
     obj: str = "Series",
     *,
     check_index: Literal[True] = True,

--- a/pandas-stubs/api/typing/__init__.pyi
+++ b/pandas-stubs/api/typing/__init__.pyi
@@ -20,7 +20,7 @@ from pandas.core.window import (
 )
 
 from pandas._libs import NaTType as NaTType
-from pandas._libs.lib import NoDefault as NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse as NoDefaultDoNotUse
 from pandas._libs.missing import NAType as NAType
 
 from pandas.io.json._json import JsonReader as JsonReader

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -78,7 +78,7 @@ from typing_extensions import (
 )
 import xarray as xr
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs import BaseOffset
 from pandas._typing import (
@@ -1199,7 +1199,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[True] = True,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Scalar, Literal[True]]: ...
     @overload
@@ -1210,7 +1210,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[False] = False,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Scalar, Literal[False]]: ...
     @overload
@@ -1221,7 +1221,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[True] = True,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Timestamp, Literal[True]]: ...
     @overload
@@ -1232,7 +1232,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[False] = False,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Timestamp, Literal[False]]: ...
     @overload
@@ -1243,7 +1243,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[True] = True,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Timedelta, Literal[True]]: ...
     @overload
@@ -1254,7 +1254,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[False] = False,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Timedelta, Literal[False]]: ...
     @overload
@@ -1265,7 +1265,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[True] = True,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Period, Literal[True]]: ...
     @overload
@@ -1276,7 +1276,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[False] = False,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Period, Literal[False]]: ...
     @overload
@@ -1287,7 +1287,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[True] = True,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[IntervalT, Literal[True]]: ...
     @overload
@@ -1298,7 +1298,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[False] = False,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[IntervalT, Literal[False]]: ...
     @overload
@@ -1309,7 +1309,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[True] = True,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[tuple[Hashable, ...], Literal[True]]: ...
     @overload
@@ -1320,7 +1320,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[False] = False,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[tuple[Hashable, ...], Literal[False]]: ...
     @overload
@@ -1331,7 +1331,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[True] = True,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[SeriesByT, Literal[True]]: ...
     @overload
@@ -1342,7 +1342,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[False] = False,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[SeriesByT, Literal[False]]: ...
     @overload
@@ -1353,7 +1353,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[True] = True,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Any, Literal[True]]: ...
     @overload
@@ -1364,7 +1364,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         as_index: Literal[False] = False,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> DataFrameGroupBy[Any, Literal[False]]: ...
     def pivot(

--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -31,7 +31,7 @@ from typing_extensions import (
     Self,
 )
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     Axis,
     CompressionOptions,
@@ -466,7 +466,7 @@ class NDFrame:
     def resample(
         self,
         rule: Frequency | dt.timedelta,
-        axis: Axis | NoDefault = 0,
+        axis: Axis | NoDefaultDoNotUse = 0,
         closed: Literal["right", "left"] | None = None,
         label: Literal["right", "left"] | None = None,
         on: Level | None = None,

--- a/pandas-stubs/core/groupby/groupby.pyi
+++ b/pandas-stubs/core/groupby/groupby.pyi
@@ -39,7 +39,7 @@ from pandas.core.window import (
 )
 from typing_extensions import Self
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._libs.tslibs import BaseOffset
 from pandas._typing import (
     S1,
@@ -277,27 +277,27 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         ascending: bool = True,
         na_option: str = "keep",
         pct: bool = False,
-        axis: AxisInt | NoDefault = 0,
+        axis: AxisInt | NoDefaultDoNotUse = 0,
     ) -> NDFrameT: ...
     @final
     def cumprod(
-        self, axis: Axis | NoDefault = ..., *args: Any, **kwargs: Any
+        self, axis: Axis | NoDefaultDoNotUse = ..., *args: Any, **kwargs: Any
     ) -> NDFrameT: ...
     @final
     def cumsum(
-        self, axis: Axis | NoDefault = ..., *args: Any, **kwargs: Any
+        self, axis: Axis | NoDefaultDoNotUse = ..., *args: Any, **kwargs: Any
     ) -> NDFrameT: ...
     @final
     def cummin(
         self,
-        axis: AxisInt | NoDefault = ...,
+        axis: AxisInt | NoDefaultDoNotUse = ...,
         numeric_only: bool = ...,
         **kwargs: Any,
     ) -> NDFrameT: ...
     @final
     def cummax(
         self,
-        axis: AxisInt | NoDefault = ...,
+        axis: AxisInt | NoDefaultDoNotUse = ...,
         numeric_only: bool = ...,
         **kwargs: Any,
     ) -> NDFrameT: ...
@@ -306,20 +306,22 @@ class GroupBy(BaseGroupBy[NDFrameT]):
         self,
         periods: int | Sequence[int] = 1,
         freq: Frequency | None = ...,
-        axis: Axis | NoDefault = 0,
+        axis: Axis | NoDefaultDoNotUse = 0,
         fill_value: Scalar | None = None,
         suffix: str | None = ...,
     ) -> NDFrameT: ...
     @final
-    def diff(self, periods: int = 1, axis: AxisInt | NoDefault = 0) -> NDFrameT: ...
+    def diff(
+        self, periods: int = 1, axis: AxisInt | NoDefaultDoNotUse = 0
+    ) -> NDFrameT: ...
     @final
     def pct_change(
         self,
         periods: int = ...,
-        fill_method: Literal["bfill", "ffill"] | None | NoDefault = ...,
-        limit: int | None | NoDefault = ...,
+        fill_method: Literal["bfill", "ffill"] | None | NoDefaultDoNotUse = ...,
+        limit: int | None | NoDefaultDoNotUse = ...,
         freq: Frequency | None = None,
-        axis: Axis | NoDefault = ...,
+        axis: Axis | NoDefaultDoNotUse = ...,
     ) -> NDFrameT: ...
     @final
     def head(self, n: int = ...) -> NDFrameT: ...

--- a/pandas-stubs/core/groupby/grouper.pyi
+++ b/pandas-stubs/core/groupby/grouper.pyi
@@ -7,7 +7,7 @@ from typing import (
 from pandas.core.resample import TimeGrouper
 from typing_extensions import Self
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     Axis,
     Frequency,
@@ -30,7 +30,7 @@ class Grouper:
         cls,
         key: KeysArgType | None = ...,
         level: Level | ListLikeHashable[Level] | None = ...,
-        axis: Axis | NoDefault = ...,
+        axis: Axis | NoDefaultDoNotUse = ...,
         sort: bool = ...,
         dropna: bool = ...,
     ) -> Self: ...

--- a/pandas-stubs/core/indexes/timedeltas.pyi
+++ b/pandas-stubs/core/indexes/timedeltas.pyi
@@ -26,7 +26,7 @@ from typing_extensions import (
 )
 
 from pandas._libs import Timedelta
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._libs.tslibs import BaseOffset
 from pandas._libs.tslibs.period import Period
 from pandas._typing import (
@@ -63,7 +63,7 @@ class TimedeltaIndex(
         data: (
             Sequence[timedelta | Timedelta | np.timedelta64 | float] | AxesData | None
         ),
-        freq: Frequency | NoDefault = ...,
+        freq: Frequency | NoDefaultDoNotUse = ...,
         dtype: Literal["<m8[ns]"] | None = None,
         copy: bool | None = None,
         name: str | None = None,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -132,7 +132,7 @@ from pandas._libs.interval import (
     Interval,
     _OrderableT,
 )
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs import BaseOffset
 from pandas._libs.tslibs.nattype import NaTType
@@ -790,7 +790,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Scalar]: ...
     @overload
@@ -801,7 +801,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Timestamp]: ...
     @overload
@@ -812,7 +812,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Timedelta]: ...
     @overload
@@ -823,7 +823,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Period]: ...
     @overload
@@ -834,7 +834,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, IntervalT]: ...
     @overload
@@ -845,7 +845,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, tuple[Hashable, ...]]: ...
     @overload
@@ -856,7 +856,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Scalar]: ...
     @overload
@@ -868,7 +868,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Scalar]: ...
     @overload
@@ -879,7 +879,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, SeriesByT]: ...
     @overload
@@ -890,7 +890,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         as_index: _bool = ...,
         sort: _bool = ...,
         group_keys: _bool = ...,
-        observed: _bool | NoDefault = ...,
+        observed: _bool | NoDefaultDoNotUse = ...,
         dropna: _bool = ...,
     ) -> SeriesGroupBy[S1, Any]: ...
     def count(self) -> int: ...
@@ -4705,7 +4705,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         labels: AxesData,
         *,
         axis: Axis = 0,
-        copy: _bool | NoDefault = ...,
+        copy: _bool | NoDefaultDoNotUse = ...,
     ) -> Self: ...
     @final
     def xs(  # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override] # ty: ignore[invalid-method-override]

--- a/pandas-stubs/core/tools/numeric.pyi
+++ b/pandas-stubs/core/tools/numeric.pyi
@@ -8,7 +8,7 @@ from typing import (
 
 import pandas as pd
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     DtypeBackend,
     RaiseCoerce,
@@ -26,26 +26,26 @@ def to_numeric(  # type: ignore[overload-overlap] # pyright: ignore[reportOverla
     arg: Scalar,
     errors: RaiseCoerce = "raise",
     downcast: _Downcast = None,
-    dtype_backend: DtypeBackend | NoDefault = "numpy_nullable",
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = "numpy_nullable",
 ) -> float: ...
 @overload
 def to_numeric(
     arg: Sequence[int],
     errors: RaiseCoerce = "raise",
     downcast: _Downcast = None,
-    dtype_backend: DtypeBackend | NoDefault = "numpy_nullable",
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = "numpy_nullable",
 ) -> np_1darray_anyint: ...
 @overload
 def to_numeric(
     arg: SequenceNotStr[Any] | np_ndarray,
     errors: RaiseCoerce = "raise",
     downcast: _Downcast = None,
-    dtype_backend: DtypeBackend | NoDefault = "numpy_nullable",
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = "numpy_nullable",
 ) -> np_1darray_float: ...
 @overload
 def to_numeric(
     arg: pd.Series,
     errors: RaiseCoerce = "raise",
     downcast: _Downcast = None,
-    dtype_backend: DtypeBackend | NoDefault = "numpy_nullable",
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = "numpy_nullable",
 ) -> pd.Series: ...

--- a/pandas-stubs/io/clipboards.pyi
+++ b/pandas-stubs/io/clipboards.pyi
@@ -12,7 +12,7 @@ from typing import (
 
 from pandas.core.frame import DataFrame
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     CompressionOptions,
     CSVEngine,
@@ -30,7 +30,7 @@ from pandas.io.parsers import TextFileReader
 def read_clipboard(
     sep: str | None = ...,
     *,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
@@ -89,7 +89,7 @@ def read_clipboard(
 def read_clipboard(
     sep: str | None = ...,
     *,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,
@@ -148,7 +148,7 @@ def read_clipboard(
 def read_clipboard(
     sep: str | None = ...,
     *,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     delimiter: str | None = ...,
     header: int | Sequence[int] | Literal["infer"] | None = ...,
     names: ListLikeHashable | None = ...,

--- a/pandas-stubs/io/excel/_base.pyi
+++ b/pandas-stubs/io/excel/_base.pyi
@@ -24,7 +24,7 @@ from typing_extensions import (
 )
 from xlrd.book import Book
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     Dtype,
     DtypeBackend,
@@ -87,7 +87,7 @@ def read_excel(
     comment: str | None = ...,
     skipfooter: int = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine_kwargs: dict[str, Any] | None = ...,
 ) -> dict[IntStrT, DataFrame]: ...
 @overload
@@ -130,7 +130,7 @@ def read_excel(
     comment: str | None = ...,
     skipfooter: int = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine_kwargs: dict[str, Any] | None = ...,
 ) -> dict[str, DataFrame]: ...
 @overload
@@ -174,7 +174,7 @@ def read_excel(  # type: ignore[overload-cannot-match]
     comment: str | None = ...,
     skipfooter: int = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine_kwargs: dict[str, Any] | None = ...,
 ) -> dict[int | str, DataFrame]: ...
 @overload
@@ -217,7 +217,7 @@ def read_excel(
     comment: str | None = ...,
     skipfooter: int = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine_kwargs: dict[str, Any] | None = ...,
 ) -> DataFrame: ...
 

--- a/pandas-stubs/io/feather_format.pyi
+++ b/pandas-stubs/io/feather_format.pyi
@@ -1,6 +1,6 @@
 from pandas import DataFrame
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     DtypeBackend,
     FilePath,
@@ -14,5 +14,5 @@ def read_feather(
     columns: list[HashableT] | None = None,
     use_threads: bool = True,
     storage_options: StorageOptions = None,
-    dtype_backend: DtypeBackend | NoDefault = "numpy_nullable",
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = "numpy_nullable",
 ) -> DataFrame: ...

--- a/pandas-stubs/io/html.pyi
+++ b/pandas-stubs/io/html.pyi
@@ -12,7 +12,7 @@ from typing import (
 
 from pandas.core.frame import DataFrame
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     DtypeBackend,
     FilePath,
@@ -53,6 +53,6 @@ def read_html(
     keep_default_na: bool = ...,
     displayed_only: bool = ...,
     extract_links: Literal["header", "footer", "body", "all"] | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     storage_options: StorageOptions = ...,
 ) -> list[DataFrame]: ...

--- a/pandas-stubs/io/json/_json.pyi
+++ b/pandas-stubs/io/json/_json.pyi
@@ -13,7 +13,7 @@ from typing import (
 from pandas.core.frame import DataFrame
 from pandas.core.series import Series
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     CompressionOptions,
     DtypeArg,
@@ -50,7 +50,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine: Literal["ujson"] = ...,
 ) -> JsonReader[Series]: ...
 @overload
@@ -75,7 +75,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine: Literal["pyarrow"],
 ) -> JsonReader[Series]: ...
 @overload
@@ -100,7 +100,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine: Literal["ujson"] = ...,
 ) -> JsonReader[DataFrame]: ...
 @overload
@@ -125,7 +125,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine: Literal["pyarrow"],
 ) -> JsonReader[DataFrame]: ...
 @overload
@@ -150,7 +150,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine: Literal["ujson"] = ...,
 ) -> Series: ...
 @overload
@@ -175,7 +175,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine: Literal["pyarrow"],
 ) -> Series: ...
 @overload
@@ -200,7 +200,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine: Literal["ujson"] = ...,
 ) -> DataFrame: ...
 @overload
@@ -225,7 +225,7 @@ def read_json(
     compression: CompressionOptions = ...,
     nrows: int | None = ...,
     storage_options: StorageOptions = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     engine: Literal["pyarrow"],
 ) -> DataFrame: ...
 

--- a/pandas-stubs/io/orc.pyi
+++ b/pandas-stubs/io/orc.pyi
@@ -3,7 +3,7 @@ from typing import Any
 from pandas import DataFrame
 from pyarrow.fs import FileSystem
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     DtypeBackend,
     FilePath,
@@ -18,7 +18,7 @@ from fsspec.spec import (  # pyright: ignore[reportMissingTypeStubs] # isort: sk
 def read_orc(
     path: FilePath | ReadBuffer[bytes],
     columns: list[HashableT] | None = None,
-    dtype_backend: DtypeBackend | NoDefault = "numpy_nullable",
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = "numpy_nullable",
     filesystem: (  # pyright: ignore[reportUnknownParameterType]
         FileSystem | AbstractFileSystem | None
     ) = None,

--- a/pandas-stubs/io/parsers/readers.pyi
+++ b/pandas-stubs/io/parsers/readers.pyi
@@ -19,7 +19,7 @@ from typing import (
 from pandas.core.frame import DataFrame
 from typing_extensions import Self
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     CompressionOptions,
     CSVEngine,
@@ -95,7 +95,7 @@ def read_csv(
     memory_map: bool = False,
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
     storage_options: StorageOptions | None = None,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> TextFileReader: ...
 @overload
 def read_csv(
@@ -158,7 +158,7 @@ def read_csv(
     memory_map: bool = False,
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
     storage_options: StorageOptions | None = None,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> TextFileReader: ...
 @overload
 def read_csv(
@@ -221,7 +221,7 @@ def read_csv(
     memory_map: bool = ...,
     float_precision: Literal["high", "legacy", "round_trip"] | None = ...,
     storage_options: StorageOptions | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> DataFrame: ...
 @overload
 def read_table(
@@ -284,7 +284,7 @@ def read_table(
     memory_map: bool = False,
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
     storage_options: StorageOptions | None = None,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> TextFileReader: ...
 @overload
 def read_table(
@@ -347,7 +347,7 @@ def read_table(
     memory_map: bool = False,
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
     storage_options: StorageOptions | None = None,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> TextFileReader: ...
 @overload
 def read_table(
@@ -410,7 +410,7 @@ def read_table(
     memory_map: bool = False,
     float_precision: Literal["high", "legacy", "round_trip"] | None = None,
     storage_options: StorageOptions | None = None,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> DataFrame: ...
 @overload
 def read_fwf(
@@ -419,7 +419,7 @@ def read_fwf(
     colspecs: Sequence[tuple[int, int]] | Literal["infer"] | None = ...,
     widths: Sequence[int] | None = ...,
     infer_nrows: int = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     date_format: dict[Hashable, str] | str | None = ...,
     iterator: Literal[True],
     chunksize: int | None = ...,
@@ -432,7 +432,7 @@ def read_fwf(
     colspecs: Sequence[tuple[int, int]] | Literal["infer"] | None = ...,
     widths: Sequence[int] | None = ...,
     infer_nrows: int = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     date_format: dict[Hashable, str] | str | None = ...,
     iterator: bool = ...,
     chunksize: int,
@@ -445,7 +445,7 @@ def read_fwf(
     colspecs: Sequence[tuple[int, int]] | Literal["infer"] | None = ...,
     widths: Sequence[int] | None = ...,
     infer_nrows: int = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
     date_format: dict[Hashable, str] | str | None = ...,
     iterator: Literal[False] = False,
     chunksize: None = None,

--- a/pandas-stubs/io/spss.pyi
+++ b/pandas-stubs/io/spss.pyi
@@ -1,6 +1,6 @@
 from pandas.core.frame import DataFrame
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     DtypeBackend,
     FilePath,
@@ -11,5 +11,5 @@ def read_spss(
     path: FilePath,
     usecols: list[HashableT] | None = None,
     convert_categoricals: bool = True,
-    dtype_backend: DtypeBackend | NoDefault = "numpy_nullable",
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = "numpy_nullable",
 ) -> DataFrame: ...

--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -18,7 +18,7 @@ import sqlalchemy.engine
 from sqlalchemy.orm import FromStatement
 import sqlalchemy.sql.expression
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     DtypeArg,
     DtypeBackend,
@@ -49,7 +49,7 @@ def read_sql_table(
     columns: list[str] | None = ...,
     *,
     chunksize: int,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql_table(
@@ -61,7 +61,7 @@ def read_sql_table(
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = ...,
     columns: list[str] | None = ...,
     chunksize: None = None,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> DataFrame: ...
 @overload
 def read_sql_query(
@@ -81,7 +81,7 @@ def read_sql_query(
     *,
     chunksize: int,
     dtype: DtypeArg | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql_query(
@@ -100,7 +100,7 @@ def read_sql_query(
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = ...,
     chunksize: None = None,
     dtype: DtypeArg | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> DataFrame: ...
 @overload
 def read_sql(
@@ -120,7 +120,7 @@ def read_sql(
     *,
     chunksize: int,
     dtype: DtypeArg | None = ...,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> Generator[DataFrame, None, None]: ...
 @overload
 def read_sql(
@@ -139,7 +139,7 @@ def read_sql(
     columns: list[str] | None = None,
     chunksize: None = None,
     dtype: DtypeArg | None = None,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> DataFrame: ...
 
 class PandasSQL:

--- a/pandas-stubs/io/xml.pyi
+++ b/pandas-stubs/io/xml.pyi
@@ -2,7 +2,7 @@ from typing import Any
 
 from pandas.core.frame import DataFrame
 
-from pandas._libs.lib import NoDefault
+from pandas._libs.lib import NoDefaultDoNotUse
 from pandas._typing import (
     CompressionOptions,
     ConvertersArg,
@@ -34,5 +34,5 @@ def read_xml(
     iterparse: dict[str, list[str]] | None = None,
     compression: CompressionOptions = "infer",
     storage_options: StorageOptions = None,
-    dtype_backend: DtypeBackend | NoDefault = ...,
+    dtype_backend: DtypeBackend | NoDefaultDoNotUse = ...,
 ) -> DataFrame: ...

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def test_no_default_alias() -> None:
+    from pandas._libs.lib import no_default
+
+    assert no_default
+
+    msg = r"cannot import name 'NoDefaultDoNotUse' from 'pandas._libs.lib'"
+    with pytest.raises(ImportError, match=msg):
+        from pandas._libs.lib import (  # isort: skip
+            NoDefaultDoNotUse as NoDefaultDoNotUse,  # noqa: PLC0414
+        )


### PR DESCRIPTION
`_NoDefaultDoNotUse` has been called `NoDefault` since pandas-dev/pandas#47045.