### PR TITLE
GH1654 Pandas 3.0 support

### DIFF
--- a/pandas-stubs/core/arrays/sparse/dtype.pyi
+++ b/pandas-stubs/core/arrays/sparse/dtype.pyi
@@ -1,8 +1,8 @@
-from pandas._typing import (
-    Dtype,
-    Scalar,
-    npt,
-)
+from typing import overload
+
+import numpy as np
+
+from pandas._typing import Scalar
 
 from pandas.core.dtypes.base import ExtensionDtype
 from pandas.core.dtypes.dtypes import (
@@ -10,10 +10,49 @@ from pandas.core.dtypes.dtypes import (
 )
 
 class SparseDtype(ExtensionDtype):
+    @overload
     def __init__(
         self,
-        dtype: Dtype | npt.DTypeLike = ...,
+        dtype: type[bool | np.bool_],
+        fill_value: bool | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        dtype: type[int | np.integer],
+        fill_value: int | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        dtype: type[float | np.floating],
+        fill_value: float | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        dtype: type[complex | np.complexfloating],
+        fill_value: complex | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        dtype: type[np.datetime64],
+        fill_value: np.datetime64 | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        dtype: type[np.timedelta64],
+        fill_value: np.timedelta64 | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        dtype: type[str | bytes] | str | np.dtype[np.generic] | ExtensionDtype = ...,
         fill_value: Scalar | None = None,
     ) -> None: ...
+    @property
+    def subtype(self) -> np.dtype: ...
     @property
     def fill_value(self) -> Scalar | None: ...

--- a/pandas-stubs/core/arrays/sparse/dtype.pyi
+++ b/pandas-stubs/core/arrays/sparse/dtype.pyi
@@ -53,6 +53,10 @@ class SparseDtype(ExtensionDtype):
         fill_value: Scalar | None = None,
     ) -> None: ...
     @property
-    def subtype(self) -> np.dtype: ...
+    def subtype(
+        self,
+    ) -> (
+        np.dtype
+    ): ...  # TODO: pandas-dev/pandas-stubs#1654 make the class Generic so we can embed the subtype more precisely
     @property
     def fill_value(self) -> Scalar | None: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -4186,6 +4186,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     def item(self) -> S1: ...
     def kurt(
         self,
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
         numeric_only: _bool = False,
@@ -4212,8 +4213,9 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         fill_value: float | None = None,
         axis: AxisIndex = ...,
     ) -> Series[_bool]: ...
