### PR TITLE
MAINT: remove `tomli` as addition pre-commit dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     rev: v2.4.1
     hooks:
     - id: codespell
-      additional_dependencies: [ tomli ]
       args: [-L, "THIRDPARTY"]
 -   repo: https://github.com/PyCQA/isort
     rev: 7.0.0


### PR DESCRIPTION
Because [`tomllib`](https://docs.python.org/3/library/tomllib.html) is available on `python>=3.11`, and pandas-stubs no longer supports `python<3.11`.