### PR TITLE
GH1654 Concat/Pivot_table and plotting fix for 3.0

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1566,6 +1566,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         self,
         func: Callable[..., Any],
         na_action: Literal["ignore"] | None = None,
+        engine: Any = None,
         **kwargs: Any,
     ) -> Self: ...
     def join(

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1366,6 +1366,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         margins_name: _str = "All",
         observed: _bool = True,
         sort: _bool = True,
+        **kwargs: Any,
     ) -> Self: ...
     def stack(
         self,

--- a/pandas-stubs/core/reshape/concat.pyi
+++ b/pandas-stubs/core/reshape/concat.pyi
@@ -37,6 +37,19 @@ def concat(
     sort: bool = False,
 ) -> Never: ...
 @overload
+def concat(
+    objs: Iterable[NDFrame | None] | Mapping[HashableT1, NDFrame | None],
+    *,
+    axis: Axis = 0,
+    join: Literal["inner", "outer"] = "outer",
+    ignore_index: Literal[True],
+    keys: Iterable[HashableT2],
+    levels: Sequence[list[HashableT3] | tuple[HashableT3, ...]] | None = None,
+    names: list[HashableT4] | None = None,
+    verify_integrity: bool = False,
+    sort: bool = False,
+) -> Never: ...
+@overload
 def concat(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
     objs: Iterable[Series[S2] | None] | Mapping[HashableT1, Series[S2] | None],
     *,

--- a/pandas-stubs/core/reshape/pivot.pyi
+++ b/pandas-stubs/core/reshape/pivot.pyi
@@ -61,6 +61,7 @@ def pivot_table(
     margins_name: Hashable = "All",
     observed: bool = True,
     sort: bool = True,
+    **kwargs: Any,
 ) -> DataFrame: ...
 
 # Can only use Index or ndarray when index or columns is a Grouper
@@ -78,6 +79,7 @@ def pivot_table(
     margins_name: Hashable = "All",
     observed: bool = True,
     sort: bool = True,
+    **kwargs: Any,
 ) -> DataFrame: ...
 @overload
 def pivot_table(
@@ -93,6 +95,7 @@ def pivot_table(
     margins_name: Hashable = "All",
     observed: bool = True,
     sort: bool = True,
+    **kwargs: Any,
 ) -> DataFrame: ...
 def pivot(
     data: DataFrame,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -1116,6 +1116,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self,
         func: Callable[Concatenate[S1, ...], S2 | NAType],
         na_action: Literal["ignore"],
+        engine: Callable[..., Any] | None = None,
         **kwargs: Any,
     ) -> Series[S2]: ...
     @overload
@@ -1123,12 +1124,14 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self,
         func: Mapping[S1, S2] | Series[S2],
         na_action: Literal["ignore"],
+        engine: None = None,
     ) -> Series[S2]: ...
     @overload
     def map(
         self,
         func: Callable[Concatenate[S1 | NAType, ...], S2 | NAType],
         na_action: None = None,
+        engine: Callable[..., Any] | None = None,
         **kwargs: Any,
     ) -> Series[S2]: ...
     @overload
@@ -1136,12 +1139,14 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self,
         func: Mapping[S1, S2] | Series[S2],
         na_action: None = None,
+        engine: None = None,
     ) -> Series[S2]: ...
     @overload
     def map(
         self,
         func: Callable[..., Any],
         na_action: Literal["ignore"] | None = None,
+        engine: Callable[..., Any] | None = None,
         **kwargs: Any,
     ) -> Series: ...
     @overload
@@ -1149,6 +1154,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         self,
         func: Mapping[Any, Any] | Series,
         na_action: Literal["ignore"] | None = None,
+        engine: None = None,
     ) -> Series: ...
     @overload
     def aggregate(

--- a/pandas-stubs/core/window/ewm.pyi
+++ b/pandas-stubs/core/window/ewm.pyi
@@ -54,13 +54,13 @@ class ExponentialMovingWindow(BaseWindow[NDFrameT]):
         **kwargs: Any,
     ) -> Series: ...
     @overload
