### PR TITLE
chore(ci): declare contents: read on test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
 env:
   MPLBACKEND: "Agg"
 
+permissions:
+  contents: read
+
 jobs:
   released:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Hardens `test.yml` by declaring the minimum `GITHUB_TOKEN` scope it needs.

The workflow already runs read-only (checkout + test). Without an explicit `permissions:` block, the run inherits the repo's default token permission. On older repositories that default is permissive read-write, which means any action invoked inside the job could in principle use the token to commit back to the branch, open issues, or modify releases. Whether that ever happens in practice depends on the supply chain of every action used in the workflow.

The fix: add `permissions: contents: read` at the top level. That tightens the scope to exactly what the workflow consumes. If a future step adds a genuinely write-scoped operation, the override can be added at the job level with explicit justification.

References:
- GitHub token hardening guide: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- OpenSSF Scorecard (Token-Permissions)
- the tj-actions/changed-files supply-chain incident from March 2025

YAML validated with `yaml.safe_load`. No other edits in the PR.
