### PR TITLE
TYP: Update Timedelta __init__ type hints to document it takes Tick objects

### DIFF
--- a/pandas-stubs/_libs/tslibs/timedeltas.pyi
+++ b/pandas-stubs/_libs/tslibs/timedeltas.pyi
@@ -22,7 +22,6 @@ from typing_extensions import Self
 
 from pandas._libs.tslibs import (
     NaTType,
-    Tick,
 )
 from pandas._libs.tslibs.period import Period
 from pandas._libs.tslibs.timestamps import Timestamp
@@ -38,6 +37,8 @@ from pandas._typing import (
     np_ndarray_float,
     np_ndarray_td,
 )
+
+from pandas.tseries.offsets import Tick
 
 class Components(NamedTuple):
     days: int

--- a/tests/arrays/test_timedeltas.py
+++ b/tests/arrays/test_timedeltas.py
@@ -10,7 +10,6 @@ from pandas.core.arrays.timedeltas import TimedeltaArray
 from typing_extensions import assert_type
 
 from pandas._libs import NaTType
-from pandas._libs.tslibs.offsets import Minute
 from pandas._libs.tslibs.timedeltas import Timedelta
 from pandas._typing import TimeUnit
 
@@ -23,6 +22,8 @@ from tests._typing import (
     np_1darray_object,
     np_1darray_td,
 )
+
+from pandas.tseries.offsets import Minute
 
 
 def test_construction() -> None:
@@ -110,9 +111,8 @@ def test_timedelta_array_mod() -> None:
 
 def test_timedelta_takes_tick_object() -> None:
     """Test that Timedelta objects can be built using tick objects such as Minute."""
-    tick = Minute(15)
-    seconds = pd.Timedelta(tick).total_seconds()
-    assert seconds == 900.0
+    td = pd.Timedelta(Minute(15))
+    check(assert_type(td, pd.Timedelta), pd.Timedelta)
 
 
 def test_timedelta_array_divmod() -> None:


### PR DESCRIPTION
When trying to follow https://github.com/pandas-dev/pandas/issues/55498, mypy complaines
> error: Argument 1 to "Timedelta" has incompatible type "Minute | Hour | Day"; expected "str | float | Timedelta | timedelta | timedelta64[timedelta | int | None]"  [arg-type]

The [pandas source code](https://github.com/pandas-dev/pandas/blob/fee634a677c8fa51526ced66a630fa14cba3cd86/pandas/_libs/tslibs/timedeltas.pyx#L2259) checks if the `value` parameter is a Tick object (`is_tick_object`)

This is my first PR to this project. Question to reviewers: Shall I also open a PR to the pandas main repo to update the [docstring](https://github.com/pandas-dev/pandas/blob/fee634a677c8fa51526ced66a630fa14cba3cd86/pandas/_libs/tslibs/timedeltas.pyx#L2039) to improve the [documentation](https://pandas.pydata.org/docs/reference/api/pandas.Timedelta.html)?

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