-    def max(
+    def max(  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride] # ty: ignore[invalid-method-override] # pyrefly: ignore[bad-override]
         self,
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
         level: None = None,
@@ -4223,6 +4225,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def mean(
         self: Series[Never],
+        *,
         axis: AxisIndex | None = ...,
         skipna: _bool = ...,
         level: None = None,
@@ -4232,6 +4235,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def mean(
         self: Series[Timestamp],
+        *,
         axis: AxisIndex | None = ...,
         skipna: _bool = ...,
         level: None = None,
@@ -4241,6 +4245,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def mean(
         self: SupportsGetItem[Scalar, SupportsTruedivInt[S2]],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
         level: None = None,
@@ -4250,6 +4255,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def median(
         self: Series[Never],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
         level: None = None,
@@ -4259,6 +4265,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def median(
         self: Series[complex],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
         level: None = None,
@@ -4268,6 +4275,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def median(
         self: SupportsGetItem[Scalar, SupportsTruedivInt[S2]],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
         level: None = None,
@@ -4277,14 +4285,16 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def median(
         self: Series[Timestamp],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
         level: None = None,
         numeric_only: _bool = False,
         **kwargs: Any,
     ) -> Timestamp: ...
-    def min(
+    def min(  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride] # ty: ignore[invalid-method-override] # pyrefly: ignore[bad-override]
         self,
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
         level: None = None,
@@ -4316,6 +4326,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[S1]: ...
     def prod(
         self,
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         numeric_only: _bool = False,
@@ -4379,6 +4390,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[S1]: ...
     def sem(
         self,
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         ddof: int = 1,
@@ -4387,6 +4399,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Scalar: ...
     def skew(
         self,
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         numeric_only: _bool = False,
@@ -4395,6 +4408,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def std(
         self: Series[Never],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         ddof: int = 1,
@@ -4404,6 +4418,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def std(
         self: Series[complex],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         level: None = None,
@@ -4414,6 +4429,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def std(
         self: Series[Timestamp],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         level: None = None,
@@ -4424,6 +4440,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def std(
         self: SupportsGetItem[Scalar, SupportsTruedivInt[S2]],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         ddof: int = 1,
@@ -4432,6 +4449,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> S2: ...
     def sum(
         self: SupportsGetItem[Scalar, _SupportsAdd[_T]],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = ...,
         numeric_only: _bool = ...,
@@ -4603,6 +4621,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def var(
         self: Series[Never],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         ddof: int = 1,
@@ -4612,6 +4631,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def var(
         self: Series[Timedelta] | Series[Timestamp],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         ddof: int = 1,
@@ -4621,6 +4641,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def var(
         self: Series[complex],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         ddof: int = 1,
@@ -4630,6 +4651,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def var(
         self: SupportsGetItem[Scalar, SupportsTruedivInt[S2]],
+        *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
         ddof: int = 1,

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -167,11 +167,17 @@ def test_types_any() -> None:
     check(assert_type(pd.Series([False, False]).any(bool_only=False), np.bool), np.bool)
     check(assert_type(pd.Series([np.nan]).any(skipna=False), np.bool), np.bool)
 
+    if TYPE_CHECKING_INVALID_USAGE:
+        pd.Series([False, True]).any(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+
 
 def test_types_all() -> None:
     check(assert_type(pd.Series([False, False]).all(), np.bool), np.bool)
     check(assert_type(pd.Series([False, False]).all(bool_only=False), np.bool), np.bool)
     check(assert_type(pd.Series([np.nan]).all(skipna=False), np.bool), np.bool)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        pd.Series([False, True]).all(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
 
 
 def test_types_csv(tmp_path: Path) -> None:
@@ -475,6 +481,9 @@ def test_types_median() -> None:
     check(assert_type(s.median(skipna=False), float), float)
     check(assert_type(s.median(numeric_only=False), float), float)
 
+    if TYPE_CHECKING_INVALID_USAGE:
+        s.median(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+
 
 def test_types_sum() -> None:
     s = pd.Series([1, 2, 3, np.nan])
@@ -533,13 +542,23 @@ def test_types_min() -> None:
     )
     check(assert_type(s.min(skipna=False), float), np.floating)
 
+    if TYPE_CHECKING_INVALID_USAGE:
+        s.min(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+
 
 def test_types_max() -> None:
     s = pd.Series([1, 2, 3, np.nan])
-    s.max()
-    s.max(axis=0)
-    s.groupby(level=0).max()
-    s.max(skipna=False)
+    check(assert_type(s.max(), float), np.floating)
+    check(assert_type(s.max(axis=0), float), np.floating)
+    check(
+        assert_type(s.groupby(level=0).max(), "pd.Series[float]"),
+        pd.Series,
+        np.floating,
+    )
+    check(assert_type(s.max(skipna=False), float), np.floating)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        s.max(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
 
 
 def test_types_groupby_level() -> None:
@@ -941,6 +960,15 @@ def test_types_groupby_methods() -> None:
         pd.Series,
         np.integer,
     )
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        s.sum(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+        s.prod(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+        s.std(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+        s.var(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+        s.sem(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+        s.skew(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
+        s.kurt(0)  # type: ignore[misc] # pyright: ignore[reportCallIssue]
 
 
 def test_groupby_result() -> None:

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -150,6 +150,35 @@ def test_sparse_dtype() -> None:
     check(assert_type(s_dt.fill_value, Scalar | None), int)
 
 
+def test_sparse_dtype_fill_value_subtype_compatibility() -> None:
+    # int subtype: default fill_value is 0
+    s_dt_int = pd.SparseDtype(int)
+    check(assert_type(s_dt_int.subtype, np.dtype), np.dtype)
+    check(assert_type(s_dt_int.fill_value, Scalar | None), int)
+
+    # float subtype: default fill_value is np.nan
+    s_dt_float = pd.SparseDtype(float)
+    check(assert_type(s_dt_float.subtype, np.dtype), np.dtype)
+    check(assert_type(s_dt_float.fill_value, Scalar | None), float)
+
+    # bool subtype: default fill_value is False
+    s_dt_bool = pd.SparseDtype(bool)
+    check(assert_type(s_dt_bool.subtype, np.dtype), np.dtype)
+    check(assert_type(s_dt_bool.fill_value, Scalar | None), bool)
+
+    # datetime64 subtype: default fill_value is NaT
+    s_dt_dt = pd.SparseDtype(np.datetime64)
+    check(assert_type(s_dt_dt.subtype, np.dtype), np.dtype)
+    check(assert_type(s_dt_dt.fill_value, Scalar | None), np.datetime64)
+
+    # passing a fill_value incompatible with the subtype is both a static type error
+    # and a runtime ValueError
+    if TYPE_CHECKING_INVALID_USAGE:
+        pd.SparseDtype(
+            int, fill_value="hello"  # type: ignore[arg-type] # pyright: ignore[reportCallIssue, reportArgumentType]
+        )
+
+
 @pytest.mark.parametrize("storage", ["python", "pyarrow", None])
 @pytest.mark.parametrize("na_value", [pd.NA, float("nan")])
 def test_string_dtype(

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -153,22 +153,22 @@ def test_sparse_dtype() -> None:
 def test_sparse_dtype_fill_value_subtype_compatibility() -> None:
     # int subtype: default fill_value is 0
     s_dt_int = pd.SparseDtype(int)
-    check(assert_type(s_dt_int.subtype, np.dtype), np.dtype)
+    check(assert_type(s_dt_int.subtype, np.dtype), np.dtypes.Int64DType)
     check(assert_type(s_dt_int.fill_value, Scalar | None), int)
 
     # float subtype: default fill_value is np.nan
     s_dt_float = pd.SparseDtype(float)
-    check(assert_type(s_dt_float.subtype, np.dtype), np.dtype)
+    check(assert_type(s_dt_float.subtype, np.dtype), np.dtypes.Float64DType)
     check(assert_type(s_dt_float.fill_value, Scalar | None), float)
 
     # bool subtype: default fill_value is False
     s_dt_bool = pd.SparseDtype(bool)
-    check(assert_type(s_dt_bool.subtype, np.dtype), np.dtype)
+    check(assert_type(s_dt_bool.subtype, np.dtype), np.dtypes.BoolDType)
     check(assert_type(s_dt_bool.fill_value, Scalar | None), bool)
 
     # datetime64 subtype: default fill_value is NaT
     s_dt_dt = pd.SparseDtype(np.datetime64)
-    check(assert_type(s_dt_dt.subtype, np.dtype), np.dtype)
+    check(assert_type(s_dt_dt.subtype, np.dtype), np.dtypes.DateTime64DType)
     check(assert_type(s_dt_dt.fill_value, Scalar | None), np.datetime64)
 
     # passing a fill_value incompatible with the subtype is both a static type error


### PR DESCRIPTION
- [x] Closes #1654
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

These are the last items on the 3.0 migration.

- [x] Deprecated allowing non-keyword arguments in [DataFrame.all()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.all.html#pandas.DataFrame.all), [DataFrame.min()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.min.html#pandas.DataFrame.min), [DataFrame.max()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.max.html#pandas.DataFrame.max), [DataFrame.sum()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.sum.html#pandas.DataFrame.sum), [DataFrame.prod()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.prod.html#pandas.DataFrame.prod), [DataFrame.mean()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.mean.html#pandas.DataFrame.mean), [DataFrame.median()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.median.html#pandas.DataFrame.median), [DataFrame.sem()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.sem.html#pandas.DataFrame.sem), [DataFrame.var()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.var.html#pandas.DataFrame.var), [DataFrame.std()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.std.html#pandas.DataFrame.std), [DataFrame.skew()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.skew.html#pandas.DataFrame.skew), [DataFrame.kurt()](https://pandas.pydata.org/docs/dev/reference/api/pandas.DataFrame.kurt.html#pandas.DataFrame.kurt), [Series.all()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.all.html#pandas.Series.all), [Series.min()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.min.html#pandas.Series.min), [Series.max()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.max.html#pandas.Series.max), [Series.sum()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.sum.html#pandas.Series.sum), [Series.prod()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.prod.html#pandas.Series.prod), [Series.mean()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.mean.html#pandas.Series.mean), [Series.median()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.median.html#pandas.Series.median), [Series.sem()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.sem.html#pandas.Series.sem), [Series.var()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.var.html#pandas.Series.var), [Series.std()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.std.html#pandas.Series.std), [Series.skew()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.skew.html#pandas.Series.skew), and [Series.kurt()](https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.kurt.html#pandas.Series.kurt). (https://github.com/pandas-dev/pandas/issues/57087)
- [x] Require SparseDtype.fill_value() to be a valid value for the SparseDtype.subtype() (https://github.com/pandas-dev/pandas/issues/53043)