### PR TITLE
BUG: allow kwargs in Styler apply_index and map_index

### DIFF
--- a/pandas-stubs/io/formats/style.pyi
+++ b/pandas-stubs/io/formats/style.pyi
@@ -57,6 +57,11 @@ class _SeriesFunc(Protocol):
         self, series: Series, /, *args: Any, **kwargs: Any
     ) -> list[Any] | Series: ...
 
+class _SeriesStrFunc(Protocol):
+    def __call__(
+        self, series: Series[str], /, *args: Any, **kwargs: Any
+    ) -> list[str] | Series[str]: ...
+
 class _DataFrameFunc(Protocol):
     def __call__(
         self, series: DataFrame, /, *args: Any, **kwargs: Any
@@ -277,14 +282,17 @@ class Styler(StylerRenderer):
     ) -> Styler: ...
     def apply_index(
         self,
-        func: Callable[[Series], list[str] | np_ndarray_str | Series[str]],
+        func: (
+            _SeriesStrFunc
+            | Callable[[Series], list[str] | np_ndarray_str | Series[str]]
+        ),
         axis: Axis = ...,
         level: Level | list[Level] | None = ...,
         **kwargs: Any,
     ) -> Styler: ...
     def map_index(
         self,
-        func: Callable[[Scalar], str | None],
+        func: _MapCallable | Callable[[Scalar], str | None],
         axis: Axis = ...,
         level: Level | list[Level] | None = ...,
         **kwargs: Any,

--- a/tests/test_styler.py
+++ b/tests/test_styler.py
@@ -76,12 +76,25 @@ def test_apply_index() -> None:
 
     check(assert_type(DF.style.apply_index(f1), Styler), Styler)
 
+    # GH 1723
+    def highlight_odd(index: pd.Series, /, color: str) -> list[str]:
+        return [f"color: {color}" if x % 2 else "" for x in index]
+
+    check(
+        assert_type(DF.style.apply_index(highlight_odd, color="purple"), Styler), Styler
+    )
+
 
 def test_map_index() -> None:
     def f(s: Scalar) -> str | None:
         return "background-color: yellow;" if s == "B" else None
 
     check(assert_type(DF.style.map_index(f), Styler), Styler)
+
+    def f1(s: Scalar, /, color: str) -> str | None:
+        return f"background-color: {color};" if s == "b" else None
+
+    check(assert_type(DF.style.map_index(f1, color="pink"), Styler), Styler)
 
 
 def test_background_gradient() -> None:

--- a/tests/test_styler.py
+++ b/tests/test_styler.py
@@ -77,11 +77,14 @@ def test_apply_index() -> None:
     check(assert_type(DF.style.apply_index(f1), Styler), Styler)
 
     # GH 1723
-    def highlight_odd(index: pd.Series, /, color: str) -> list[str]:
+    def highlight_odd(index: pd.Series, color: str) -> list[str]:
         return [f"color: {color}" if x % 2 else "" for x in index]
 
     check(
-        assert_type(DF.style.apply_index(highlight_odd, color="purple"), Styler), Styler
+        assert_type(
+            DF.style.apply_index(highlight_odd, axis=0, color="purple"), Styler
+        ),
+        Styler,
     )
 
 
@@ -91,10 +94,10 @@ def test_map_index() -> None:
 
     check(assert_type(DF.style.map_index(f), Styler), Styler)
 
-    def f1(s: Scalar, /, color: str) -> str | None:
+    def f1(s: Scalar, color: str) -> str | None:
         return f"background-color: {color};" if s == "b" else None
 
-    check(assert_type(DF.style.map_index(f1, color="pink"), Styler), Styler)
+    check(assert_type(DF.style.map_index(f1, color="pink", axis=0), Styler), Styler)
 
 
 def test_background_gradient() -> None:


### PR DESCRIPTION
Adds ability to pass a function with `**kwargs` to Styler `apply_index` and `map_index`. The `apply` and `map` functions already supported this. 

- [x] Closes #1723
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
