### PR TITLE
TYP: GH1474 Remove deprecated NumListLike and collapse arithmetic Sequence overloads

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -1025,9 +1025,6 @@ S1 = TypeVar("S1", bound=SeriesDType, default=Any)
 # Like S0 and S1, but without `default=Any`.
 S2 = TypeVar("S2", bound=SeriesDType)
 S2_contra = TypeVar("S2_contra", bound=SeriesDType, contravariant=True)
-S2_NDT_contra = TypeVar(
-    "S2_NDT_contra", bound=SeriesDTypeNoDateTime, contravariant=True
-)
 S2_NSDT = TypeVar("S2_NSDT", bound=SeriesDTypeNoStrDateTime)
 S3 = TypeVar("S3", bound=SeriesDType)
 

--- a/pandas-stubs/core/base.pyi
+++ b/pandas-stubs/core/base.pyi
@@ -45,9 +45,7 @@ from pandas._typing import (
     SupportsDType,
     np_1darray,
     np_1darray_intp,
-    np_ndarray,
     np_ndarray_anyint,
-    np_ndarray_bool,
     np_ndarray_complex,
     np_ndarray_float,
     np_ndarray_td,
@@ -236,16 +234,6 @@ ScalarArrayIndexSeriesTimedelta: TypeAlias = (
     ScalarArrayIndexTimedelta | Series[Timedelta]
 )
 
-NumListLike: TypeAlias = (  # TODO: pandas-dev/pandas-stubs#1474 deprecated, do not use
-    ExtensionArray
-    | np_ndarray_bool
-    | np_ndarray_anyint
-    | np_ndarray_float
-    | np_ndarray_complex
-    | dict[str, np_ndarray]
-    | Sequence[complex]
-)
-
 @type_check_only
 class ElementOpsMixin(Generic[S2]):
     @overload
@@ -284,6 +272,30 @@ class ElementOpsMixin(Generic[S2]):
     ) -> ElementOpsMixin[complex]: ...
     @overload
     def _proto_radd(self: ElementOpsMixin[str], other: str) -> ElementOpsMixin[str]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[int], other: int | np.integer
