### PR TITLE
GH1654 strings

### DIFF
--- a/pandas-stubs/core/strings/accessor.pyi
+++ b/pandas-stubs/core/strings/accessor.pyi
@@ -7,7 +7,6 @@ from collections.abc import (
 )
 import re
 from typing import (
-    Any,
     Generic,
     Literal,
     TypeVar,
@@ -141,7 +140,7 @@ class StringMethods(
     @overload
     def replace(
         self,
-        pat: dict[Any, Any],
+        pat: dict[str, str],
         repl: None = None,
         n: int = -1,
         case: bool | None = None,

--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -503,6 +503,7 @@ def test_series_str_replace() -> None:
     check(
         assert_type(sr.str.replace(pat={"A": "a", "B": "b"}), "pd.Series[str]"),
         pd.Series,
+        str,
     )
 
     if TYPE_CHECKING_INVALID_USAGE:


### PR DESCRIPTION
- [x] [Series.str.get_dummies()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.str.get_dummies.html#pandas.Series.str.get_dummies) now accepts a dtype parameter to specify the dtype of the resulting DataFrame (https://github.com/pandas-dev/pandas/issues/47872)
- [x] Added [Series.str.isascii()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.str.isascii.html#pandas.Series.str.isascii) (https://github.com/pandas-dev/pandas/issues/59091)
- [x] Allow dictionaries to be passed to [Series.str.replace()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.str.replace.html#pandas.Series.str.replace) via pat parameter (https://github.com/pandas-dev/pandas/issues/51748)