### PR TITLE
TST: propagate PyTables/PyTables#1261

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ html5lib = ">=1.1"
 python-calamine = ">=0.2.0"
 pyarrow-stubs = { version = ">=20.0.0.20250928", python = "<4" }
 fsspec = "^2025.10.0"
-tables = { version = ">=3.10.2", python = "<3.14" }  # TODO: add py314 when PyTables/PyTables#1261 is resolved
+tables = ">=3.10.2"
 pytz = "^2025.2"
 types-pytz = ">=2022.1.1"
 pyiceberg = "^0.10.0"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -7,7 +7,6 @@ import io
 import os
 from pathlib import Path
 import sqlite3
-import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -339,19 +338,12 @@ def test_sas_xport() -> None:
         pass
 
 
-MESSAGE_PYTABLE_314 = (
-    "PyTables does not support Python 3.14+ yet, see PyTables/PyTables#1261"
-)
-
-
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason=MESSAGE_PYTABLE_314)
 def test_hdf(tmp_path: Path) -> None:
     path_str = str(tmp_path / str(uuid.uuid4()))
     check(assert_type(DF.to_hdf(path_str, key="df"), None), type(None))
     check(assert_type(read_hdf(path_str), DataFrame | Series), DataFrame)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason=MESSAGE_PYTABLE_314)
 def test_hdfstore(tmp_path: Path) -> None:
     path_str = str(tmp_path / str(uuid.uuid4()))
     store = HDFStore(path_str, model="w")
@@ -386,7 +378,6 @@ def test_hdfstore(tmp_path: Path) -> None:
     store.close()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason=MESSAGE_PYTABLE_314)
 def test_read_hdf_iterator(tmp_path: Path) -> None:
     path_str = str(tmp_path / str(uuid.uuid4()))
     check(assert_type(DF.to_hdf(path_str, key="df", format="table"), None), type(None))
@@ -401,7 +392,6 @@ def test_read_hdf_iterator(tmp_path: Path) -> None:
     ti.close()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason=MESSAGE_PYTABLE_314)
 def test_hdf_context_manager(tmp_path: Path) -> None:
     path_str = str(tmp_path / str(uuid.uuid4()))
     check(assert_type(DF.to_hdf(path_str, key="df", format="table"), None), type(None))
@@ -410,7 +400,6 @@ def test_hdf_context_manager(tmp_path: Path) -> None:
         check(assert_type(store.get("df"), DataFrame | Series), DataFrame)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason=MESSAGE_PYTABLE_314)
 def test_hdf_series(tmp_path: Path) -> None:
     s = DF["a"]
     path_str = str(tmp_path / str(uuid.uuid4()))


### PR DESCRIPTION
PyTables now builds wheels for py314 after PyTables/PyTables#1286. We can enable the corresponding tests.