### PR TITLE
TYP: add CategoricalSeries type alias for Series[CategoricalDtype] (#1415)

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -531,6 +531,14 @@ BytesDtypeArg: TypeAlias = (
     BuiltinBytesDtypeArg | NumpyBytesDtypeArg | PyArrowBytesDtypeArg
 )
 CategoryDtypeArg: TypeAlias = CategoricalDtype | Literal["category"]
+# Alias for a Series with a categorical dtype. The element-type of a categorical
+# Series is not statically known (it can hold any hashable categories), so we
+# parameterize by `CategoricalDtype` rather than the element type. Users can
+# spell ``Series[CategoricalDtype]`` directly, but the alias is shorter and
+# easier to remember; see GH#1415. Guarded by ``TYPE_CHECKING`` because
+# ``Series`` is not subscriptable at runtime.
+if TYPE_CHECKING:
+    CategoricalSeries: TypeAlias = Series[CategoricalDtype]
 
 # Builtin object type and its string alias
 BuiltinObjectDtypeArg: TypeAlias = type[object] | Literal["object"]

--- a/tests/series/categorical/test_dtypes.py
+++ b/tests/series/categorical/test_dtypes.py
@@ -5,12 +5,17 @@ from typing import (
     assert_type,
 )
 
+import numpy as np
 import pandas as pd
+from pandas.core.arrays.categorical import Categorical
 import pytest
 
 from tests import check
 from tests._typing import CategoryDtypeArg
 from tests.dtypes import ASTYPE_CATEGORICAL_ARGS
+
+if TYPE_CHECKING:
+    from pandas._typing import CategoricalSeries
 
 
 @pytest.mark.parametrize(
@@ -24,3 +29,45 @@ def test_astype_categorical(cast_arg: CategoryDtypeArg, target_type: type) -> No
         # pandas category
         assert_type(s.astype(pd.CategoricalDtype()), "pd.Series[pd.CategoricalDtype]")
         assert_type(s.astype(cast_arg), "pd.Series[pd.CategoricalDtype]")
+
+
+def test_categorical_series_alias() -> None:
+    # GH1415: ``CategoricalSeries`` is the public alias for
+    # ``Series[CategoricalDtype]``. It must be assignment-compatible with the
+    # parameterized form so existing user code keeps type-checking.
+    s_cat = pd.Series([1, 2, 3], dtype="category")
+    check(assert_type(s_cat, "pd.Series[pd.CategoricalDtype]"), pd.Series, np.integer)
+
+    if TYPE_CHECKING:
+        s_alias: CategoricalSeries = s_cat
+        s_param: pd.Series[pd.CategoricalDtype] = s_cat
+        # Reverse direction: a value typed as the alias is assignable to the
+        # parameterized form.
+        s_back: pd.Series[pd.CategoricalDtype] = s_alias
+        # Suppress unused-variable warnings without runtime evaluation.
+        del s_alias, s_param, s_back
+
+
+def test_categorical_cat_accessor() -> None:
+    # GH1415: exercise common ``.cat`` accessor methods on a categorical
+    # ``Series`` and confirm their return types are well-defined.
+    # ``Sequence[str]`` triggers the str-data overload first, so build the
+    # series via ``astype`` to keep the categorical parameterization.
+    s_cat = pd.Series(["a", "b", "a", "c"]).astype("category")
+    check(assert_type(s_cat, "pd.Series[pd.CategoricalDtype]"), pd.Series)
+
+    # ``codes`` returns a ``Series[int]``; ``categories`` returns an Index.
+    check(assert_type(s_cat.cat.codes, "pd.Series[int]"), pd.Series, np.integer)
+    check(assert_type(s_cat.cat.categories, pd.Index), pd.Index)
+    check(assert_type(s_cat.cat.ordered, "bool | None"), bool)
+
+    # ``Series.array`` for a categorical Series narrows to ``Categorical``.
+    check(assert_type(s_cat.array, Categorical), Categorical)
+
+
+def test_categorical_series_copy() -> None:
+    # GH1415: ``Series.copy`` on a ``CategoricalSeries`` must preserve the
+    # categorical parameterization so further operations stay typed.
+    s_cat = pd.Series([1, 2, 3], dtype="category")
+    s_copy = s_cat.copy()
+    check(assert_type(s_copy, "pd.Series[pd.CategoricalDtype]"), pd.Series)


### PR DESCRIPTION
## Summary
Refs #1415. Adds the additive piece of "how should we type Series with categorical dtype?" — a `CategoricalSeries: TypeAlias = Series[CategoricalDtype]` declared under `TYPE_CHECKING` in `pandas-stubs/_typing.pyi`.

## Design choice
The broader question — re-parameterizing `Series` by element type, or introducing a `CategoricalItem[C1]` generic mirroring `Interval` — was discussed in the issue thread but is genuinely open. Re-parameterizing would break every existing user that wrote `Series[CategoricalDtype]`. This PR ships only the additive subset: a short, discoverable spelling. Maintainers can layer the generic design on top later without breaking anything here.

## Files changed
- `pandas-stubs/_typing.pyi` — alias under `TYPE_CHECKING` (Series is not subscriptable at runtime; mirrors `MaskType`/`IndexType` pattern).
- `tests/series/categorical/test_dtypes.py` — 3 new tests: assignment compatibility, cat accessor typing, copy-preserves-parameterization.

## Test plan
- ruff check, black --check, isort --check-only — all clean
- pyright — 0 errors on changed files
- pytest — 5/5 categorical tests pass
