### PR TITLE
TYP: refactor string methods

### DIFF
--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -60,11 +60,10 @@ from pandas.core.indexes.category import CategoricalIndex
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.frozen import FrozenList
 from pandas.core.indexes.interval import IntervalIndex
-from pandas.core.indexes.multi import MultiIndex
 from pandas.core.indexes.period import PeriodIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.series import Series
-from pandas.core.strings.accessor import StringMethods
+from pandas.core.strings.accessor import StrDescriptor
 
 from pandas._libs.interval import Interval
 from pandas._libs.tslibs.period import Period
@@ -347,20 +346,7 @@ class Index(IndexOpsMixin[S1], ElementOpsMixin[S1]):
         name: Hashable = None,
         tupleize_cols: bool = True,
     ) -> Self: ...
-    @property
-    def str(
-        self,
-    ) -> StringMethods[
-        S1,
-        Self,
-        MultiIndex,
-        np_1darray_bool,
-        Index[list[_str]],
-        Index[int],
-        Index[bytes],
-        Index[_str],
-        Index,
-    ]: ...
+    str = StrDescriptor()
     @final
     def is_(self, other: Any) -> bool: ...
     def __len__(self) -> int: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -119,7 +119,7 @@ from pandas.core.indexing import _IndexSliceTuple  # pyright: ignore[reportPriva
 from pandas.core.indexing import _LocIndexer  # pyright: ignore[reportPrivateUsage]
 from pandas.core.indexing import _iAtIndexer  # pyright: ignore[reportPrivateUsage]
 from pandas.core.indexing import _iLocIndexer  # pyright: ignore[reportPrivateUsage]
-from pandas.core.strings.accessor import StringMethods
+from pandas.core.strings.accessor import StrDescriptor
 from pandas.core.window import (
     Expanding,
     ExponentialMovingWindow,
@@ -1470,20 +1470,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         how: ToTimestampHow = "start",
     ) -> Series[S1]: ...
     def to_period(self, freq: PeriodFrequency | None = None) -> DataFrame: ...
-    @property
-    def str(
-        self,
-    ) -> StringMethods[
-        S1,
-        Self,
-        DataFrame,
-        Series[bool],
-        Series[list[_str]],
-        Series[int],
-        Series[bytes],
-        Series[_str],
-        Series,
-    ]: ...
+    str = StrDescriptor()
     dt = DtDescriptor()
     @property
     def plot(self) -> PlotAccessor: ...

--- a/pandas-stubs/core/strings/accessor.pyi
+++ b/pandas-stubs/core/strings/accessor.pyi
@@ -10,18 +10,15 @@ from typing import (
     Generic,
     Literal,
     Never,
-    TypeVar,
     overload,
+    type_check_only,
 )
 
-import pandas as pd
-from pandas import (
-    DataFrame,
-    Index,
-    MultiIndex,
-    Series,
-)
 from pandas.core.base import NoNewAttributesMixin
+from pandas.core.frame import DataFrame
+from pandas.core.indexes.base import Index
+from pandas.core.indexes.multi import MultiIndex
+from pandas.core.series import Series
 
 from pandas._libs.missing import NAType
 from pandas._libs.tslibs.nattype import NaTType
@@ -31,48 +28,17 @@ from pandas._typing import (
     Dtype,
     DtypeObj,
     Scalar,
-    T,
     np_1darray_bool,
     np_ndarray_str,
 )
 
