### PR TITLE
Allow SQLAlchemy types in DataFrame.to_sql dtype

### DIFF
--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -27,14 +27,14 @@ from pandas import Index
 from pandas.core.resample import DatetimeIndexResampler
 from pandas.core.series import Series
 from sqlalchemy.engine import Connectable
-from sqlalchemy.types import TypeEngine
+from sqlalchemy.sql.type_api import TypeEngineMixin
 
 from pandas._libs.lib import NoDefault
 from pandas._typing import (
     Axis,
     CompressionOptions,
     CSVQuoting,
-    DtypeArg,
+    Dtype,
     DtypeBackend,
     ExcelWriterMergeCells,
     FilePath,
@@ -177,7 +177,11 @@ class NDFrame:
         index_label: IndexLabel = None,
         chunksize: int | None = None,
         dtype: (
-            DtypeArg | Mapping[Hashable, type[TypeEngine[Any]] | TypeEngine[Any]] | None
+            Dtype
+            | type[TypeEngineMixin]
+            | TypeEngineMixin
+            | Mapping[Hashable, Dtype | type[TypeEngineMixin] | TypeEngineMixin]
+            | None
         ) = None,
         method: (
             Literal["multi"]

--- a/pandas-stubs/core/generic.pyi
+++ b/pandas-stubs/core/generic.pyi
@@ -27,6 +27,7 @@ from pandas import Index
 from pandas.core.resample import DatetimeIndexResampler
 from pandas.core.series import Series
 from sqlalchemy.engine import Connectable
+from sqlalchemy.types import TypeEngine
 
 from pandas._libs.lib import NoDefault
 from pandas._typing import (
@@ -175,7 +176,9 @@ class NDFrame:
         index: _bool = True,
         index_label: IndexLabel = None,
         chunksize: int | None = None,
-        dtype: DtypeArg | None = None,
+        dtype: (
+            DtypeArg | Mapping[Hashable, type[TypeEngine[Any]] | TypeEngine[Any]] | None
+        ) = None,
         method: (
             Literal["multi"]
             | Callable[

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1246,6 +1246,28 @@ def test_read_sql_via_sqlalchemy_engine_with_params(tmp_path: Path) -> None:
     engine.dispose()
 
 
+def test_to_sql_dtype_sqlalchemy_type(tmp_path: Path) -> None:
+    path_str = str(tmp_path / str(uuid.uuid4()))
+    db_uri = "sqlite:///" + path_str
+    engine = sqlalchemy.create_engine(db_uri)
+
+    check(
+        assert_type(
+            DF.to_sql(
+                "test",
+                con=engine,
+                dtype={
+                    "a": sqlalchemy.types.VARCHAR(16),
+                    "b": sqlalchemy.types.INTEGER,
+                },
+            ),
+            int | None,
+        ),
+        int,
+    )
+    engine.dispose()
+
+
 def test_read_sql_generator(tmp_path: Path) -> None:
     path_str = str(tmp_path / str(uuid.uuid4()))
     con = sqlite3.connect(path_str)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1281,6 +1281,16 @@ def test_to_sql_dtype_sqlalchemy_type(tmp_path: Path) -> None:
         ),
         int,
     )
+    df_int_cols = DataFrame({0: [1, 2, 3]})
+    check(
+        assert_type(
+            df_int_cols.to_sql(
+                "test_non_str_key", con=engine, dtype={0: sqlalchemy.types.INTEGER}
+            ),
+            int | None,
+        ),
+        int,
+    )
     engine.dispose()
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1265,6 +1265,22 @@ def test_to_sql_dtype_sqlalchemy_type(tmp_path: Path) -> None:
         ),
         int,
     )
+    check(
+        assert_type(
+            DF.to_sql(
+                "test_scalar_instance", con=engine, dtype=sqlalchemy.types.VARCHAR(16)
+            ),
+            int | None,
+        ),
+        int,
+    )
+    check(
+        assert_type(
+            DF.to_sql("test_scalar_class", con=engine, dtype=sqlalchemy.types.INTEGER),
+            int | None,
+        ),
+        int,
+    )
     engine.dispose()
 
 


### PR DESCRIPTION
- [x] Closes #1762
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

`DataFrame.to_sql` passes its `dtype` mapping straight through to SQLAlchemy, so the values can be SQLAlchemy types (either the class or an instance like `NVARCHAR(length=1024)`), but the stub only accepted `DtypeArg`. Widen the `dtype` parameter to also allow a column mapping of `TypeEngine` classes/instances.
