### PR TITLE
fix IndexSlice where columns are multiindex

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -265,7 +265,9 @@ class _LocIndexerFrame(_LocIndexer, Generic[_T]):
     @overload
     def __getitem__(self, idx: Scalar) -> Series | _T: ...
     @overload
-    def __getitem__(self, idx: tuple[Scalar, slice]) -> Series | _T: ...
+    def __getitem__(
+        self, idx: tuple[Scalar, slice] | tuple[slice, tuple[Scalar, ...]]
+    ) -> Series | _T: ...
     @overload
     def __getitem__(
         self,
@@ -281,7 +283,11 @@ class _LocIndexerFrame(_LocIndexer, Generic[_T]):
                 | slice
                 | _IndexSliceTuple
                 | Callable[..., Any],
-                MaskType | Iterable[HashableT] | IndexType | Callable[..., Any],
+                MaskType
+                | Iterable[HashableT]
+                | IndexType
+                | Callable[..., Any]
+                | _IndexSliceTuple,
             ]
         ),
     ) -> _T: ...

--- a/tests/frame/test_indexing.py
+++ b/tests/frame/test_indexing.py
@@ -183,6 +183,20 @@ def test_indexslice_getitem() -> None:
     )
 
 
+def test_indexslice_getitem_multiindex_columns() -> None:
+    mic = pd.MultiIndex.from_product([["a", "b"], [1, 2, 3]], names=["let", "num"])
+    df = pd.DataFrame.from_records(
+        [list(range(6)), [k * 10 + 1 for k in range(6)]], columns=mic
+    )
+
+    check(assert_type(df.loc[:, pd.IndexSlice["a", :]], pd.DataFrame), pd.DataFrame)
+    check(assert_type(df.loc[:, pd.IndexSlice[:, 1]], pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.loc[:, pd.IndexSlice["a", 3]], pd.DataFrame | pd.Series),
+        pd.Series,
+    )
+
+
 def test_getset_untyped() -> None:
     """Test that Dataframe.__getitem__ needs to return untyped series."""
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [10, 20, 30, 40, 50]})
@@ -467,7 +481,7 @@ def test_loc_iterable(col: Hashable, typ: type) -> None:
         assert_type(df.loc[:, [1]], pd.DataFrame)
 
         assert_type(df.loc[:, (None,)], pd.DataFrame)
-        assert_type(df.loc[:, (1,)], pd.DataFrame)
+        assert_type(df.loc[:, (1,)], pd.DataFrame | pd.Series)
 
         assert_type(df.loc[:, deque([None])], pd.DataFrame)
         assert_type(df.loc[:, deque([1])], pd.DataFrame)


### PR DESCRIPTION
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
  - `test_indexing.py:test_indexslice_getitem_multiindex_columns()`

Discovered in some application code that had a `MultiIndex` for the columns that the types weren't inferred correctly.