-# Used for the result of str.split with expand=True
-_T_EXPANDING = TypeVar("_T_EXPANDING", bound=DataFrame | MultiIndex)
-# Used for the result of str.split with expand=False
-_T_LIST_STR = TypeVar("_T_LIST_STR", bound=Series[list[str]] | Index[list[str]])
-# Used for the result of str.match
-_T_BOOL = TypeVar("_T_BOOL", bound=Series[bool] | np_1darray_bool)
-# Used for the result of str.index / str.find
-_T_INT = TypeVar("_T_INT", bound=Series[int] | Index[int])
-# Used for the result of str.encode
-_T_BYTES = TypeVar("_T_BYTES", bound=Series[bytes] | Index[bytes])
-# Used for the result of str.decode
-_T_STR = TypeVar("_T_STR", bound=Series[str] | Index[str])
-# Used for the result of str.partition
-_T_OBJECT = TypeVar("_T_OBJECT", bound=Series | Index)
-
-class StringMethods(
-    NoNewAttributesMixin,
-    Generic[
-        S2, T, _T_EXPANDING, _T_BOOL, _T_LIST_STR, _T_INT, _T_BYTES, _T_STR, _T_OBJECT
-    ],
-):
-    def __init__(self, data: T) -> None: ...
-    def __getitem__(self, key: _slice | int) -> _T_STR: ...
+@type_check_only
+class IndexStringMethods(NoNewAttributesMixin, Generic[S2]):
+    def __getitem__(self, key: _slice | int) -> Index[str]: ...
     def __iter__(self) -> Never: ...
     @overload
     def cat(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         others: None = None,
         sep: str | None = None,
         na_rep: str | None = None,
@@ -80,523 +46,162 @@ class StringMethods(
     ) -> str: ...
     @overload
     def cat(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        others: list[str] | np_ndarray_str | Series[str] | Index[str] | pd.DataFrame,
+        self: IndexStringMethods[str],
+        others: list[str] | np_ndarray_str | Index[str] | DataFrame,
         sep: str | None = None,
         na_rep: str | None = None,
         join: AlignJoin = "left",
-    ) -> _T_STR: ...
+    ) -> Index[str]: ...
     @overload
     def split(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | re.Pattern[str] | None = None,
         *,
         n: int = -1,
         expand: Literal[True],
         regex: bool | None = None,
-    ) -> _T_EXPANDING: ...
+    ) -> MultiIndex: ...
     @overload
     def split(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | re.Pattern[str] | None = None,
         *,
         n: int = -1,
         expand: Literal[False] = False,
         regex: bool | None = None,
-    ) -> _T_LIST_STR: ...
+    ) -> Index[list[str]]: ...
     @overload
     def rsplit(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | None = None,
         *,
         n: int = -1,
         expand: Literal[True],
-    ) -> _T_EXPANDING: ...
+    ) -> MultiIndex: ...
     @overload
     def rsplit(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | None = None,
         *,
         n: int = -1,
         expand: Literal[False] = False,
-    ) -> _T_LIST_STR: ...
+    ) -> Index[list[str]]: ...
     @overload  # expand=True
     def partition(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sep: str = " ",
-        expand: Literal[True] = True,
-    ) -> _T_EXPANDING: ...
+        self: IndexStringMethods[str], sep: str = " ", expand: Literal[True] = True
+    ) -> MultiIndex: ...
     @overload  # expand=False (positional argument)
     def partition(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sep: str,
-        expand: Literal[False],
-    ) -> _T_OBJECT: ...
+        self: IndexStringMethods[str], sep: str, expand: Literal[False]
+    ) -> Index: ...
     @overload  # expand=False (keyword argument)
