### PR TITLE
TYP: accept `integer` and `floating` ndarrays in `to_datetime`

### DIFF
--- a/pandas-stubs/core/tools/datetimes.pyi
+++ b/pandas-stubs/core/tools/datetimes.pyi
@@ -26,8 +26,9 @@ from pandas._typing import (
     DictConvertible,
     RaiseCoerce,
     TimestampConvertibleTypes,
+    np_ndarray_anyint,
     np_ndarray_dt,
-    np_ndarray_int64,
+    np_ndarray_float,
     np_ndarray_str,
 )
 
@@ -104,7 +105,8 @@ def to_datetime(
         | tuple[float | str | date, ...]
         | np_ndarray_dt
         | np_ndarray_str
-        | np_ndarray_int64
+        | np_ndarray_anyint
+        | np_ndarray_float
         | Index
         | ExtensionArray
     ),

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -1499,6 +1499,22 @@ def test_to_datetime_array() -> None:
         assert_type(pd.to_datetime(np.array([1, 2, 3])), pd.DatetimeIndex),
         pd.DatetimeIndex,
     )
+    check(
+        assert_type(pd.to_datetime(np.array([1.0, 2.0, 3.0])), pd.DatetimeIndex),
+        pd.DatetimeIndex,
+    )
+    check(
+        assert_type(pd.to_datetime(np.array([1, 2, 3], np.uint8)), pd.DatetimeIndex),
+        pd.DatetimeIndex,
+    )
+    check(
+        assert_type(pd.to_datetime(np.array([1, 2, 3], np.int16)), pd.DatetimeIndex),
+        pd.DatetimeIndex,
+    )
+    check(
+        assert_type(pd.to_datetime(np.array([1, 2, 3], np.float32)), pd.DatetimeIndex),
+        pd.DatetimeIndex,
+    )
     pd.to_datetime(
         pd.Index([2451544.5, 2451545.5, 2451546.5]), unit="D", origin="julian"
     )


### PR DESCRIPTION
- [x] Closes #1645
- [x] Tests added 
