### PR TITLE
TYP: Update TimeAmbiguous type alias to include bool

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -824,7 +824,9 @@ ReindexMethod: TypeAlias = FillnaOptions | Literal["nearest"]
 TimeGrouperOrigin: TypeAlias = (
     Timestamp | Literal["epoch", "start", "start_day", "end", "end_day"]
 )
-TimeAmbiguous: TypeAlias = Literal["infer", "NaT", "raise"] | npt.NDArray[np.bool_]
+TimeAmbiguous: TypeAlias = (
+    Literal["infer", "NaT", "raise"] | bool | npt.NDArray[np.bool_]
+)
 # Note this is same as TimestampNonexistent - defined both ways in pandas
 TimeNonexistent: TypeAlias = (
     Literal["shift_forward", "shift_backward", "NaT", "raise"]

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -468,6 +468,19 @@ def test_series_dt_accessors() -> None:
         pd.Series,
         pd.Timestamp,
     )
+    check(
+        assert_type(s0.dt.ceil("D", ambiguous=True), "pd.Series[pd.Timestamp]"),
+        pd.Series,
+        pd.Timestamp,
+    )
+    check(
+        assert_type(
+            s0.dt.ceil("D", ambiguous=np.array([True, False])),
+            "pd.Series[pd.Timestamp]",
+        ),
+        pd.Series,
+        pd.Timestamp,
+    )
     check(assert_type(s0.dt.month_name(), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s0.dt.day_name(), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s0.dt.unit, TimeUnit), str)


### PR DESCRIPTION
equivalent of https://github.com/pandas-dev/pandas/pull/63699

Internally, the `ambiguous` parameter supports a single bool as well as an array of bool (https://github.com/pandas-dev/pandas/blob/2.3.x/pandas/_libs/tslibs/tzconversion.pyx#L206). Passing a single bool is also handled correctly at runtime (https://github.com/pandas-dev/pandas/blob/2.3.x/pandas/_libs/tslibs/tzconversion.pyx#L263-L268). The public API currently enforces an array—which either means unnecessary overhead or ignoring the type hint.

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
