### PR TITLE
Modernize project settings in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ public visibility.
   The stubs help you write code compatible with future pandas versions. Type checkers will flag deprecated or removed APIs based on the pandas version the stubs were tested against.
 
 > [!NOTE]
-> 
+>
 > Using a newer version of the stubs in conjunction with an older version of pandas
 > - Will cause type checkers to allow you to see which APIs will be deprecated or removed in a future version
 > - Will cause type checkers to consider code to be acceptable that uses newer or changed API's in current versions of pandas, such that the code would fail at runtime with an older version of
@@ -131,7 +131,7 @@ conda install poetry
 
 ```sh
 # or PyPI
-pip install 'poetry>=1.2'
+pip install 'poetry>=2.0'
 ```
 
 - Install the project dependencies
@@ -153,7 +153,7 @@ poetry run poe install_dist
 
 ## Documentation
 
-Documentation is a work-in-progress.  
+Documentation is a work-in-progress.
 
 ## Background
 
@@ -173,7 +173,7 @@ If issues are found with the public stubs, pull requests to correct those issues
 
 ## Getting help
 
-Ask questions and report issues on the [pandas-stubs repository](https://github.com/pandas-dev/pandas-stubs/issues).  
+Ask questions and report issues on the [pandas-stubs repository](https://github.com/pandas-dev/pandas-stubs/issues).
 
 ## Discussion and Development
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,7 +2,7 @@
 
 - Make sure you have `python >= 3.11` installed.
 - If using macOS, you may need to install `hdf5` (e.g., via `brew install hdf5`).
-- Install poetry: `pip install 'poetry>=1.8'`
+- Install poetry: `pip install 'poetry>=2.0'`
 - Install the project dependencies: `poetry update`
 - Enter the virtual environment: `poetry shell`
 - Run all tests: `poe test_all`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 packages = [{ include = "pandas-stubs" }]
-exclude = ["pandas-stubs/__init__.py"]
 
 [tool.poe.tasks.test_all]
 help = "Run all tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,15 @@
-[tool.poetry]
+[project]
 name = "pandas-stubs"
 version = "3.0.0.260204"
 description = "Type annotations for pandas"
-authors = ["The Pandas Development Team <pandas-dev@python.org>"]
+authors = [{name = "The Pandas Development Team", email = "pandas-dev@python.org"}]
 license = "BSD-3-Clause"
 readme = "README.md"
-homepage = "https://pandas.pydata.org"
-repository = "https://github.com/pandas-dev/pandas-stubs"
+requires-python = '>=3.11'
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
@@ -23,60 +21,63 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Stubs Only",
 ]
-packages = [{ include = "pandas-stubs" }]
-exclude = ["pandas-stubs/__init__.py"]
+dependencies = ["numpy>=1.23.5"]
 
-[tool.poetry.urls]
+[project.urls]
+Homepage = "https://pandas.pydata.org"
+Repository = "https://github.com/pandas-dev/pandas-stubs"
 "Bug Tracker" = "https://github.com/pandas-dev/pandas-stubs/issues"
-"Documentation" = "https://pandas.pydata.org/pandas-docs/stable"
+Documentation = "https://pandas.pydata.org/pandas-docs/stable"
 
-[tool.poetry.dependencies]
-python = ">=3.11"
-numpy = ">=1.23.5"
-
-[tool.poetry.group.dev.dependencies]
-mypy = ">=2.0.0"
-pandas = "3.0.3"
-pyarrow = ">=10.0.1"
-pytest = ">=8.4.2"
-pyright = ">=1.1.409"
-ty = ">=0.0.34"
-pyrefly = ">=0.64.1"
-poethepoet = ">=0.16.5"
-loguru = ">=0.6.0"
-typing-extensions = ">=4.5.0"
-matplotlib = ">=3.10.1"
-pre-commit = ">=4.3.0"
-black = ">=25.9.0"
-isort = ">=7.0.0"
-openpyxl = ">=3.0.10"
-numexpr = ">=2.13.1"
-lxml = ">=4.9.1"
-pyreadstat = ">=1.2.0"
-xlrd = ">=2.0.1"
-xlsxwriter = ">=3.0.3"
-pyxlsb = ">=1.0.10"
-odfpy = ">=1.4.1"
-xarray = ">=22.6.0"
-tabulate = ">=0.8.10"
-jinja2 = ">=3.1"
-scipy = ">=1.9.1"
-scipy-stubs = ">=1.15.3.0"
-SQLAlchemy = ">=2.0.39"
-types-python-dateutil = ">=2.8.19"
-beautifulsoup4 = ">=4.14.2"
-html5lib = ">=1.1"
-python-calamine = ">=0.2.0"
-pyarrow-stubs = { version = ">=20.0.0.20250928", python = "<4" }
-fsspec = "^2025.10.0"
-tables = ">=3.10.2"
-pytz = "^2025.2"
-types-pytz = ">=2022.1.1"
-pyiceberg = "^0.10.0"
+[dependency-groups]
+dev = [
+  "mypy>=2.0.0",
+  "pandas==3.0.3",
+  "pyarrow>=10.0.1",
+  "pytest>=8.4.2",
+  "pyright>=1.1.409",
+  "ty>=0.0.34",
+  "pyrefly>=0.64.1",
+  "poethepoet>=0.16.5",
+  "loguru>=0.6.0",
+  "typing-extensions>=4.5.0",
+  "matplotlib>=3.10.1",
+  "pre-commit>=4.3.0",
+  "black>=25.9.0",
+  "isort>=7.0.0",
+  "openpyxl>=3.0.10",
+  "numexpr>=2.13.1",
+  "lxml>=4.9.1",
+  "pyreadstat>=1.2.0",
+  "xlrd>=2.0.1",
+  "xlsxwriter>=3.0.3",
+  "pyxlsb>=1.0.10",
+  "odfpy>=1.4.1",
+  "xarray>=22.6.0",
+  "tabulate>=0.8.10",
+  "jinja2>=3.1",
+  "scipy>=1.9.1",
+  "scipy-stubs>=1.15.3.0",
+  "SQLAlchemy>=2.0.39",
+  "types-python-dateutil>=2.8.19",
+  "beautifulsoup4>=4.14.2",
+  "html5lib>=1.1",
+  "python-calamine>=0.2.0",
+  "pyarrow-stubs>=20.0.0.20250928;python_version<'4'",
+  "fsspec>=2025.10.0",
+  "tables>=3.10.2",
+  "pytz>=2025.2",
+  "types-pytz>=2022.1.1",
+  "pyiceberg>=0.10.0",
+]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+packages = [{ include = "pandas-stubs" }]
+exclude = ["pandas-stubs/__init__.py"]
 
 [tool.poe.tasks.test_all]
 help = "Run all tests"
@@ -141,9 +142,6 @@ args = [
 help = "Check type completeness"
 script = "scripts.test.run:type_completeness"
 
-[tool.black]
-target-version = ["py311"]
-
 [tool.isort]
 known_pre_libs = "pandas._config"
 known_pre_core = [
@@ -174,7 +172,6 @@ skip_glob = "env"
 
 
 [tool.ruff]
-target-version = "py311"
 fix = true
 
 
@@ -339,7 +336,6 @@ unannotated-attribute = true
 
 [tool.ty.environment]
 python-platform = "all"
-python-version = "3.11"
 
 [tool.ty.rules]
 possibly-unresolved-reference = "error"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1718,14 +1718,7 @@ def test_converters_partial(tmp_path: Path) -> None:
 def test_iceberg(tmp_path: Path) -> None:
     """Test read_iceberg and DataFrame.to_iceberg GH1654."""
 
-    from pydantic.warnings import PydanticDeprecatedSince212
-    from pyparsing.warnings import PyparsingDeprecationWarning
-
-    with (
-        pytest_warns_bounded(PydanticDeprecatedSince212, match="Using"),
-        pytest_warns_bounded(PyparsingDeprecationWarning, match="deprecat"),
-    ):
-        from pyiceberg.catalog.sql import SqlCatalog
+    from pyiceberg.catalog.sql import SqlCatalog
 
     warehouse_path = tmp_path / "warehouse"
     warehouse_path.mkdir()


### PR DESCRIPTION
- Use standards compliant `project` table supported since [poetry 2.0](https://github.com/python-poetry/poetry/releases/tag/2.0.0) released in Jan 2025 and update the poetry version in the documentation
- Remove redundant python version specifiers for tools that support the `project.requires-python` field, namely [black](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#command-line-options), [ruff](https://docs.astral.sh/ruff/settings/#target-version), [ty](https://docs.astral.sh/ty/python-version/#python-version)
- Remove the [deprecated](https://packaging.python.org/en/latest/specifications/pyproject-toml/#classifiers) license classifier

I verified that `poetry build` produces the correct wheel and source distributions