-    def partition(self, sep: str = " ", *, expand: Literal[False]) -> _T_OBJECT: ...
+    def partition(self, sep: str = " ", *, expand: Literal[False]) -> Index: ...
     @overload  # expand=True
     def rpartition(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sep: str = " ",
-        expand: Literal[True] = True,
-    ) -> _T_EXPANDING: ...
+        self: IndexStringMethods[str], sep: str = " ", expand: Literal[True] = True
+    ) -> MultiIndex: ...
     @overload  # expand=False (positional argument)
     def rpartition(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sep: str,
-        expand: Literal[False],
-    ) -> _T_OBJECT: ...
+        self: IndexStringMethods[str], sep: str, expand: Literal[False]
+    ) -> Index: ...
     @overload  # expand=False (keyword argument)
     def rpartition(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sep: str = " ",
-        *,
-        expand: Literal[False],
-    ) -> _T_OBJECT: ...
-    def get(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        i: int | Hashable,
-    ) -> _T_STR: ...
-    def join(self, sep: str) -> _T_STR: ...
+        self: IndexStringMethods[str], sep: str = " ", *, expand: Literal[False]
+    ) -> Index: ...
+    def get(self: IndexStringMethods[str], i: int | Hashable) -> Index[str]: ...
+    def join(self, sep: str) -> Index[str]: ...
     def contains(
-        self: (
-            StringMethods[
-                float | str,
-                T,
-                _T_EXPANDING,
-                _T_BOOL,
-                _T_LIST_STR,
-                _T_INT,
-                _T_BYTES,
-                _T_STR,
-                _T_OBJECT,
-            ]
-            | StringMethods[
-                str,
-                T,
-                _T_EXPANDING,
-                _T_BOOL,
-                _T_LIST_STR,
-                _T_INT,
-                _T_BYTES,
-                _T_STR,
-                _T_OBJECT,
-            ]
-        ),
+        self: IndexStringMethods[float | str] | IndexStringMethods[str],
         pat: str | re.Pattern[str],
         case: bool = True,
         flags: int = 0,
         na: float | NAType | NaTType | bool | None = ...,
         regex: bool = True,
-    ) -> _T_BOOL: ...
+    ) -> np_1darray_bool: ...
     def match(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | re.Pattern[str],
         case: bool = True,
         flags: int = 0,
         na: Scalar | NaTType | None = ...,
-    ) -> _T_BOOL: ...
+    ) -> np_1darray_bool: ...
     def fullmatch(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | re.Pattern[str],
         case: bool = True,
         flags: int = 0,
         na: Scalar | NaTType | None = ...,
-    ) -> _T_BOOL: ...
+    ) -> np_1darray_bool: ...
     @overload
     def replace(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: dict[str, str],
         repl: None = None,
         n: int = -1,
         case: bool | None = None,
         flags: int = 0,
         regex: bool = False,
-    ) -> _T_STR: ...
+    ) -> Index[str]: ...
     @overload
     def replace(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | re.Pattern[str],
         repl: str | Callable[[re.Match[str]], str] | None = None,
         n: int = -1,
         case: bool | None = None,
         flags: int = 0,
         regex: bool = False,
-    ) -> _T_STR: ...
+    ) -> Index[str]: ...
     def repeat(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        repeats: int | Sequence[int],
-    ) -> _T_STR: ...
+        self: IndexStringMethods[str], repeats: int | Sequence[int]
+    ) -> Index[str]: ...
     def pad(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         width: int,
         side: Literal["left", "right", "both"] = "left",
         fillchar: str = " ",
-    ) -> _T_STR: ...
+    ) -> Index[str]: ...
     def center(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        width: int,
-        fillchar: str = " ",
-    ) -> _T_STR: ...
+        self: IndexStringMethods[str], width: int, fillchar: str = " "
+    ) -> Index[str]: ...
     def ljust(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        width: int,
-        fillchar: str = " ",
-    ) -> _T_STR: ...
+        self: IndexStringMethods[str], width: int, fillchar: str = " "
+    ) -> Index[str]: ...
     def rjust(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        width: int,
-        fillchar: str = " ",
-    ) -> _T_STR: ...
-    def zfill(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        width: int,
-    ) -> _T_STR: ...
+        self: IndexStringMethods[str], width: int, fillchar: str = " "
+    ) -> Index[str]: ...
+    def zfill(self: IndexStringMethods[str], width: int) -> Index[str]: ...
     def slice(
-        self,
-        start: int | None = None,
-        stop: int | None = None,
-        step: int | None = None,
-    ) -> T: ...
+        self, start: int | None = None, stop: int | None = None, step: int | None = None
+    ) -> Index[S2]: ...
     def slice_replace(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         start: int | None = None,
         stop: int | None = None,
         repl: str | None = None,
-    ) -> _T_STR: ...
+    ) -> Index[str]: ...
     def decode(
-        self: StringMethods[
-            bytes,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[bytes],
         encoding: str,
         errors: str = "strict",
         dtype: str | DtypeObj | None = None,
-    ) -> _T_STR: ...
+    ) -> Index[str]: ...
     def encode(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        encoding: str,
-        errors: str = "strict",
-    ) -> _T_BYTES: ...
+        self: IndexStringMethods[str], encoding: str, errors: str = "strict"
+    ) -> Index[bytes]: ...
     def strip(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        to_strip: str | None = None,
-    ) -> _T_STR: ...
+        self: IndexStringMethods[str], to_strip: str | None = None
+    ) -> Index[str]: ...
     def lstrip(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        to_strip: str | None = None,
-    ) -> _T_STR: ...
+        self: IndexStringMethods[str], to_strip: str | None = None
+    ) -> Index[str]: ...
     def rstrip(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        to_strip: str | None = None,
-    ) -> _T_STR: ...
-    def removeprefix(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        prefix: str,
-    ) -> _T_STR: ...
-    def removesuffix(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        suffix: str,
-    ) -> _T_STR: ...
+        self: IndexStringMethods[str], to_strip: str | None = None
+    ) -> Index[str]: ...
+    def removeprefix(self: IndexStringMethods[str], prefix: str) -> Index[str]: ...
+    def removesuffix(self: IndexStringMethods[str], suffix: str) -> Index[str]: ...
     def wrap(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         width: int,
         *,
         # kwargs passed to textwrap.TextWrapper
@@ -605,485 +210,353 @@ class StringMethods(
         drop_whitespace: bool = True,
         break_long_words: bool = True,
         break_on_hyphens: bool = True,
-    ) -> _T_STR: ...
+    ) -> Index[str]: ...
     def get_dummies(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sep: str = "|",
-        dtype: Dtype | None = None,
-    ) -> _T_EXPANDING: ...
+        self: IndexStringMethods[str], sep: str = "|", dtype: Dtype | None = None
+    ) -> MultiIndex: ...
     def translate(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        table: Mapping[int, int | str | None] | None,
-    ) -> _T_STR: ...
+        self: IndexStringMethods[str], table: Mapping[int, int | str | None] | None
+    ) -> Index[str]: ...
     def count(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        pat: str,
-        flags: int = 0,
-    ) -> _T_INT: ...
+        self: IndexStringMethods[str], pat: str, flags: int = 0
+    ) -> Index[int]: ...
     def startswith(
-        self: (
-            StringMethods[
-                float | str,
-                T,
-                _T_EXPANDING,
-                _T_BOOL,
-                _T_LIST_STR,
-                _T_INT,
-                _T_BYTES,
-                _T_STR,
-                _T_OBJECT,
-            ]
-            | StringMethods[
-                str,
-                T,
-                _T_EXPANDING,
-                _T_BOOL,
-                _T_LIST_STR,
-                _T_INT,
-                _T_BYTES,
-                _T_STR,
-                _T_OBJECT,
-            ]
-        ),
+        self: IndexStringMethods[float | str] | IndexStringMethods[str],
         pat: str | tuple[str, ...],
         na: float | NAType | NaTType | bool | None = ...,
-    ) -> _T_BOOL: ...
+    ) -> np_1darray_bool: ...
     def endswith(
-        self: (
-            StringMethods[
-                float | str,
-                T,
-                _T_EXPANDING,
-                _T_BOOL,
-                _T_LIST_STR,
-                _T_INT,
-                _T_BYTES,
-                _T_STR,
-                _T_OBJECT,
-            ]
-            | StringMethods[
-                str,
-                T,
-                _T_EXPANDING,
-                _T_BOOL,
-                _T_LIST_STR,
-                _T_INT,
-                _T_BYTES,
-                _T_STR,
-                _T_OBJECT,
-            ]
-        ),
+        self: IndexStringMethods[float | str] | IndexStringMethods[str],
         pat: str | tuple[str, ...],
         na: float | NAType | NaTType | bool | None = ...,
-    ) -> _T_BOOL: ...
+    ) -> np_1darray_bool: ...
     def findall(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        pat: str | re.Pattern[str],
-        flags: int = 0,
-    ) -> _T_LIST_STR: ...
+        self: IndexStringMethods[str], pat: str | re.Pattern[str], flags: int = 0
+    ) -> Index[list[str]]: ...
     @overload  # expand=True
     def extract(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | re.Pattern[str],
         flags: int = 0,
         expand: Literal[True] = True,
-    ) -> pd.DataFrame: ...
+    ) -> DataFrame: ...
     @overload  # expand=False (positional argument)
     def extract(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | re.Pattern[str],
         flags: int,
         expand: Literal[False],
-    ) -> _T_OBJECT: ...
+    ) -> Index: ...
     @overload  # expand=False (keyword argument)
     def extract(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str],
         pat: str | re.Pattern[str],
         flags: int = 0,
         *,
         expand: Literal[False],
