### PR TITLE
Make mypy reject `float(Series)` calls

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -21,6 +21,7 @@ from datetime import (
     timedelta,
 )
 from pathlib import Path
+import sys
 from typing import (
     Any,
     ClassVar,
@@ -357,6 +358,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     # Same as above but for int() and float()
     __float__: ClassVar[None]
     __int__: ClassVar[None]
+    if sys.version_info < (3, 14):
+        __trunc__: ClassVar[None]
     __buffer__: ClassVar[None]
     __hash__: ClassVar[None]  # pyright: ignore[reportIncompatibleMethodOverride]
 

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -354,6 +354,10 @@ _DataLike: TypeAlias = ArrayLike | dict[str, np_ndarray] | SequenceNotStr[S1]
 class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     # Define __index__ because mypy thinks Series follows protocol `SupportsIndex` https://github.com/pandas-dev/pandas-stubs/pull/1332#discussion_r2285648790
     __index__: ClassVar[None]
+    # Same as above but for int() and float()
+    __float__: ClassVar[None]
+    __int__: ClassVar[None]
+    __buffer__: ClassVar[None]
     __hash__: ClassVar[None]  # pyright: ignore[reportIncompatibleMethodOverride]
 
     @overload

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -21,7 +21,6 @@ from datetime import (
     timedelta,
 )
 from pathlib import Path
-import sys
 from typing import (
     Any,
     ClassVar,
@@ -355,12 +354,16 @@ _DataLike: TypeAlias = ArrayLike | dict[str, np_ndarray] | SequenceNotStr[S1]
 class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     # Define __index__ because mypy thinks Series follows protocol `SupportsIndex` https://github.com/pandas-dev/pandas-stubs/pull/1332#discussion_r2285648790
     __index__: ClassVar[None]
-    # Same as above but for int() and float()
+    # Same as above to prevent primitive conversions of Series
+    # such as int(), float(), complex(), math.trunc(), etc.
+    __complex__: ClassVar[None]
     __float__: ClassVar[None]
     __int__: ClassVar[None]
-    if sys.version_info < (3, 14):
-        __trunc__: ClassVar[None]
+    __trunc__: ClassVar[None]
+    __ceil__: ClassVar[None]
+    __floor__: ClassVar[None]
     __buffer__: ClassVar[None]
+
     __hash__: ClassVar[None]  # pyright: ignore[reportIncompatibleMethodOverride]
 
     @overload

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -3809,3 +3809,15 @@ def test_series_copy_deprecated() -> None:
         _7 = s.astype(int, copy=True)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportUnknownVariableType]
         # swaplevel
         _8 = s.swaplevel(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType]
+
+
+def test_series_float_protocols() -> None:
+    s1 = pd.Series([1, 2, 3])
+    if TYPE_CHECKING_INVALID_USAGE:
+        float(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        int(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+    s2: pd.Series[Any] = pd.Series([1, 2, 3])
+    if TYPE_CHECKING_INVALID_USAGE:
+        float(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        int(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -3813,28 +3813,34 @@ def test_series_copy_deprecated() -> None:
 
 
 def test_series_primitive_conversions() -> None:
-    s1 = pd.Series([1, 2, 3])
-    check(assert_type(str(s1), str), str)
-    check(assert_type(bytes(s1), bytes), bytes)
-    check(assert_type(bytearray(s1), bytearray), bytearray)
+    s_int = pd.Series([1, 2, 3])
+    check(assert_type(str(s_int), str), str)
+    check(assert_type(bytes(s_int), bytes), bytes)
+    check(assert_type(bytearray(s_int), bytearray), bytearray)
     if TYPE_CHECKING_INVALID_USAGE:
-        int(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
-        float(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        complex(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
-        math.trunc(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        math.ceil(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
-        math.floor(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
-        memoryview(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        int(s_int)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
+        float(s_int)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        complex(s_int)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        math.trunc(s_int)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        math.ceil(s_int)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        math.floor(s_int)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        memoryview(s_int)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
-    s2: pd.Series[Any] = pd.Series([1, 2, 3])
-    check(assert_type(str(s2), str), str)
-    check(assert_type(bytes(s2), bytes), bytes)
-    check(assert_type(bytearray(s2), bytearray), bytearray)
+    s_any: pd.Series[Any] = pd.Series([1, 2, 3])
+    check(assert_type(str(s_any), str), str)
+    check(assert_type(bytes(s_any), bytes), bytes)
+    check(assert_type(bytearray(s_any), bytearray), bytearray)
     if TYPE_CHECKING_INVALID_USAGE:
-        int(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
-        float(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        complex(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
-        math.trunc(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        math.ceil(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
-        math.floor(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
-        memoryview(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        int(s_any)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
+        float(s_any)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        complex(s_any)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        math.trunc(s_any)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        math.ceil(s_any)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        math.floor(s_any)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        memoryview(s_any)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+
+    s_float = pd.Series([1.5, 2.5, 3.5])
+    check(assert_type(str(s_float), str), str)
+    if TYPE_CHECKING_INVALID_USAGE:
+        bytes(s_float)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        bytearray(s_float)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -3815,9 +3815,9 @@ def test_series_float_protocols() -> None:
     s1 = pd.Series([1, 2, 3])
     if TYPE_CHECKING_INVALID_USAGE:
         float(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        int(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        int(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
 
     s2: pd.Series[Any] = pd.Series([1, 2, 3])
     if TYPE_CHECKING_INVALID_USAGE:
         float(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
-        int(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        int(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -13,6 +13,7 @@ import datetime
 from decimal import Decimal
 from enum import Enum
 import io
+import math
 from pathlib import Path
 import re
 from typing import (
@@ -3811,13 +3812,21 @@ def test_series_copy_deprecated() -> None:
         _8 = s.swaplevel(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType]
 
 
-def test_series_float_protocols() -> None:
+def test_series_primitive_conversions_prohibited() -> None:
     s1 = pd.Series([1, 2, 3])
     if TYPE_CHECKING_INVALID_USAGE:
-        float(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
         int(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
+        float(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        complex(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        math.trunc(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        math.ceil(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        math.floor(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
 
     s2: pd.Series[Any] = pd.Series([1, 2, 3])
     if TYPE_CHECKING_INVALID_USAGE:
-        float(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
         int(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
+        float(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        complex(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        math.trunc(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
+        math.ceil(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        math.floor(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -3821,6 +3821,7 @@ def test_series_primitive_conversions_prohibited() -> None:
         math.trunc(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
         math.ceil(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
         math.floor(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        memoryview(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
     s2: pd.Series[Any] = pd.Series([1, 2, 3])
     if TYPE_CHECKING_INVALID_USAGE:
@@ -3830,3 +3831,4 @@ def test_series_primitive_conversions_prohibited() -> None:
         math.trunc(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
         math.ceil(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
         math.floor(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue]
+        memoryview(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -3812,8 +3812,11 @@ def test_series_copy_deprecated() -> None:
         _8 = s.swaplevel(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType]
 
 
-def test_series_primitive_conversions_prohibited() -> None:
+def test_series_primitive_conversions() -> None:
     s1 = pd.Series([1, 2, 3])
+    check(assert_type(str(s1), str), str)
+    check(assert_type(bytes(s1), bytes), bytes)
+    check(assert_type(bytearray(s1), bytearray), bytearray)
     if TYPE_CHECKING_INVALID_USAGE:
         int(s1)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
         float(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
@@ -3824,6 +3827,9 @@ def test_series_primitive_conversions_prohibited() -> None:
         memoryview(s1)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]
 
     s2: pd.Series[Any] = pd.Series([1, 2, 3])
+    check(assert_type(str(s2), str), str)
+    check(assert_type(bytes(s2), bytes), bytes)
+    check(assert_type(bytearray(s2), bytearray), bytearray)
     if TYPE_CHECKING_INVALID_USAGE:
         int(s2)  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
         float(s2)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
Similar to the SupportsIndex problem solved by explicit `__index__: ClassVar[None]` addition, there are other magic methods worth explicitly removing. I propose four more: `__float__`, `__int__`, `__trunc__` (pre-3.14 alternative integer conversion), and `__buffer__`. This will ban doing `int(series)` and `float(series)` for `Series[Any]`.

Those already raise an error with `pyright`, and `mypy` does not pick them up due to `__getattr__`. Neither of typechecker implementations is obviously correct (because direct access to protocol member - `series.__float__` - will indeed return a member named `__float__` if it exists), so I suggest to pick an approach that helps all popular checkers.

I'm not a bot, you may have met me in mypy before:)