+    ) -> ElementOpsMixin[int]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[float], other: float | np.floating
+    ) -> ElementOpsMixin[float]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[complex], other: complex | np.complexfloating
+    ) -> ElementOpsMixin[complex]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[int], other: int | np.integer
+    ) -> ElementOpsMixin[int]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[float], other: float | np.floating
+    ) -> ElementOpsMixin[float]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[complex], other: complex | np.complexfloating
+    ) -> ElementOpsMixin[complex]: ...
     @overload
     def _proto_mul(
         self: ElementOpsMixin[bool], other: bool | np.bool_
@@ -398,6 +410,14 @@ class Supports_ProtoAdd(Protocol[T_contra, S2]):
 @type_check_only
 class Supports_ProtoRAdd(Protocol[T_contra, S2]):
     def _proto_radd(self, other: T_contra, /) -> ElementOpsMixin[S2]: ...
+
+@type_check_only
+class Supports_ProtoSub(Protocol[T_contra, S2]):
+    def _proto_sub(self, other: T_contra, /) -> ElementOpsMixin[S2]: ...
+
+@type_check_only
+class Supports_ProtoRSub(Protocol[T_contra, S2]):
+    def _proto_rsub(self, other: T_contra, /) -> ElementOpsMixin[S2]: ...
 
 @type_check_only
 class Supports_ProtoMul(Protocol[T_contra, S2]):

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -82,7 +82,6 @@ from pandas.core.base import (
     ArrayIndexTimedeltaNoSeq,
     ElementOpsMixin,
     IndexOpsMixin,
-    NumListLike,
     ScalarArrayIndexSeriesComplex,
     ScalarArrayIndexSeriesJustComplex,
     ScalarArrayIndexSeriesJustFloat,
@@ -97,7 +96,9 @@ from pandas.core.base import (
     Supports_ProtoRAdd,
     Supports_ProtoRFloorDiv,
     Supports_ProtoRMul,
+    Supports_ProtoRSub,
     Supports_ProtoRTrueDiv,
+    Supports_ProtoSub,
     Supports_ProtoTrueDiv,
 )
 from pandas.core.frame import DataFrame
@@ -199,7 +200,6 @@ from pandas._typing import (
     Renamer,
     ReplaceValue,
     S2_contra,
-    S2_NDT_contra,
     Scalar,
     ScalarT,
     SequenceNotStr,
@@ -1737,6 +1737,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         other: (
             timedelta
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -1747,7 +1748,12 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     def __add__(
         self: Series[Timedelta],
         other: (
-            datetime | np.datetime64 | np_ndarray_dt | DatetimeIndex | Series[Timestamp]
+            datetime
+            | np.datetime64
+            | Sequence[datetime | np.datetime64]
+            | np_ndarray_dt
+            | DatetimeIndex
+            | Series[Timestamp]
         ),
     ) -> Series[Timestamp]: ...
     @overload
@@ -1756,6 +1762,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         other: (
             timedelta
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -1767,12 +1774,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[S2]: ...
     @overload
     def __add__(
-        self: Series[S2_contra], other: SupportsRAdd[S2_contra, S2]
-    ) -> Series[S2]: ...
-    # pandas-dev/pandas#62353
-    @overload
-    def __add__(
-        self: Series[S2_NDT_contra], other: Sequence[SupportsRAdd[S2_NDT_contra, S2]]
+        self: Series[S2_contra],
+        other: SupportsRAdd[S2_contra, S2] | Sequence[SupportsRAdd[S2_contra, S2]],
     ) -> Series[S2]: ...
     @overload
     def __add__(
@@ -1856,8 +1859,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self: Series[Timedelta],
         other: (
             datetime
-            | Sequence[datetime]
             | np.datetime64
+            | Sequence[datetime | np.datetime64]
             | np_ndarray_dt
             | DatetimeIndex
             | Series[Timestamp]
@@ -1871,8 +1874,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self: Series[Timedelta],
         other: (
             timedelta
-            | Sequence[timedelta]
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -1966,6 +1969,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         other: (
             timedelta
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -1976,7 +1980,12 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     def __radd__(
         self: Series[Timedelta],
         other: (
-            datetime | np.datetime64 | np_ndarray_dt | DatetimeIndex | Series[Timestamp]
+            datetime
+            | np.datetime64
+            | Sequence[datetime | np.datetime64]
+            | np_ndarray_dt
+            | DatetimeIndex
+            | Series[Timestamp]
         ),
     ) -> Series[Timestamp]: ...
     @overload
@@ -1985,6 +1994,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         other: (
             timedelta
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -2006,12 +2016,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[S2]: ...
     @overload
     def __radd__(
-        self: Series[S2_contra], other: SupportsAdd[S2_contra, S2]
-    ) -> Series[S2]: ...
-    # pandas-dev/pandas#62353
-    @overload
-    def __radd__(
-        self: Series[S2_NDT_contra], other: Sequence[SupportsAdd[S2_NDT_contra, S2]]
+        self: Series[S2_contra],
+        other: SupportsAdd[S2_contra, S2] | Sequence[SupportsAdd[S2_contra, S2]],
     ) -> Series[S2]: ...
     @overload
     def __radd__(
@@ -2083,8 +2089,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self: Series[Timestamp],
         other: (
             timedelta
-            | Sequence[timedelta]
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -2099,8 +2105,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self: Series[Timedelta],
         other: (
             datetime
-            | Sequence[datetime]
             | np.datetime64
+            | Sequence[datetime | np.datetime64]
             | np_ndarray_dt
             | DatetimeIndex
             | Series[Timestamp]
@@ -2114,8 +2120,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self: Series[Timedelta],
         other: (
             timedelta
-            | Sequence[timedelta]
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -2515,7 +2521,17 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[_bool]: ...
     @overload
     def __mul__(  # type: ignore[overload-overlap]
-        self: Series[Never], other: complex | NumListLike | Index | Series
+        self: Series[Never],
+        other: (
+            complex
+            | Sequence[complex]
+            | np_ndarray_bool
+            | np_ndarray_anyint
+            | np_ndarray_float
+            | np_ndarray_complex
+            | Index
+            | Series
+        ),
     ) -> Series: ...
     @overload
     def __mul__(self, other: Index[Never] | Series[Never]) -> Series: ...
@@ -2731,7 +2747,17 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[complex]: ...
     @overload
     def __rmul__(  # type: ignore[overload-overlap]
-        self: Series[Never], other: complex | NumListLike | Index | Series
+        self: Series[Never],
+        other: (
+            complex
+            | Sequence[complex]
+            | np_ndarray_bool
+            | np_ndarray_anyint
+            | np_ndarray_float
+            | np_ndarray_complex
+            | Index
+            | Series
+        ),
     ) -> Series: ...
     @overload
     def __rmul__(self, other: Index[Never] | Series[Never]) -> Series: ...  # type: ignore[misc]
@@ -2979,94 +3005,81 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     def __rxor__(self, other: int | np_ndarray_anyint | Series[int]) -> Series[int]: ...
     @overload
     def __sub__(
-        self: Series[Never],
-        other: complex | NumListLike | Index[T_COMPLEX] | Series[T_COMPLEX],
+        self: Series[Never], other: ScalarArrayIndexSeriesComplex
     ) -> Series: ...
     @overload
     def __sub__(self, other: Index[Never] | Series[Never]) -> Series: ...
     @overload
     def __sub__(
-        self: Series[bool],
-        other: (
-            Just[int]
-            | Sequence[Just[int]]
-            | np_ndarray_anyint
-            | Index[int]
-            | Series[int]
-        ),
-    ) -> Series[int]: ...
-    @overload
-    def __sub__(
-        self: Series[bool],
-        other: (
-            Just[float]
-            | Sequence[Just[float]]
-            | np_ndarray_float
-            | Index[float]
-            | Series[float]
-        ),
-    ) -> Series[float]: ...
+        self: Supports_ProtoSub[T_contra, S2], other: T_contra | Sequence[T_contra]
+    ) -> Series[S2]: ...
     @overload
     def __sub__(
         self: Series[int],
         other: (
-            int
-            | Sequence[int]
+            bool
+            | np.bool
+            | Sequence[bool | np.bool]
             | np_ndarray_bool
-            | np_ndarray_anyint
             | Index[bool]
             | Series[bool]
-            | Index[int]
-            | Series[int]
         ),
     ) -> Series[int]: ...
-    @overload
-    def __sub__(
-        self: Series[int],
-        other: (
-            Just[float]
-            | Sequence[Just[float]]
-            | np_ndarray_float
-            | Index[float]
-            | Series[float]
-        ),
-    ) -> Series[float]: ...
     @overload
     def __sub__(
         self: Series[float],
         other: (
-            float
-            | Sequence[float]
+            bool
+            | np.bool
+            | Sequence[bool | np.bool]
             | np_ndarray_bool
-            | np_ndarray_anyint
-            | np_ndarray_float
             | Index[bool]
             | Series[bool]
-            | Index[int]
-            | Series[int]
-            | Index[float]
-            | Series[float]
         ),
     ) -> Series[float]: ...
     @overload
     def __sub__(
         self: Series[complex],
         other: (
-            T_COMPLEX
-            | Sequence[T_COMPLEX]
+            bool
+            | np.bool
+            | Sequence[bool | np.bool]
             | np_ndarray_bool
-            | np_ndarray_anyint
-            | np_ndarray_float
-            | Index[T_COMPLEX]
-            | Series[T_COMPLEX]
+            | Index[bool]
+            | Series[bool]
         ),
     ) -> Series[complex]: ...
     @overload
     def __sub__(
-        self: Series[T_COMPLEX],
+        self: Series[bool] | Series[int],
+        other: (
+            Just[int]
+            | np.integer
+            | Sequence[Just[int] | np.integer]
+            | np_ndarray_anyint
+            | Index[int]
+            | Series[int]
+        ),
+    ) -> Series[int]: ...
+    @overload
+    def __sub__(
+        self: Series[bool] | Series[int] | Series[float],
+        other: (
+            Just[float]
+            | np.floating
+            | Sequence[Just[float] | np.floating]
+            | np_ndarray_float
+            | Index[float]
+            | Series[float]
+        ),
+    ) -> Series[float]: ...
+    @overload
+    def __sub__(
+        self: Series[bool] | Series[int] | Series[float] | Series[complex],
         other: (
             Just[complex]
-            | Sequence[Just[complex]]
+            | np.complexfloating
+            | Sequence[Just[complex] | np.complexfloating]
             | np_ndarray_complex
             | Index[complex]
             | Series[complex]
@@ -3076,7 +3089,12 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     def __sub__(
         self: Series[Timestamp],
         other: (
-            datetime | np.datetime64 | np_ndarray_dt | DatetimeIndex | Series[Timestamp]
+            datetime
+            | np.datetime64
+            | Sequence[datetime | np.datetime64]
+            | np_ndarray_dt
+            | DatetimeIndex
+            | Series[Timestamp]
         ),
     ) -> Series[Timedelta]: ...
     @overload
@@ -3085,6 +3103,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         other: (
             timedelta
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -3099,6 +3118,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         other: (
             timedelta
             | np.timedelta64
+            | Sequence[timedelta | np.timedelta64]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -3111,7 +3131,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def sub(
         self: Series[Never],
-        other: complex | NumListLike | Index[T_COMPLEX] | Series[T_COMPLEX],
+        other: ScalarArrayIndexSeriesComplex,
         level: Level | None = None,
         fill_value: float | None = None,
         axis: int = 0,
@@ -3253,8 +3273,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self: Series[Timestamp],
         other: (
             timedelta
-            | Sequence[timedelta]
             | np.timedelta64
+            | Sequence[timedelta]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -3290,21 +3310,29 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def __rsub__(
         self: Series[Never],
-        other: (
-            complex
-            | datetime
-            | np.datetime64
-            | np_ndarray_dt
-            | NumListLike
-            | Index[T_COMPLEX]
-            | Series[T_COMPLEX]
-        ),
+        other: ScalarArrayIndexSeriesComplex | Sequence[datetime] | np_ndarray_dt,
     ) -> Series: ...
     @overload
     def __rsub__(self, other: Index[Never] | Series[Never]) -> Series: ...
     @overload
     def __rsub__(
-        self: Series[bool],
+        self: Supports_ProtoRSub[T_contra, S2], other: T_contra | Sequence[T_contra]
+    ) -> Series[S2]: ...
+    @overload
+    def __rsub__(
+        self: Series[int], other: np_ndarray_bool | Index[bool] | Series[bool]
+    ) -> Series[int]: ...
+    @overload
+    def __rsub__(
+        self: Series[float], other: np_ndarray_bool | Index[bool] | Series[bool]
+    ) -> Series[float]: ...
+    @overload
+    def __rsub__(
+        self: Series[complex], other: np_ndarray_bool | Index[bool] | Series[bool]
+    ) -> Series[complex]: ...
+    @overload
+    def __rsub__(
+        self: Series[bool] | Series[int],
         other: (
             Just[int]
             | Sequence[Just[int]]
@@ -3315,7 +3343,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[int]: ...
     @overload
     def __rsub__(
-        self: Series[bool],
+        self: Series[bool] | Series[int] | Series[float],
         other: (
             Just[float]
             | Sequence[Just[float]]
@@ -3326,62 +3354,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[float]: ...
     @overload
     def __rsub__(
-        self: Series[int],
-        other: (
-            int
-            | Sequence[int]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | Index[bool]
-            | Series[bool]
-            | Index[int]
-            | Series[int]
-        ),
-    ) -> Series[int]: ...
-    @overload
-    def __rsub__(
-        self: Series[int],
-        other: (
-            Just[float]
-            | Sequence[Just[float]]
-            | np_ndarray_float
-            | Index[float]
-            | Series[float]
-        ),
-    ) -> Series[float]: ...
-    @overload
-    def __rsub__(
-        self: Series[float],
-        other: (
-            float
-            | Sequence[float]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | np_ndarray_float
-            | Index[bool]
-            | Series[bool]
-            | Index[int]
-            | Series[int]
-            | Index[float]
-            | Series[float]
-        ),
-    ) -> Series[float]: ...
-    @overload
-    def __rsub__(
-        self: Series[complex],
-        other: (
-            T_COMPLEX
-            | Sequence[T_COMPLEX]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | np_ndarray_float
-            | Index[T_COMPLEX]
-            | Series[T_COMPLEX]
-        ),
-    ) -> Series[complex]: ...
-    @overload
-    def __rsub__(
-        self: Series[T_COMPLEX],
+        self: Series[bool] | Series[int] | Series[float] | Series[complex],
         other: (
             Just[complex]
             | Sequence[Just[complex]]
@@ -3396,14 +3369,24 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     def __rsub__(
         self: Series[Timestamp],
         other: (
-            datetime | np.datetime64 | np_ndarray_dt | DatetimeIndex | Series[Timestamp]
+            datetime
+            | np.datetime64
+            | Sequence[datetime]
+            | np_ndarray_dt
+            | DatetimeIndex
+            | Series[Timestamp]
         ),
     ) -> Series[Timedelta]: ...
     @overload
     def __rsub__(
         self: Series[Timedelta],
         other: (
-            datetime | np.datetime64 | np_ndarray_dt | DatetimeIndex | Series[Timestamp]
+            datetime
+            | np.datetime64
+            | Sequence[datetime]
+            | np_ndarray_dt
+            | DatetimeIndex
+            | Series[Timestamp]
         ),
     ) -> Series[Timestamp]: ...
     @overload
@@ -3412,6 +3395,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         other: (
             timedelta
             | np.timedelta64
+            | Sequence[timedelta]
             | np_ndarray_td
             | TimedeltaIndex
             | Series[Timedelta]
@@ -3427,10 +3411,13 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         other: (
             complex
             | datetime
-            | Sequence[datetime]
             | np.datetime64
+            | Sequence[complex | datetime]
             | np_ndarray_dt
-            | NumListLike
+            | np_ndarray_bool
+            | np_ndarray_anyint
+            | np_ndarray_float
+            | np_ndarray_complex
             | Index[T_COMPLEX]
             | Series[T_COMPLEX]
             | Series[Timestamp]
@@ -3632,8 +3619,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Never: ...
     @overload
     def __truediv__(
-        self: Supports_ProtoTrueDiv[T_contra, S2],
-        other: T_contra | Sequence[T_contra],
+        self: Supports_ProtoTrueDiv[T_contra, S2], other: T_contra | Sequence[T_contra]
     ) -> Series[S2]: ...
     @overload
     def __truediv__(

--- a/tests/series/test_sub.py
+++ b/tests/series/test_sub.py
@@ -190,27 +190,18 @@ def test_sub_ts_py_datetime() -> None:
     a = [s + timedelta(minutes=m) for m in range(3)]
 
     check(assert_type(left_ts - s, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
-    if TYPE_CHECKING_INVALID_USAGE:
-        # Series[Any] (Timestamp) - Sequence[datetime] should work, see pandas-dev/pandas#62353
-        _1 = left_ts - a  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
+    check(assert_type(left_ts - a, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     # Series[Any] (Timedelta) - datetime fails at runtime,
     # which cannot be revealed by our static type checking
     # _2 = left_td - s
-    if TYPE_CHECKING_INVALID_USAGE:
-        # Series[Any] (Timedelta) - Sequence[datetime] is not supported by Pandas,
-        # see pandas-dev/pandas#62353. Even if such __sub__ is supported
-        # it will fail at runtime here,
-        # which cannot be revealed by our static type checking
-        _3 = left_td - a  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
+    # Series[Any] (Timedelta) - Sequence[datetime] fails at runtime,
+    # which cannot be revealed by our static type checking
+    # _3 = left_td - a
 
-    check(assert_type(s - left_ts, pd.Series), pd.Series, pd.Timedelta)
-    if TYPE_CHECKING_INVALID_USAGE:
-        # Sequence[datetime] - Series[Any] (Timestamp) should work, see pandas-dev/pandas#62353
-        _5 = a - left_ts  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
-    check(assert_type(s - left_td, pd.Series), pd.Series, pd.Timestamp)
-    if TYPE_CHECKING_INVALID_USAGE:
-        # Sequence[datetime] - Series[Any] (Timedelta) should work, see pandas-dev/pandas#62353
-        _7 = a - left_td  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
+    check(assert_type(s - left_ts, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
+    check(assert_type(a - left_ts, pd.Series), pd.Series, pd.Timedelta)
+    check(assert_type(s - left_td, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timestamp)
+    check(assert_type(a - left_td, pd.Series), pd.Series, pd.Timestamp)
 
     check(
         assert_type(left_ts.sub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta
@@ -246,13 +237,13 @@ def test_sub_ts_numpy_datetime() -> None:
     # checking, where our `__rsub__` cannot override. At runtime, they return
     # `Series`.
     # microsoft/pyright#10924
-    check(assert_type(s - left_ts, pd.Series), pd.Series, pd.Timedelta)
+    check(assert_type(s - left_ts, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     check(
         assert_type(a - left_ts, Any),  # pyright: ignore[reportAssertTypeFailure]
         pd.Series,
         pd.Timedelta,
     )
-    check(assert_type(s - left_td, pd.Series), pd.Series, pd.Timestamp)
+    check(assert_type(s - left_td, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timestamp)
     check(
         assert_type(a - left_td, Any),  # pyright: ignore[reportAssertTypeFailure]
         pd.Series,
@@ -290,9 +281,9 @@ def test_sub_ts_pd_datetime() -> None:
     # left_td - s
     # left_td - a
 
-    check(assert_type(s - left_ts, pd.Series), pd.Series, pd.Timedelta)
+    check(assert_type(s - left_ts, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     check(assert_type(a - left_ts, pd.Series), pd.Series, pd.Timedelta)
-    check(assert_type(s - left_td, pd.Series), pd.Series, pd.Timestamp)
+    check(assert_type(s - left_td, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timestamp)
     check(assert_type(a - left_td, pd.Series), pd.Series, pd.Timestamp)
 
     check(

--- a/tests/series/timedelta/test_add.py
+++ b/tests/series/timedelta/test_add.py
@@ -8,10 +8,7 @@ from typing import assert_type
 import numpy as np
 import pandas as pd
 
-from tests import (
-    TYPE_CHECKING_INVALID_USAGE,
-    check,
-)
+from tests import check
 from tests._typing import (
     np_ndarray_dt,
     np_ndarray_td,
@@ -79,14 +76,11 @@ def test_add_py_sequence() -> None:
     s = [datetime(2025, 8, 20)]
     d = [timedelta(seconds=1)]
 
-    if TYPE_CHECKING_INVALID_USAGE:
-        # Series[Timedelta] + Sequence[datetime] should work, see pandas-dev/pandas#62353
-        _0 = left + s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
-        # Series[Timedelta] + Sequence[timedelta] should work, see pandas-dev/pandas#62353
-        _a = left + d  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
+    check(assert_type(left + s, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(left + d, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
-        _1 = s + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
-        _b = d + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
+    check(assert_type(s + left, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(d + left, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
     check(assert_type(left.add(s), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
     check(assert_type(left.add(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)

--- a/tests/series/timedelta/test_sub.py
+++ b/tests/series/timedelta/test_sub.py
@@ -28,7 +28,7 @@ def test_sub_py_scalar() -> None:
     d = timedelta(seconds=1)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _00 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
     check(assert_type(left - d, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
     check(assert_type(s - left, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
@@ -48,7 +48,7 @@ def test_sub_numpy_scalar() -> None:
     d = np.timedelta64(1, "s")
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _00 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
     check(assert_type(left - d, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
     check(assert_type(s - left, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
@@ -68,7 +68,7 @@ def test_sub_pd_scalar() -> None:
     d = pd.Timedelta(seconds=1)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _00 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
     check(assert_type(left - d, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
     check(assert_type(s - left, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
@@ -88,12 +88,11 @@ def test_sub_py_sequence() -> None:
     d = [timedelta(seconds=1)]
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        # Series[Timedelta] - Sequence[timedelta] should work, see pandas-dev/pandas#62353
-        _a = left - d  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _00 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+    check(assert_type(left - d, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
-        _1 = s - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _b = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+    check(assert_type(s - left, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(d - left, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
     if TYPE_CHECKING_INVALID_USAGE:
         left.sub(s)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
@@ -132,7 +131,7 @@ def test_sub_pd_index() -> None:
     d = pd.Index([pd.Timedelta(seconds=1)])
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _00 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
     check(assert_type(left - d, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
     check(assert_type(s - left, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
@@ -152,7 +151,7 @@ def test_sub_pd_series() -> None:
     d = pd.Series([pd.Timedelta(seconds=1)])
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _00 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
     check(assert_type(left - d, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
     check(assert_type(s - left, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)

--- a/tests/series/timestamp/test_add.py
+++ b/tests/series/timestamp/test_add.py
@@ -96,11 +96,11 @@ def test_add_py_sequence() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         _0 = left + s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
-        # Series[Timestamp] + Sequence[timedelta] should work, see pandas-dev/pandas#62353
-        _a = left + d  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
+    check(assert_type(left + d, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
+    if TYPE_CHECKING_INVALID_USAGE:
         _1 = s + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
-        _b = d + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType]
+    check(assert_type(d + left, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
     if TYPE_CHECKING_INVALID_USAGE:
         left.add(s)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue]

--- a/tests/series/timestamp/test_sub.py
+++ b/tests/series/timestamp/test_sub.py
@@ -32,7 +32,7 @@ def test_sub_py_scalar() -> None:
         _ = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
 
     check(assert_type(left.sub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
-    check(assert_type(left - d, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(left.sub(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
     check(assert_type(left.rsub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:
@@ -52,7 +52,7 @@ def test_sub_numpy_scalar() -> None:
         _ = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
 
     check(assert_type(left.sub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
-    check(assert_type(left - d, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(left.sub(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
     check(assert_type(left.rsub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:
@@ -72,7 +72,7 @@ def test_sub_pd_scalar() -> None:
         _ = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
 
     check(assert_type(left.sub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
-    check(assert_type(left - d, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(left.sub(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
     check(assert_type(left.rsub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:
@@ -84,19 +84,17 @@ def test_sub_py_sequence() -> None:
     s = [datetime(2025, 8, 20)]
     d = [timedelta(seconds=1)]
 
+    check(assert_type(left - s, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
+    check(assert_type(left - d, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+
+    check(assert_type(s - left, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:
-        # Series[Timestamp] - Sequence[timestamp] should work, see pandas-dev/pandas#62353
-        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        # Series[Timestamp] - Sequence[timedelta] should work, see pandas-dev/pandas#62353
-        _a = left - d  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _11 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
 
-        _1 = s - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _b = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+    check(assert_type(left.sub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
+    check(assert_type(left.sub(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
-    left.sub(s)
-    left.sub(d)
-
-    left.rsub(s)
+    check(assert_type(left.rsub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:
         left.rsub(d)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
@@ -117,7 +115,7 @@ def test_sub_numpy_array() -> None:
         assert_type(d - left, np_ndarray_td)
 
     check(assert_type(left.sub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
-    check(assert_type(left - d, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(left.sub(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
     check(assert_type(left.rsub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:
@@ -137,7 +135,7 @@ def test_sub_pd_index() -> None:
         _ = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
 
     check(assert_type(left.sub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
-    check(assert_type(left - d, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(left.sub(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
     check(assert_type(left.rsub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:
@@ -157,7 +155,7 @@ def test_sub_pd_series() -> None:
         _ = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
 
     check(assert_type(left.sub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
-    check(assert_type(left - d, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
+    check(assert_type(left.sub(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
     check(assert_type(left.rsub(s), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:


### PR DESCRIPTION
## Summary

Closes #1474. Propagates the fix for [pandas-dev/pandas#62353](https://github.com/pandas-dev/pandas/issues/62353).

### Remove `NumListLike` (resolves #1474)

`NumListLike` was introduced in #1360 and contained a suspicious `dict[str, np.ndarray]` member. It was never correct for arithmetic operations and was marked for deprecation. This PR removes it entirely from `base.pyi` and inlines its components directly into each arithmetic method's `other` parameter:

- `__mul__` / `__rmul__` / `mul` / `rmul` on `Series[Never]`
- `__sub__` / `sub` on `Series[Never]`
- `__sub__` / `sub` on `Series[Timestamp]`

### Collapse `__add__` / `__radd__` Sequence workaround (pandas-dev/pandas#62353)

The old workaround introduced two separate overloads to handle the case where `other` is a sequence — one restricted to non-datetime scalar types via `S2_NDT_contra` — because pandas used to raise a `TypeError` for datetime array arithmetic with lists. Now that the upstream issue is fixed:

- Merge the two overloads into one: `other: SupportsRAdd[S2_contra, S2] | Sequence[SupportsRAdd[S2_contra, S2]]`
- Remove the `S2_NDT_contra` import from `series.pyi`
- Add `Sequence[datetime]` to `Series[Timestamp].__sub__` so list-of-datetime subtraction is covered

🤖 Co-authored by Claude Sonnet 4.6