### PR TITLE
BLD: remove invalid `pyproject.toml` property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Stubs Only",
 ]
-packages = [{ include = "pandas-stubs" }]
 exclude = ["pandas-stubs/__init__.py"]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Only properties specified in https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-toml-spec are allowed in `pyproject.toml`, and `packages`  isn't one of those.