### PR TITLE
TYP: fix variance issue with `NDFrame.to_latex(formatters=)`

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -701,7 +701,8 @@ CompressionOptions: TypeAlias = (
 FormattersType: TypeAlias = (
     list[Callable[..., Any]]
     | tuple[Callable[..., Any], ...]
-    | Mapping[str | int, Callable[..., Any]]
+    | Mapping[str, Callable[..., Any]]
+    | Mapping[int, Callable[..., Any]]
 )
 # ColspaceType = Mapping[Hashable, Union[str, int]] not used in stubs
 FloatFormatType: TypeAlias = str | Callable[[float], str] | EngFormatter

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -2801,6 +2801,10 @@ def test_types_to_latex() -> None:
     check(assert_type(df.to_latex(position="some"), str), str)
     check(assert_type(df.to_latex(caption=("cap1", "cap2")), str), str)
 
+    # https://github.com/pandas-dev/pandas-stubs/issues/1647
+    formatters: dict[str, Callable[[float], str]] = {"A": lambda x: f"{x:.2f}"}
+    check(assert_type(df.to_latex(formatters=formatters), str), str)
+
 
 def test_types_explode() -> None:
     df = pd.DataFrame([[1, 2], [8, 9]], columns=["A", "B"])


### PR DESCRIPTION
`NDFrame.to_latex(formatters=)` uses `Callable[[str | int], Any]` as key type, which caused it to reject valid `formatter` arguments of types like `dict[float, Callable[[float], str]]` and `dict[str, Callable[[str], str]]`. That's because the argument types of a `Callable` type are contravariant. So `Callable[[A], _]` will accept `Callable[[A | B], _]`, but not the other way around.

- [x] Closes #1647
- [x] Tests added