-    ) -> _T_OBJECT: ...
+    ) -> Index: ...
     def extractall(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
+        self: IndexStringMethods[str], pat: str | re.Pattern[str], flags: int = 0
+    ) -> DataFrame: ...
+    def find(
+        self: IndexStringMethods[str], sub: str, start: int = 0, end: int | None = None
+    ) -> Index[int]: ...
+    def rfind(
+        self: IndexStringMethods[str], sub: str, start: int = 0, end: int | None = None
+    ) -> Index[int]: ...
+    def normalize(
+        self: IndexStringMethods[str], form: Literal["NFC", "NFKC", "NFD", "NFKD"]
+    ) -> Index[str]: ...
+    def index(
+        self: IndexStringMethods[str], sub: str, start: int = 0, end: int | None = None
+    ) -> Index[int]: ...
+    def rindex(
+        self: IndexStringMethods[str], sub: str, start: int = 0, end: int | None = None
+    ) -> Index[int]: ...
+    def len(self: IndexStringMethods[str]) -> Index[int]: ...
+    def lower(self: IndexStringMethods[str]) -> Index[str]: ...
+    def upper(self: IndexStringMethods[str]) -> Index[str]: ...
+    def title(self: IndexStringMethods[str]) -> Index[str]: ...
+    def capitalize(self: IndexStringMethods[str]) -> Index[str]: ...
+    def swapcase(self: IndexStringMethods[str]) -> Index[str]: ...
+    def casefold(self: IndexStringMethods[str]) -> Index[str]: ...
+    def isalnum(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def isalpha(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def isdigit(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def isspace(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def islower(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def isupper(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def istitle(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def isnumeric(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def isdecimal(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+    def isascii(self: IndexStringMethods[str]) -> np_1darray_bool: ...
+
+@type_check_only
+class SeriesStringMethods(NoNewAttributesMixin, Generic[S2]):
+    def __getitem__(self, key: _slice | int) -> Series[str]: ...
+    def __iter__(self) -> Never: ...
+    @overload
+    def cat(
+        self: SeriesStringMethods[str],
+        others: None = None,
+        sep: str | None = None,
+        na_rep: str | None = None,
+        join: AlignJoin = "left",
+    ) -> str: ...
+    @overload
+    def cat(
+        self: SeriesStringMethods[str],
+        others: list[str] | np_ndarray_str | Series[str] | Index[str] | DataFrame,
+        sep: str | None = None,
+        na_rep: str | None = None,
+        join: AlignJoin = "left",
+    ) -> Series[str]: ...
+    @overload
+    def split(
+        self: SeriesStringMethods[str],
+        pat: str | re.Pattern[str] | None = None,
+        *,
+        n: int = -1,
+        expand: Literal[True],
+        regex: bool | None = None,
+    ) -> DataFrame: ...
+    @overload
+    def split(
+        self: SeriesStringMethods[str],
+        pat: str | re.Pattern[str] | None = None,
+        *,
+        n: int = -1,
+        expand: Literal[False] = False,
+        regex: bool | None = None,
+    ) -> Series[list[str]]: ...
+    @overload
+    def rsplit(
+        self: SeriesStringMethods[str],
+        pat: str | None = None,
+        *,
+        n: int = -1,
+        expand: Literal[True],
+    ) -> DataFrame: ...
+    @overload
+    def rsplit(
+        self: SeriesStringMethods[str],
+        pat: str | None = None,
+        *,
+        n: int = -1,
+        expand: Literal[False] = False,
+    ) -> Series[list[str]]: ...
+    @overload  # expand=True
+    def partition(
+        self: SeriesStringMethods[str], sep: str = " ", expand: Literal[True] = True
+    ) -> DataFrame: ...
+    @overload  # expand=False (positional argument)
+    def partition(
+        self: SeriesStringMethods[str], sep: str, expand: Literal[False]
+    ) -> Series: ...
+    @overload  # expand=False (keyword argument)
+    def partition(self, sep: str = " ", *, expand: Literal[False]) -> Series: ...
+    @overload  # expand=True
+    def rpartition(
+        self: SeriesStringMethods[str], sep: str = " ", expand: Literal[True] = True
+    ) -> DataFrame: ...
+    @overload  # expand=False (positional argument)
+    def rpartition(
+        self: SeriesStringMethods[str], sep: str, expand: Literal[False]
+    ) -> Series: ...
+    @overload  # expand=False (keyword argument)
+    def rpartition(
+        self: SeriesStringMethods[str], sep: str = " ", *, expand: Literal[False]
+    ) -> Series: ...
+    def get(self: SeriesStringMethods[str], i: int | Hashable) -> Series[str]: ...
+    def join(self, sep: str) -> Series[str]: ...
+    def contains(
+        self: SeriesStringMethods[float | str] | SeriesStringMethods[str],
+        pat: str | re.Pattern[str],
+        case: bool = True,
+        flags: int = 0,
+        na: float | NAType | NaTType | bool | None = ...,
+        regex: bool = True,
+    ) -> Series[bool]: ...
+    def match(
+        self: SeriesStringMethods[str],
+        pat: str | re.Pattern[str],
+        case: bool = True,
+        flags: int = 0,
+        na: Scalar | NaTType | None = ...,
+    ) -> Series[bool]: ...
+    def fullmatch(
+        self: SeriesStringMethods[str],
+        pat: str | re.Pattern[str],
+        case: bool = True,
+        flags: int = 0,
+        na: Scalar | NaTType | None = ...,
+    ) -> Series[bool]: ...
+    @overload
+    def replace(
+        self: SeriesStringMethods[str],
+        pat: dict[str, str],
+        repl: None = None,
+        n: int = -1,
+        case: bool | None = None,
+        flags: int = 0,
+        regex: bool = False,
+    ) -> Series[str]: ...
+    @overload
+    def replace(
+        self: SeriesStringMethods[str],
+        pat: str | re.Pattern[str],
+        repl: str | Callable[[re.Match[str]], str] | None = None,
+        n: int = -1,
+        case: bool | None = None,
+        flags: int = 0,
+        regex: bool = False,
+    ) -> Series[str]: ...
+    def repeat(
+        self: SeriesStringMethods[str], repeats: int | Sequence[int]
+    ) -> Series[str]: ...
+    def pad(
+        self: SeriesStringMethods[str],
+        width: int,
+        side: Literal["left", "right", "both"] = "left",
+        fillchar: str = " ",
+    ) -> Series[str]: ...
+    def center(
+        self: SeriesStringMethods[str], width: int, fillchar: str = " "
+    ) -> Series[str]: ...
+    def ljust(
+        self: SeriesStringMethods[str], width: int, fillchar: str = " "
+    ) -> Series[str]: ...
+    def rjust(
+        self: SeriesStringMethods[str], width: int, fillchar: str = " "
+    ) -> Series[str]: ...
+    def zfill(self: SeriesStringMethods[str], width: int) -> Series[str]: ...
+    def slice(
+        self, start: int | None = None, stop: int | None = None, step: int | None = None
+    ) -> Series[S2]: ...
+    def slice_replace(
+        self: SeriesStringMethods[str],
+        start: int | None = None,
+        stop: int | None = None,
+        repl: str | None = None,
+    ) -> Series[str]: ...
+    def decode(
+        self: SeriesStringMethods[bytes],
+        encoding: str,
+        errors: str = "strict",
+        dtype: str | DtypeObj | None = None,
+    ) -> Series[str]: ...
+    def encode(
+        self: SeriesStringMethods[str], encoding: str, errors: str = "strict"
+    ) -> Series[bytes]: ...
+    def strip(
+        self: SeriesStringMethods[str], to_strip: str | None = None
+    ) -> Series[str]: ...
+    def lstrip(
+        self: SeriesStringMethods[str], to_strip: str | None = None
+    ) -> Series[str]: ...
+    def rstrip(
+        self: SeriesStringMethods[str], to_strip: str | None = None
+    ) -> Series[str]: ...
+    def removeprefix(self: SeriesStringMethods[str], prefix: str) -> Series[str]: ...
+    def removesuffix(self: SeriesStringMethods[str], suffix: str) -> Series[str]: ...
+    def wrap(
+        self: SeriesStringMethods[str],
+        width: int,
+        *,
+        # kwargs passed to textwrap.TextWrapper
+        expand_tabs: bool = True,
+        replace_whitespace: bool = True,
+        drop_whitespace: bool = True,
+        break_long_words: bool = True,
+        break_on_hyphens: bool = True,
+    ) -> Series[str]: ...
+    def get_dummies(
+        self: SeriesStringMethods[str], sep: str = "|", dtype: Dtype | None = None
+    ) -> DataFrame: ...
+    def translate(
+        self: SeriesStringMethods[str], table: Mapping[int, int | str | None] | None
+    ) -> Series[str]: ...
+    def count(
+        self: SeriesStringMethods[str], pat: str, flags: int = 0
+    ) -> Series[int]: ...
+    def startswith(
+        self: SeriesStringMethods[float | str] | SeriesStringMethods[str],
+        pat: str | tuple[str, ...],
+        na: float | NAType | NaTType | bool | None = ...,
+    ) -> Series[bool]: ...
+    def endswith(
+        self: SeriesStringMethods[float | str] | SeriesStringMethods[str],
+        pat: str | tuple[str, ...],
+        na: float | NAType | NaTType | bool | None = ...,
+    ) -> Series[bool]: ...
+    def findall(
+        self: SeriesStringMethods[str], pat: str | re.Pattern[str], flags: int = 0
+    ) -> Series[list[str]]: ...
+    @overload  # expand=True
+    def extract(
+        self: SeriesStringMethods[str],
         pat: str | re.Pattern[str],
         flags: int = 0,
-    ) -> pd.DataFrame: ...
+        expand: Literal[True] = True,
+    ) -> DataFrame: ...
+    @overload  # expand=False (positional argument)
+    def extract(
+        self: SeriesStringMethods[str],
+        pat: str | re.Pattern[str],
+        flags: int,
+        expand: Literal[False],
+    ) -> Series: ...
+    @overload  # expand=False (keyword argument)
+    def extract(
+        self: SeriesStringMethods[str],
+        pat: str | re.Pattern[str],
+        flags: int = 0,
+        *,
+        expand: Literal[False],
+    ) -> Series: ...
+    def extractall(
+        self: SeriesStringMethods[str], pat: str | re.Pattern[str], flags: int = 0
+    ) -> DataFrame: ...
     def find(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sub: str,
-        start: int = 0,
-        end: int | None = None,
-    ) -> _T_INT: ...
+        self: SeriesStringMethods[str], sub: str, start: int = 0, end: int | None = None
+    ) -> Series[int]: ...
     def rfind(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sub: str,
-        start: int = 0,
-        end: int | None = None,
-    ) -> _T_INT: ...
+        self: SeriesStringMethods[str], sub: str, start: int = 0, end: int | None = None
+    ) -> Series[int]: ...
     def normalize(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        form: Literal["NFC", "NFKC", "NFD", "NFKD"],
-    ) -> _T_STR: ...
+        self: SeriesStringMethods[str], form: Literal["NFC", "NFKC", "NFD", "NFKD"]
+    ) -> Series[str]: ...
     def index(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sub: str,
-        start: int = 0,
-        end: int | None = None,
-    ) -> _T_INT: ...
+        self: SeriesStringMethods[str], sub: str, start: int = 0, end: int | None = None
+    ) -> Series[int]: ...
     def rindex(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-        sub: str,
-        start: int = 0,
-        end: int | None = None,
-    ) -> _T_INT: ...
-    def len(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_INT: ...
-    def lower(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_STR: ...
-    def upper(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_STR: ...
-    def title(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_STR: ...
-    def capitalize(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_STR: ...
-    def swapcase(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_STR: ...
-    def casefold(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_STR: ...
-    def isalnum(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def isalpha(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def isdigit(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def isspace(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def islower(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def isupper(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def istitle(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def isnumeric(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def isdecimal(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
-    def isascii(
-        self: StringMethods[
-            str,
-            T,
-            _T_EXPANDING,
-            _T_BOOL,
-            _T_LIST_STR,
-            _T_INT,
-            _T_BYTES,
-            _T_STR,
-            _T_OBJECT,
-        ],
-    ) -> _T_BOOL: ...
+        self: SeriesStringMethods[str], sub: str, start: int = 0, end: int | None = None
+    ) -> Series[int]: ...
+    def len(self: SeriesStringMethods[str]) -> Series[int]: ...
+    def lower(self: SeriesStringMethods[str]) -> Series[str]: ...
+    def upper(self: SeriesStringMethods[str]) -> Series[str]: ...
+    def title(self: SeriesStringMethods[str]) -> Series[str]: ...
+    def capitalize(self: SeriesStringMethods[str]) -> Series[str]: ...
+    def swapcase(self: SeriesStringMethods[str]) -> Series[str]: ...
+    def casefold(self: SeriesStringMethods[str]) -> Series[str]: ...
+    def isalnum(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def isalpha(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def isdigit(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def isspace(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def islower(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def isupper(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def istitle(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def isnumeric(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def isdecimal(self: SeriesStringMethods[str]) -> Series[bool]: ...
+    def isascii(self: SeriesStringMethods[str]) -> Series[bool]: ...
+
+@type_check_only
+class StrDescriptor:
+    @overload
+    def __get__(
+        self, instance: Series[S2], owner: type[Series]
+    ) -> SeriesStringMethods[S2]: ...
+    @overload
+    def __get__(
+        self, instance: Index[S2], owner: type[Index]
+    ) -> IndexStringMethods[S2]: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Stubs Only",
 ]
-dependencies = ["numpy>=1.23.5"]
+dependencies = ["numpy>=1.23.5,<2.5"]
 
 [project.urls]
 Homepage = "https://pandas.pydata.org"


### PR DESCRIPTION
The class of `StringMethods` in `pandas-stubs`-`main` contains quite a few type variables. When we want to fix some of them in `self`, as in pandas-dev/pandas-stubs#1779, they break into one `TypeVar` per line, and the code becomes much longer.

Meanwhile, these type variables serve just to distinguish `Index` and `Series`, the only reason we have so many of them is that type variables cannot be generic.

I propose the current PR to reduce the number of `TypeVar`s to one, by creating `IndexStringMethods` and `SeriesStringMethods` separately. The number of code lines also reduced by several hundred.

Caveats:
1. ~~It seems some irrelevant `mypy` checks are failing~~ edit: caused by incompatible versions of `numpy` and `numpy-typing-compact`
2. `StringMethods`, which is a class in `pandas` and the runtime type of `idx.str` and `sr.str`, now does not exist in the stubs any more. This might be acceptable, because it is [not quite a public class by documentation](https://pandas.pydata.org/pandas-docs/stable/search.html?q=StringMethods); there is no stand-alone page for it.