### PR TITLE
GH1396 Add concat compatibility for subclasses of DataFrame

### DIFF
--- a/pandas-stubs/core/reshape/concat.pyi
+++ b/pandas-stubs/core/reshape/concat.pyi
@@ -6,6 +6,7 @@ from collections.abc import (
 from typing import (
     Literal,
     Never,
+    TypeVar,
     overload,
 )
 
@@ -22,6 +23,8 @@ from pandas._typing import (
     HashableT3,
     HashableT4,
 )
+
+DataFrameCompatType = TypeVar("DataFrameCompatType", bound=DataFrame)
 
 @overload
 def concat(
@@ -62,6 +65,19 @@ def concat(  # type: ignore[overload-overlap]
     verify_integrity: bool = False,
     sort: bool = False,
 ) -> Series: ...
+@overload
+def concat(
+    objs: Iterable[DataFrameCompatType | None],
+    *,
+    axis: Axis = 0,
+    join: Literal["inner", "outer"] = "outer",
+    ignore_index: bool = False,
+    keys: Iterable[HashableT2] | None = None,
+    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = None,
+    names: list[HashableT4] | None = None,
+    verify_integrity: bool = False,
+    sort: bool = False,
+) -> DataFrameCompatType: ...
 @overload
 def concat(
     objs: Iterable[NDFrame | None] | Mapping[HashableT1, NDFrame | None],

--- a/pandas-stubs/core/reshape/concat.pyi
+++ b/pandas-stubs/core/reshape/concat.pyi
@@ -24,7 +24,7 @@ from pandas._typing import (
     HashableT4,
 )
 
-DataFrameCompatType = TypeVar("DataFrameCompatType", bound=DataFrame)
+DataFrameT0 = TypeVar("DataFrameT0", bound=DataFrame)
 
 @overload
 def concat(
@@ -67,7 +67,7 @@ def concat(  # type: ignore[overload-overlap]
 ) -> Series: ...
 @overload
 def concat(
-    objs: Iterable[DataFrameCompatType | None],
+    objs: Iterable[DataFrameT0 | None],
     *,
     axis: Axis = 0,
     join: Literal["inner", "outer"] = "outer",
@@ -77,7 +77,7 @@ def concat(
     names: list[HashableT4] | None = None,
     verify_integrity: bool = False,
     sort: bool = False,
-) -> DataFrameCompatType: ...
+) -> DataFrameT0: ...
 @overload
 def concat(
     objs: Iterable[NDFrame | None] | Mapping[HashableT1, NDFrame | None],

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -404,6 +404,21 @@ def test_concat_args() -> None:
     )
 
 
+def test_frame_subclass_concat() -> None:
+    """Test concatenate subclass of DataFrame GH1396."""
+
+    class ChildDataFrame(pd.DataFrame):
+        @property
+        def _constructor(self) -> type[ChildDataFrame]:
+            return ChildDataFrame
+
+    cdf1 = ChildDataFrame(data={"a": [0]})
+    cdf2 = ChildDataFrame(data={"a": [1]})
+
+    cdf = pd.concat([cdf1, cdf2], ignore_index=True)
+    check(assert_type(cdf, ChildDataFrame), ChildDataFrame)
+
+
 def test_types_json_normalize() -> None:
     data1: list[dict[str, Any]] = [
         {"id": 1, "name": {"first": "Coleen", "last": "Volk"}},
@@ -2544,18 +2559,3 @@ def test_argmin_and_argmax_return() -> None:
     i1 = df.a.abs().argmax()
     check(assert_type(i, np.int64), np.int64)
     check(assert_type(i1, np.int64), np.int64)
-
-
-def test_frame_subclass_concat() -> None:
-    """Test concatenate subclass of DataFrame GH1396."""
-
-    class ChildDataFrame(pd.DataFrame):
-        @property
-        def _constructor(self) -> type[ChildDataFrame]:
-            return ChildDataFrame
-
-    cdf1 = ChildDataFrame(data={"a": [0]})
-    cdf2 = ChildDataFrame(data={"a": [1]})
-
-    cdf = pd.concat([cdf1, cdf2], ignore_index=True)
-    check(assert_type(cdf, ChildDataFrame), ChildDataFrame)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2544,3 +2544,18 @@ def test_argmin_and_argmax_return() -> None:
     i1 = df.a.abs().argmax()
     check(assert_type(i, np.int64), np.int64)
     check(assert_type(i1, np.int64), np.int64)
+
+
+def test_frame_subclass_concat() -> None:
+    """Test concatenate subclass of DataFrame GH1396."""
+
+    class ChildDataFrame(pd.DataFrame):
+        @property
+        def _constructor(self) -> type[ChildDataFrame]:
+            return ChildDataFrame
+
+    cdf1 = ChildDataFrame(data={"a": [0]})
+    cdf2 = ChildDataFrame(data={"a": [1]})
+
+    cdf = pd.concat([cdf1, cdf2], ignore_index=True)
+    check(assert_type(cdf, ChildDataFrame), ChildDataFrame)


### PR DESCRIPTION
- [x] Closes #1396
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
