### PR TITLE
Read-only (covariant) list parameter annotations

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -17,6 +17,7 @@ import sys
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Generic,
     Literal,
     Protocol,
@@ -1231,12 +1232,13 @@ class Just(Protocol, Generic[T]):
     def __class__(self, t: type[T], /) -> None: ...
 
 class CovariantList(Protocol[_T_co]):
+    __hash__: ClassVar[None]  # type: ignore[assignment] # pyright: ignore[reportIncompatibleMethodOverride]
     @property  # type: ignore[override]
     def __class__(self) -> type[list[Any]]: ...  # pyrefly: ignore[bad-override]
     @__class__.setter
-    def __class__(
+    def __class__(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, value: type[list[Any]], /
-    ) -> None: ...  # pyright: ignore[reportIncompatibleMethodOverride]
+    ) -> None: ...
     def __iter__(self) -> Iterator[_T_co]: ...
     # copy() is only TEMPORARILY needed because `__class__` is a property
     # and ty doesn't support property protocol members. Remove when

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -1230,6 +1230,19 @@ class Just(Protocol, Generic[T]):
     @override
     def __class__(self, t: type[T], /) -> None: ...
 
+class CovariantList(Protocol[_T_co]):
+    @property  # type: ignore[override]
+    def __class__(self) -> type[list[Any]]: ...  # pyrefly: ignore[bad-override]
+    @__class__.setter
+    def __class__(
+        self, value: type[list[Any]], /
+    ) -> None: ...  # pyright: ignore[reportIncompatibleMethodOverride]
+    def __iter__(self) -> Iterator[_T_co]: ...
+    # copy() is only TEMPORARILY needed because `__class__` is a property
+    # and ty doesn't support property protocol members. Remove when
+    # https://github.com/astral-sh/ty/issues/1379 is resolved
+    def copy(self) -> list[Any]: ...
+
 class SupportsTrueDiv(Protocol[_T_contra, _T_co]):
     def __truediv__(self, x: _T_contra, /) -> _T_co: ...
 

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -1231,6 +1231,7 @@ class Just(Protocol, Generic[T]):
     @override
     def __class__(self, t: type[T], /) -> None: ...
 
+# Read-only (covariant) list for use in parameter annotations (See GH #1745)
 class CovariantList(Protocol[_T_co]):
     __hash__: ClassVar[None]  # type: ignore[assignment] # pyright: ignore[reportIncompatibleMethodOverride]
     @property  # type: ignore[override]

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -99,6 +99,7 @@ from pandas._typing import (
     CalculationMethod,
     ColspaceArgType,
     CompressionOptions,
+    CovariantList,
     DropKeep,
     Dtype,
     FilePath,
@@ -2092,9 +2093,11 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def get(self, key: Hashable, default: _T) -> Series | _T: ...
     @overload
-    def get(self, key: list[Hashable], default: None = None) -> Self | None: ...
+    def get(
+        self, key: CovariantList[Hashable], default: None = None
+    ) -> Self | None: ...
     @overload
-    def get(self, key: list[Hashable], default: _T) -> Self | _T: ...
+    def get(self, key: CovariantList[Hashable], default: _T) -> Self | _T: ...
     def gt(
         self,
         other: complex | ListLike | DataFrame,

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -3921,6 +3921,9 @@ def test_get() -> None:
     )
     check(assert_type(df.get(["z"], default=1), pd.DataFrame | int), int)
 
+    key = ["a", "b"]
+    check(assert_type(df.get(key), pd.DataFrame | None), pd.DataFrame)
+
 
 def test_info() -> None:
     df = pd.DataFrame()

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 from typing import (
+    TYPE_CHECKING,
     Any,
     Literal,
 )
@@ -8,12 +9,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandas._typing import CovariantList
-
 from pandas.core.dtypes.base import ExtensionDtype
 
 from tests import get_dtype
 from tests.dtypes import DTYPE_ARG_ALIAS_MAPS
+
+if TYPE_CHECKING:
+    from pandas._typing import CovariantList
 
 
 def test_get_dtype() -> None:
@@ -41,7 +43,7 @@ def test_dtype_arg_aliases(dtype_arg: Any, alias_map: Mapping[Any, Any]) -> None
 
 
 def test_covariant_list() -> None:
-    def f(_: CovariantList[float]) -> None: ...
+    def f(_: "CovariantList[float]") -> None: ...
 
     good1: list[float] = [1.0, 2.0, 3.0]  # OK, trivial case
     good2: list[int] = [1, 2, 3]  # OK, list[int] < list[float] due to covariance

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -8,6 +8,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from pandas._typing import CovariantList
+
 from pandas.core.dtypes.base import ExtensionDtype
 
 from tests import get_dtype
@@ -36,3 +38,21 @@ def test_dtype_arg_aliases(dtype_arg: Any, alias_map: Mapping[Any, Any]) -> None
     assert set(get_dtype(dtype_arg)) == {
         type(t) if isinstance(t, ExtensionDtype) else t for t in alias_map
     }
+
+
+def test_covariant_list() -> None:
+    def f(_: CovariantList[float]) -> None: ...
+
+    good1: list[float] = [1.0, 2.0, 3.0]  # OK, trivial case
+    good2: list[int] = [1, 2, 3]  # OK, list[int] < list[float] due to covariance
+    bad1: tuple[float, ...] = (1.0, 2.0, 3.0)  # Error, tuple is not a subtype of list
+    bad2: list[str] = ["a", "b", "c"]  # Error, list[str] !< list[float]
+    bad3: list[object] = [1, "a", 3.0]  # Error, list[object] !< list[float]
+    bad4: float = 1.0  # Error, float !< list[float]
+
+    f(good1)
+    f(good2)
+    f(bad1)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+    f(bad2)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+    f(bad3)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+    f(bad4)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -11,7 +11,10 @@ import pytest
 
 from pandas.core.dtypes.base import ExtensionDtype
 
-from tests import get_dtype
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    get_dtype,
+)
 from tests.dtypes import DTYPE_ARG_ALIAS_MAPS
 
 if TYPE_CHECKING:
@@ -54,7 +57,8 @@ def test_covariant_list() -> None:
 
     f(good1)
     f(good2)
-    f(bad1)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
-    f(bad2)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
-    f(bad3)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
-    f(bad4)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+    if TYPE_CHECKING_INVALID_USAGE:
+        f(bad1)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        f(bad2)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        f(bad3)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        f(bad4)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
- [x] Closes #153 (already closed but similar issues still exist)
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] No AI used

Some pandas functions expect a list as argument but not any sequence. Because `list` is invariant, parameters annotated with `list[float]` will not accept `list[int]`, for examlpe, even though we know that the list is read-only and will not be modified. To fix this, I propose the following trick using the `CovariantList` protocol. This protocol can replace `list` annotations in parameter positions (never use as a return type, instead keep using `list` there).

Note that this problem has manifested before and one trick you use today is to parametrize the list with a type variable that has an appropriate upper bound (for example you use `list[HashableT]` where you want a list of hashable objects). This is cumbersome because for every type of list element, you'll need to define a corresponding type variable. Also, there are some places where a list of a very wide type like a union is still used (for example `list[AggFuncTypeBase]` in `DataFrame.aggregate`). All of these can be replaced with the `CovariantList` protocol.

In this PR I only introduce the protocol and change one method to use it to demonstrate its value. I think it would be better to incrementally use this protocol in follow up PR(s) for easier work and review. For example a PR could replace all `list[HashableT]` and `list[Hashable]` in parameter positions by `CovariantList[Hashable]` then other uses could be audited and changed in separate follow-up PRs.