### PR TITLE
BUG: update `numpy-typing-compat` and cap `numpy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
   "pytz>=2025.2",
   "types-pytz>=2022.1.1",
   "pyiceberg>=0.10.0",
-  "numpy-typing-compat>=20260602.2.4",
+  "numpy-typing-compat>=20260602",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Stubs Only",
 ]
-dependencies = ["numpy>=1.23.5"]
+dependencies = ["numpy>=1.23.5,<2.5"]
 
 [project.urls]
 Homepage = "https://pandas.pydata.org"
@@ -69,6 +69,7 @@ dev = [
   "pytz>=2025.2",
   "types-pytz>=2022.1.1",
   "pyiceberg>=0.10.0",
+  "numpy-typing-compat>=20260602.2.4",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Stubs Only",
 ]
-dependencies = ["numpy>=1.23.5"]
+dependencies = ["numpy>=1.23.5,<2.5"]  # TODO: pandas-dev/pandas-stubs#1786 remove <2.5
 
 [project.urls]
 Homepage = "https://pandas.pydata.org"
@@ -70,7 +70,6 @@ dev = [
   "types-pytz>=2022.1.1",
   "pyiceberg>=0.10.0",
   "numpy-typing-compat>=20260602",
-  "numpy<2.5",  # TODO: pandas-dev/pandas-stubs#1786 to be removed
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Stubs Only",
 ]
-dependencies = ["numpy>=1.23.5,<2.5"]
+dependencies = ["numpy>=1.23.5"]
 
 [project.urls]
 Homepage = "https://pandas.pydata.org"
@@ -70,6 +70,7 @@ dev = [
   "types-pytz>=2022.1.1",
   "pyiceberg>=0.10.0",
   "numpy-typing-compat>=20260602",
+  "numpy<2.5",  # TODO: pandas-dev/pandas-stubs#1786 to be removed
 ]
 
 [build-system]


### PR DESCRIPTION
Pipelines like https://github.com/pandas-dev/pandas-stubs/actions/runs/27935121522/job/82654970732 and https://github.com/pandas-dev/pandas-stubs/actions/runs/27947029379/job/82694274269?pr=1784 because https://github.com/numpy/numpy/releases/tag/v2.5.0 has just been released.
- https://github.com/jorenham/numpy-typing-compat has changed its version format, we need to update
- new `numpy` introduces breaking changes https://github.com/pandas-dev/pandas-stubs/actions/runs/27948511803/job/82699244836