### PR TITLE
Remove `pyrefly: ignore-errors` in `test_io.py`

### DIFF
--- a/pandas-stubs/io/json/_json.pyi
+++ b/pandas-stubs/io/json/_json.pyi
@@ -4,7 +4,6 @@ from collections.abc import (
 )
 from types import TracebackType
 from typing import (
-    Any,
     Generic,
     Literal,
     overload,
@@ -229,7 +228,7 @@ def read_json(
     engine: Literal["pyarrow"],
 ) -> DataFrame: ...
 
-class JsonReader(Iterator[Any], Generic[NDFrameT]):
+class JsonReader(Iterator[NDFrameT], Generic[NDFrameT]):
     def read(self) -> NDFrameT: ...
     def close(self) -> None: ...
     def __iter__(self) -> JsonReader[NDFrameT]: ...

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,4 +1,3 @@
-# pyrefly: ignore-errors
 from collections import defaultdict
 from collections.abc import Generator
 import csv
@@ -267,8 +266,8 @@ def test_clipboard() -> None:
     DF.to_clipboard(quoting=csv.QUOTE_ALL)
     DF.to_clipboard(sep=",", index=False)
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.read_clipboard(names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
-        pd.read_clipboard(usecols="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
+        pd.read_clipboard(names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        pd.read_clipboard(usecols="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
 
 
 def test_clipboard_iterator() -> None:
@@ -535,7 +534,12 @@ def test_parquet_to_pandas() -> None:
     """Test passing `to_pandas_kwargs` in read_parquet."""
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = read_parquet(Path(), to_pandas_kwargs={"categories": ["a", "b"]})  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType]
+        _0 = read_parquet(  # type: ignore[call-overload]
+            Path(),
+            to_pandas_kwargs={  # pyrefly: ignore[bad-argument-type]
+                "categories": ["a", "b"]
+            },  # pyright: ignore[reportArgumentType]
+        )
 
 
 def test_parquet_options(tmp_path: Path) -> None:
@@ -589,7 +593,7 @@ def test_read_csv(tmp_path: Path) -> None:
     pd.read_csv(path_str, usecols=cols)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.read_csv(path_str, keep_date_col=False)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue]
+        pd.read_csv(path_str, keep_date_col=False)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
 def test_read_csv_iterator(tmp_path: Path) -> None:
@@ -728,8 +732,8 @@ def test_types_read_csv_num(tmp_path: Path) -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.read_csv(path_str, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
-        pd.read_csv(path_str, usecols="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
+        pd.read_csv(path_str, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        pd.read_csv(path_str, usecols="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
 
         def cols2(x: set[float]) -> bool:
             return sum(x) < 1.0
@@ -853,8 +857,8 @@ def test_read_table(tmp_path: Path) -> None:
         DataFrame,
     )
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.read_table(path_str, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
-        pd.read_table(path_str, usecols="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
+        pd.read_table(path_str, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        pd.read_table(path_str, usecols="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
 
 
 def test_read_table_iterator(tmp_path: Path) -> None:
@@ -1034,7 +1038,7 @@ def test_read_excel(tmp_path: Path) -> None:
         pd.DataFrame,
     )
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.read_excel(path_str, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
+        pd.read_excel(path_str, names="abcd")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
 
 
 def test_read_excel_io_types(tmp_path: Path) -> None:
@@ -1116,7 +1120,7 @@ def test_excel_writer(tmp_path: Path) -> None:
     check(assert_type(read_excel(ef), DataFrame), DataFrame)
     check(assert_type(ef.close(), None), type(None))
     if TYPE_CHECKING_INVALID_USAGE:
-        _ = ef.parse  # type: ignore[attr-defined] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType]
+        _ = ef.parse  # type: ignore[attr-defined] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] # pyrefly: ignore[missing-attribute]
 
 
 def test_excel_writer_io() -> None:
@@ -1698,9 +1702,9 @@ def test_read_json_engine() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.read_json(dd, lines=False, engine="pyarrow")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType, reportCallIssue]
-        pd.read_json(io.StringIO(data), engine="pyarrow")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType]
-        pd.read_json(io.StringIO(data), lines=True, engine="pyarrow")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType, reportCallIssue]
+        pd.read_json(dd, lines=False, engine="pyarrow")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType, reportCallIssue] # pyrefly: ignore[no-matching-overload]
+        pd.read_json(io.StringIO(data), engine="pyarrow")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        pd.read_json(io.StringIO(data), lines=True, engine="pyarrow")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType, reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
 def test_converters_partial(tmp_path: Path) -> None:


### PR DESCRIPTION
In most of these cases, they're in `TYPE_CHECKING_INVALID_USAGE`, so the same ignores for mypy/pyright need applying

There's one case where, because `JsonReader` inherits from `Iterator[Any]`, pyrefly was reporting `__iter__` return type as `Any`. `ty` also flags an error there - the fix is just to make it `Iterator[NDFrameT]` 

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
