### PR TITLE
MNT: regression on #1620 regarding `PyArrow`

### DIFF
--- a/pandas-stubs/core/construction.pyi
+++ b/pandas-stubs/core/construction.pyi
@@ -164,9 +164,6 @@ def array(
 ) -> StringArray: ...
 
 # TODO: pandas-dev/pandas#54466 add BuiltinStrDtypeArg after Pandas 3.0
-# Also PyArrow will become required in Pandas 3.0, so "string" will give
-# ArrowStringArray.
-# StringDtype[None] means unknown, so it will still give BaseStringArray
 @overload
 def array(
     data: _NaNStrData, dtype: PandasBaseStrDtypeArg, copy: bool = True
@@ -181,9 +178,6 @@ def array(  # pyright: ignore[reportOverlappingOverload]
     ),
     dtype: None = None,
     copy: bool = True,
-    # TODO: pandas-dev/pandas#54466
-    # PyArrow will become required in Pandas 3.0, so no dtype will give
-    # ArrowStringArray.
 ) -> BaseStringArray: ...
 @overload
 def array(

--- a/tests/arrays/test_base_string_array.py
+++ b/tests/arrays/test_base_string_array.py
@@ -81,7 +81,7 @@ def test_construction_dtype(
 ) -> None:
     is_builtin_str = dtype in PYTHON_STRING_ARGS
     is_numpy_extension_array = PD_LTE_23 and is_builtin_str
-    # TODO: pandas-dev/pandas#54466 should give BaseStringArray or even ArrowStringAray after Pandas 3.0
+    # TODO: pandas-dev/pandas#54466 should give BaseStringArray after Pandas 3.0
     target_type = NumpyExtensionArray if is_numpy_extension_array else BaseStringArray
 
     dtype_notna = target_dtype if data else None
@@ -99,7 +99,7 @@ def test_construction_dtype(
     check(pd.array([*data, *data, np.nan], dtype), target_type, dtype_na)
 
     if TYPE_CHECKING:
-        # TODO: pandas-dev/pandas#54466 should give BaseStringArray or even ArrowStringAray after 3.0
+        # TODO: pandas-dev/pandas#54466 should give BaseStringArray after 3.0
         # The following one still gives NumpyExtensionArray because issubclass(str, object),
         # and pd.array([], object) gives NumpyExtensionArray
         assert_type(pd.array([], str), NumpyExtensionArray)


### PR DESCRIPTION
`PyArrow` will not become a mandatory depdendency in 3.0. Several comments are to be removed.