### PR TITLE
MNT: Update to pandas 3.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ numpy = ">=1.23.5"
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=2.0.0"
-pandas = "3.0.1"
+pandas = "3.0.3"
 pyarrow = ">=10.0.1"
 pytest = ">=8.4.2"
 pyright = ">=1.1.409"

--- a/tests/series/test_agg.py
+++ b/tests/series/test_agg.py
@@ -60,14 +60,14 @@ def test_agg_complex() -> None:
     with pytest_warns_bounded(
         np.exceptions.ComplexWarning,
         r"Casting complex values to real discards the imaginary part",
-        upper="3.0.99",
+        upper="3.0.3",
     ):
         check(assert_type(series.std(), np.float64), np.float64)
 
     with pytest_warns_bounded(
         np.exceptions.ComplexWarning,
         r"Casting complex values to real discards the imaginary part",
-        upper="3.0.99",
+        upper="3.0.3",
     ):
         check(assert_type(series.var(), float), np.float64)
 


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Could be worth doing a release for this one, no changes of the types between 3.0.1 and 3.03, the bigger work will be with 3.1.0.
