### PR TITLE
TST: #1767 enable `pyrefly` in `tests\test_natype.py` and `tests\arrays\test_floating.py`

### DIFF
--- a/tests/arrays/test_floating.py
+++ b/tests/arrays/test_floating.py
@@ -1,4 +1,3 @@
-# pyrefly: ignore-errors
 from collections import UserList
 from collections.abc import (
     Callable,
@@ -67,7 +66,7 @@ def test_construction_sequence_nan(
     data: tuple[Any, ...], typ: Callable[[Sequence[Any]], Sequence[Any]]
 ) -> None:
     # can't use assert_type as mypy sees the result as Any while pyright matches to FloatingArray
-    check(assert_type(pd.array(typ(data)), FloatingArray), FloatingArray)  # type: ignore[assert-type]
+    check(assert_type(pd.array(typ(data)), FloatingArray), FloatingArray)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
 
     if TYPE_CHECKING:
         assert_type(pd.array([]), FloatingArray)

--- a/tests/test_natype.py
+++ b/tests/test_natype.py
@@ -84,6 +84,7 @@ def test_arithmetic() -> None:
 
     # __divmod__
     check(assert_type(divmod(na, s_int), tuple[pd.Series, pd.Series]), tuple, pd.Series)
+    # TODO: facebook/pyrefly#3822
     check(
         assert_type(  # pyrefly: ignore[assert-type]
             divmod(na, idx_int), tuple[pd.Index, pd.Index]
@@ -91,6 +92,7 @@ def test_arithmetic() -> None:
         tuple,
         pd.Index,
     )
+    # TODO: microsoft/pyright#10899 facebook/pyrefly#3822
     check(
         assert_type(  # pyright: ignore[reportUnknownArgumentType] # pyrefly: ignore[assert-type]
             divmod(  # pyright: ignore[reportCallIssue, reportAssertTypeFailure] # pyrefly: ignore[no-matching-overload]

--- a/tests/test_natype.py
+++ b/tests/test_natype.py
@@ -1,4 +1,3 @@
-# pyrefly: ignore-errors
 from typing import (
     Literal,
     assert_type,
@@ -84,25 +83,17 @@ def test_arithmetic() -> None:
     check(assert_type(1 % na, NAType), NAType)
 
     # __divmod__
+    check(assert_type(divmod(na, s_int), tuple[pd.Series, pd.Series]), tuple, pd.Series)
     check(
-        assert_type(
-            divmod(na, s_int),
-            tuple[pd.Series, pd.Series],
-        ),
-        tuple,
-        pd.Series,
-    )
-    check(
-        assert_type(
-            divmod(na, idx_int),
-            tuple[pd.Index, pd.Index],
+        assert_type(  # pyrefly: ignore[assert-type]
+            divmod(na, idx_int), tuple[pd.Index, pd.Index]
         ),
         tuple,
         pd.Index,
     )
     check(
-        assert_type(  # pyright: ignore[reportUnknownArgumentType]
-            divmod(  # pyright: ignore[reportCallIssue, reportAssertTypeFailure]
+        assert_type(  # pyright: ignore[reportUnknownArgumentType] # pyrefly: ignore[assert-type]
+            divmod(  # pyright: ignore[reportCallIssue, reportAssertTypeFailure] # pyrefly: ignore[no-matching-overload]
                 na, 1  # pyright: ignore[reportArgumentType]
             ),
             tuple[NAType, NAType],


### PR DESCRIPTION
Not sure if we want to report the potential issues with `divmod` and in `tests\arrays\test_floating.py`.