### PR TITLE
TYP: Accept broader iterables in MultiIndex.from_product

### DIFF
--- a/pandas-stubs/core/indexes/multi.pyi
+++ b/pandas-stubs/core/indexes/multi.pyi
@@ -14,7 +14,10 @@ from typing import (
 import numpy as np
 import pandas as pd
 from pandas.core.indexes.base import Index
-from typing_extensions import Self
+from typing_extensions import (
+    Never,
+    Self,
+)
 
 from pandas._typing import (
     AnyAll,
@@ -63,6 +66,15 @@ class MultiIndex(Index):
         sortorder: int | None = None,
         names: SequenceNotStr[Hashable] | None = None,
     ) -> Self: ...
+    @overload
+    @classmethod
+    def from_product(
+        cls,
+        iterables: Sequence[str],
+        sortorder: int | None = None,
+        names: SequenceNotStr[Hashable] | None = None,
+    ) -> Never: ...
+    @overload
     @classmethod
     def from_product(
         cls,

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -1417,6 +1417,25 @@ def test_multiindex_from_product_with_sets() -> None:
     check(assert_type(midx, pd.MultiIndex), pd.MultiIndex)
 
 
+def test_multiindex_from_product_with_iterables() -> None:
+    """Test using genuinely iterable inputs in `MultiIndex.from_product` GH1637."""
+    # Test with generator expressions
+    midx = pd.MultiIndex.from_product([iter([1, 2, 3]), iter(["a", "b", "c"])])
+    check(assert_type(midx, pd.MultiIndex), pd.MultiIndex)
+
+    # Test with map object (iterator)
+    midx2 = pd.MultiIndex.from_product([map(str, [1, 2, 3]), iter(["x", "y"])])
+    check(assert_type(midx2, pd.MultiIndex), pd.MultiIndex)
+
+
+def test_multiindex_from_product_forbid_strings() -> None:
+    """Test that passing strings directly to `MultiIndex.from_product` is forbidden."""
+    if TYPE_CHECKING_INVALID_USAGE:
+
+        def _0() -> None:  # pyright: ignore[reportUnusedFunction]
+            assert_type(pd.MultiIndex.from_product(["12", "34"]), Never)
+
+
 def test_index_naming() -> None:
     """
     Test index names type both for the getter and the setter.


### PR DESCRIPTION
Change iterables parameter from Sequence[SequenceNotStr[Hashable] | pd.Series | pd.Index | range] to Sequence[Iterable[Hashable]] to accept sets and other iterables, matching pandas implementation.

- [x] Closes #1637 (Replace xxxx with the Github issue number)
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`