-    def aggregate(  # ty: ignore[invalid-method-override]  # pyright: ignore[reportIncompatibleMethodOverride]
+    def aggregate(  # pyright: ignore[reportIncompatibleMethodOverride]
         self: BaseWindow[DataFrame],
         func: str,
         *args: Any,
         **kwargs: Any,
     ) -> DataFrame: ...
-    agg = aggregate  # type: ignore[assignment]  # ty: ignore[invalid-method-override]  # pyrefly: ignore[bad-override]
+    agg = aggregate  # type: ignore[assignment]  # pyrefly: ignore[bad-override]
 
 class ExponentialMovingWindowGroupby(
     BaseWindowGroupby[NDFrameT], ExponentialMovingWindow[NDFrameT]

--- a/pandas-stubs/core/window/ewm.pyi
+++ b/pandas-stubs/core/window/ewm.pyi
@@ -60,7 +60,7 @@ class ExponentialMovingWindow(BaseWindow[NDFrameT]):
         *args: Any,
         **kwargs: Any,
     ) -> DataFrame: ...
-    agg = aggregate  # type: ignore[assignment]  # pyrefly: ignore[bad-override]
+    agg = aggregate  # type: ignore[assignment] # pyrefly: ignore[bad-override]
 
 class ExponentialMovingWindowGroupby(
     BaseWindowGroupby[NDFrameT], ExponentialMovingWindow[NDFrameT]

--- a/pandas-stubs/io/json/_normalize.pyi
+++ b/pandas-stubs/io/json/_normalize.pyi
@@ -1,11 +1,12 @@
 from typing import Any
 
 from pandas import DataFrame
+from pandas.core.series import Series
 
 from pandas._typing import IgnoreRaise
 
 def json_normalize(
-    data: dict[str, Any] | list[dict[str, Any]],
+    data: dict[str, Any] | list[dict[str, Any]] | Series[Any],
     record_path: str | list[str] | None = None,
     meta: str | list[str | list[str]] | None = None,
     meta_prefix: str | None = None,

--- a/pandas-stubs/io/json/_normalize.pyi
+++ b/pandas-stubs/io/json/_normalize.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any
 
 from pandas import DataFrame
@@ -6,7 +7,7 @@ from pandas.core.series import Series
 from pandas._typing import IgnoreRaise
 
 def json_normalize(
-    data: dict[str, Any] | list[dict[str, Any]] | Series[Any],
+    data: dict[str, Any] | Iterable[dict[str, Any]] | Series,
     record_path: str | list[str] | None = None,
     meta: str | list[str | list[str]] | None = None,
     meta_prefix: str | None = None,

--- a/pandas-stubs/plotting/_core.pyi
+++ b/pandas-stubs/plotting/_core.pyi
@@ -468,6 +468,7 @@ class PlotAccessor:
             | Callable[[gaussian_kde], float]
             | None
         ) = ...,
+        weights: np_ndarray_float | Series[float] | None = None,
         ind: np_ndarray_float | int | None = ...,
         *,
         subplots: Literal[False] | None = ...,
@@ -482,6 +483,7 @@ class PlotAccessor:
             | Callable[[gaussian_kde], float]
             | None
         ) = ...,
+        weights: np_ndarray_float | Series[float] | None = None,
         ind: np_ndarray_float | int | None = ...,
         *,
         subplots: Literal[True],

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -1528,6 +1528,27 @@ def test_types_pivot_table() -> None:
     )
 
 
+def test_pivot_table_kwargs() -> None:
+    """Test passing kwargs for the aggfunc to pivot_table."""
+    df = pd.DataFrame(
+        {
+            "A": ["good", "bad", "good", "bad", "good"],
+            "B": ["one", "two", "one", "three", "two"],
+            "X": [2, 5, 4, 20, 10],
+        }
+    )
+
+    check(
+        assert_type(
+            pd.pivot_table(
+                df, index="A", columns="B", values="X", aggfunc="std", ddof=2
+            ),
+            pd.DataFrame,
+        ),
+        pd.DataFrame,
+    )
+
+
 def test_pivot_table_aggfunc_string_reduction(sample_df: pd.DataFrame) -> None:
     """Test string aggfunc with reduction functions from ReductionKernelType."""
     check(

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -1527,9 +1527,7 @@ def test_types_pivot_table() -> None:
         pd.DataFrame,
     )
 
-
-def test_pivot_table_kwargs() -> None:
-    """Test passing kwargs for the aggfunc to pivot_table."""
+    # test passing kwargs for the aggfunc to pivot_table
     df = pd.DataFrame(
         {
             "A": ["good", "bad", "good", "bad", "good"],

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2783,6 +2783,50 @@ def test_map_na() -> None:
     )
 
 
+def test_map_engine() -> None:
+    s: pd.Series[int] = pd.Series([1, 2, 3])
+
+    def to_str(x: int) -> str:
+        return str(x)
+
+    # engine=None with na_action="ignore": func takes S1, returns S2
+    check(
+        assert_type(s.map(to_str, na_action="ignore", engine=None), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
+
+    # engine=None with na_action=None: func must handle NAType
+    def nullable_to_str(x: int | NAType) -> str | NAType:
+        return str(x) if isinstance(x, int) else x
+
+    check(
+        assert_type(
+            s.map(nullable_to_str, na_action=None, engine=None), "pd.Series[str]"
+        ),
+        pd.Series,
+        str,
+    )
+
+    # Mapping/Series: engine must be None (omitted or explicit)
+    mapping = {1: "a", 2: "b", 3: "c"}
+    check(
+        assert_type(s.map(mapping, engine=None), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
+
+    if TYPE_CHECKING:
+        # engine accepts any callable (e.g. a JIT decorator like numba.jit).
+        # Cannot be tested at runtime: pandas validates __pandas_udf__ on the engine.
+        def jit_decorator(f: Callable[..., Any]) -> Callable[..., Any]:
+            return f
+
+        assert_type(
+            s.map(to_str, na_action="ignore", engine=jit_decorator), "pd.Series[str]"
+        )
+
+
 def test_case_when() -> None:
     c = pd.Series([6, 7, 8, 9], name="c")
     a = pd.Series([0, 0, 1, 2])

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -403,6 +403,10 @@ def test_concat_args() -> None:
         pd.DataFrame,
     )
 
+    if TYPE_CHECKING_INVALID_USAGE:
+        # can't pass ignore_index=True and keys
+        assert_type(pd.concat([df, df2], ignore_index=True, keys=["df1", "df2"]), Never)
+
 
 def test_types_json_normalize() -> None:
     data1: list[dict[str, Any]] = [
@@ -2111,6 +2115,27 @@ def test_pivot_table() -> None:
             "dt": pd.date_range("2011-01-01", freq="D", periods=5),
         },
         index=idx,
+    )
+
+
+def test_pivot_table_kwargs() -> None:
+    """Test passing kwargs for the aggfunc to pivot_table."""
+    df = pd.DataFrame(
+        {
+            "A": ["good", "bad", "good", "bad", "good"],
+            "B": ["one", "two", "one", "three", "two"],
+            "X": [2, 5, 4, 20, 10],
+        }
+    )
+
+    check(
+        assert_type(
+            pd.pivot_table(
+                df, index="A", columns="B", values="X", aggfunc="std", ddof=2
+            ),
+            pd.DataFrame,
+        ),
+        pd.DataFrame,
     )
 
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -442,6 +442,25 @@ def test_types_json_normalize() -> None:
     check(assert_type(pd.json_normalize(data=data2), pd.DataFrame), pd.DataFrame)
 
 
+def test_json_normalize_series() -> None:
+    """Test passing a Series as data for json_normalize."""
+    data = [
+        {
+            "id": 1,
+            "name": "Cole Volk",
+            "fitness": {"height": 130, "weight": 60},
+        },
+        {"name": "Mark Reg", "fitness": {"height": 130, "weight": 60}},
+        {
+            "id": 2,
+            "name": "Faye Raker",
+            "fitness": {"height": 130, "weight": 60},
+        },
+    ]
+    series = pd.Series(data, index=pd.Index(["a", "b", "c"]))
+    check(assert_type(pd.json_normalize(series), pd.DataFrame), pd.DataFrame)
+
+
 def test_isna() -> None:
     # https://github.com/pandas-dev/pandas-stubs/issues/264
     s = pd.Series([1, np.nan, 3.2])

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -439,6 +439,13 @@ def test_types_json_normalize() -> None:
         ),
         pd.DataFrame,
     )
+
+    # iterable case
+    check(
+        assert_type(pd.json_normalize(data=(dic for dic in data1)), pd.DataFrame),
+        pd.DataFrame,
+    )
+
     data2: dict[str, Any] = {"name": {"given": "Mose", "family": "Regner"}}
     check(
         assert_type(data2, dict[str, Any]),
@@ -446,6 +453,7 @@ def test_types_json_normalize() -> None:
     )
     check(assert_type(pd.json_normalize(data=data2), pd.DataFrame), pd.DataFrame)
 
+    # series case
     data = [
         {
             "id": 1,

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -404,8 +404,13 @@ def test_concat_args() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        # can't pass ignore_index=True and keys
-        assert_type(pd.concat([df, df2], ignore_index=True, keys=["df1", "df2"]), Never)
+
+        def _cannot_pass_ignore_index_eq_true_and_keys() -> (  # pyright: ignore[reportUnusedFunction]
+            None
+        ):
+            assert_type(
+                pd.concat([df, df2], ignore_index=True, keys=["df1", "df2"]), Never
+            )
 
 
 def test_types_json_normalize() -> None:
@@ -441,9 +446,6 @@ def test_types_json_normalize() -> None:
     )
     check(assert_type(pd.json_normalize(data=data2), pd.DataFrame), pd.DataFrame)
 
-
-def test_json_normalize_series() -> None:
-    """Test passing a Series as data for json_normalize."""
     data = [
         {
             "id": 1,
@@ -2136,9 +2138,6 @@ def test_pivot_table() -> None:
         index=idx,
     )
 
-
-def test_pivot_table_kwargs() -> None:
-    """Test passing kwargs for the aggfunc to pivot_table."""
     df = pd.DataFrame(
         {
             "A": ["good", "bad", "good", "bad", "good"],

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -502,6 +502,17 @@ def test_plot_kde(close_figures: None) -> None:
     s.plot.kde(weights=sr_wgts)
 
 
+def test_kde_kwargs_weights(close_figures: None) -> None:
+    sr = Series(np.random.default_rng(2).uniform(size=50))
+    check(
+        assert_type(
+            sr.plot.kde(bw_method="scott", ind=40, weights=np.linspace(0.0, 2.0, 50)),
+            Axes,
+        ),
+        Axes,
+    )
+
+
 def test_plot_pie(close_figures: None) -> None:
     check(assert_type(IRIS_DF.plot.pie(y="SepalLength"), Axes), Axes)
     check(assert_type(IRIS_DF.plot(kind="pie", y="SepalLength"), Axes), Axes)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -495,18 +495,18 @@ def test_plot_kde(close_figures: None) -> None:
 
     # with numpy array
     np_wgts = np.array([0.1, 0.0, 0.0, 0.2, 0.3, 0.4, 0.9])
-    s.plot.kde(weights=np_wgts)
-
-    # with series
-    sr_wgts = pd.Series([0.1, 0.0, 0.0, 0.2, 0.3, 0.4, 0.9])
-    s.plot.kde(weights=sr_wgts)
-
-
-def test_kde_kwargs_weights(close_figures: None) -> None:
-    sr = Series(np.random.default_rng(2).uniform(size=50))
     check(
         assert_type(
-            sr.plot.kde(bw_method="scott", ind=40, weights=np.linspace(0.0, 2.0, 50)),
+            s.plot.kde(weights=np_wgts),
+            Axes,
+        ),
+        Axes,
+    )
+    # with series
+    sr_wgts = pd.Series([0.1, 0.0, 0.0, 0.2, 0.3, 0.4, 0.9])
+    check(
+        assert_type(
+            s.plot.kde(weights=sr_wgts),
             Axes,
         ),
         Axes,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -495,22 +495,10 @@ def test_plot_kde(close_figures: None) -> None:
 
     # with numpy array
     np_wgts = np.array([0.1, 0.0, 0.0, 0.2, 0.3, 0.4, 0.9])
-    check(
-        assert_type(
-            s.plot.kde(weights=np_wgts),
-            Axes,
-        ),
-        Axes,
-    )
+    check(assert_type(s.plot.kde(weights=np_wgts), Axes), Axes)
     # with series
     sr_wgts = pd.Series([0.1, 0.0, 0.0, 0.2, 0.3, 0.4, 0.9])
-    check(
-        assert_type(
-            s.plot.kde(weights=sr_wgts),
-            Axes,
-        ),
-        Axes,
-    )
+    check(assert_type(s.plot.kde(weights=sr_wgts), Axes), Axes)
 
 
 def test_plot_pie(close_figures: None) -> None:


### PR DESCRIPTION
- [x] Added missing parameter weights in [DataFrame.plot.kde()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.plot.kde.html#pandas.DataFrame.plot.kde) for the estimation of the PDF (https://github.com/pandas-dev/pandas/issues/59337)
- [x] [DataFrame.pivot_table()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.pivot_table.html#pandas.DataFrame.pivot_table) and [pivot_table()](https://pandas.pydata.org/docs/dev/reference/api/pandas.pivot_table.html#pandas.pivot_table) now allow the passing of keyword arguments to aggfunc through **kwargs (https://github.com/pandas-dev/pandas/issues/57884)
- [x] [pandas.concat()](https://pandas.pydata.org/docs/dev/reference/api/pandas.concat.html#pandas.concat) will raise a ValueError when ignore_index=True and keys is not None (https://github.com/pandas-dev/pandas/issues/59274)
- [x] [Series.map()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.map.html#pandas.Series.map) now accepts an engine parameter to allow execution with a third-party execution engine (https://github.com/pandas-dev/pandas/issues/61125)
- [x] Support passing a [Series](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.html#pandas.Series) input to [json_normalize()](https://pandas.pydata.org/docs/dev/reference/api/pandas.json_normalize.html#pandas.json_normalize) that retains the [Index](https://pandas.pydata.org/docs/dev/reference/api/pandas.Index.html#pandas.Index) (https://github.com/pandas-dev/pandas/issues/51452)