### PR TITLE
Support passing DataFrames to df.clip()

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1982,30 +1982,10 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def clip(
         self,
-        lower: DataFrame | None = ...,
-        upper: DataFrame | None = ...,
+        lower: DataFrame | None = None,
+        upper: DataFrame | None = None,
         *,
-        axis: Axis | None = ...,
-        inplace: bool = False,
-        **kwargs: Any,
-    ) -> Self: ...
-    @overload
-    def clip(
-        self,
-        lower: DataFrame = ...,
-        upper: DataFrame | None = ...,
-        *,
-        axis: Axis | None = ...,
-        inplace: bool = False,
-        **kwargs: Any,
-    ) -> Self: ...
-    @overload
-    def clip(
-        self,
-        lower: DataFrame | None = ...,
-        upper: DataFrame = ...,
-        *,
-        axis: Axis | None = ...,
+        axis: None = None,
         inplace: bool = False,
         **kwargs: Any,
     ) -> Self: ...

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1989,6 +1989,26 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         inplace: bool = False,
         **kwargs: Any,
     ) -> Self: ...
+    @overload
+    def clip(
+        self,
+        lower: DataFrame = ...,
+        upper: DataFrame | None = ...,
+        *,
+        axis: Axis | None = ...,
+        inplace: bool = False,
+        **kwargs: Any,
+    ) -> Self: ...
+    @overload
+    def clip(
+        self,
+        lower: DataFrame | None = ...,
+        upper: DataFrame = ...,
+        *,
+        axis: Axis | None = ...,
+        inplace: bool = False,
+        **kwargs: Any,
+    ) -> Self: ...
     @final
     def copy(self, deep: _bool = True) -> Self: ...
     def cummax(

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1965,7 +1965,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         lower: AnyArrayLike = ...,
         upper: AnyArrayLike | None = ...,
         *,
-        axis: Axis = ...,
+        axis: Axis,
         inplace: bool = False,
         **kwargs: Any,
     ) -> Self: ...
@@ -1975,7 +1975,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         lower: AnyArrayLike | None = ...,
         upper: AnyArrayLike = ...,
         *,
-        axis: Axis = ...,
+        axis: Axis,
         inplace: bool = False,
         **kwargs: Any,
     ) -> Self: ...

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1979,6 +1979,16 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
         inplace: bool = False,
         **kwargs: Any,
     ) -> Self: ...
+    @overload
+    def clip(
+        self,
+        lower: DataFrame | None = ...,
+        upper: DataFrame | None = ...,
+        *,
+        axis: Axis | None = ...,
+        inplace: bool = False,
+        **kwargs: Any,
+    ) -> Self: ...
     @final
     def copy(self, deep: _bool = True) -> Self: ...
     def cummax(

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -780,6 +780,7 @@ def test_types_quantile() -> None:
 def test_dataframe_clip() -> None:
     """Test different clipping combinations for dataframe."""
     df = pd.DataFrame(data={"col1": [20, 12], "col2": [3, 14]})
+    df2 = pd.DataFrame({"col1": [10, 15], "col2": [5, 1]})
     if TYPE_CHECKING_INVALID_USAGE:
         df.clip(lower=pd.Series([4, 5]), upper=None, axis=None)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue, reportArgumentType]
         df.clip(lower=None, upper=pd.Series([4, 5]), axis=None)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue, reportArgumentType]
@@ -878,7 +879,7 @@ def test_dataframe_clip() -> None:
         pd.DataFrame,
     )
     check(
-        assert_type(df.clip(lower=df, upper=df), pd.DataFrame),
+        assert_type(df.clip(lower=df2, upper=df2), pd.DataFrame),
         pd.DataFrame,
     )
     check(
@@ -908,7 +909,7 @@ def test_dataframe_clip() -> None:
         pd.DataFrame,
     )
     check(
-        assert_type(df.clip(lower=df, upper=df, inplace=True), pd.DataFrame),
+        assert_type(df.clip(lower=df2, upper=df2, inplace=True), pd.DataFrame),
         pd.DataFrame,
     )
 
@@ -927,7 +928,7 @@ def test_dataframe_clip() -> None:
     check(assert_type(df.clip(upper=None, axis=0), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.clip(upper=15, axis=0), pd.DataFrame), pd.DataFrame)
     check(
-        assert_type(df.clip(upper=df), pd.DataFrame),
+        assert_type(df.clip(upper=df2), pd.DataFrame),
         pd.DataFrame,
     )
     check(
@@ -963,7 +964,7 @@ def test_dataframe_clip() -> None:
         pd.DataFrame,
     )
     check(
-        assert_type(df.clip(upper=df, inplace=True), pd.DataFrame),
+        assert_type(df.clip(upper=df2, inplace=True), pd.DataFrame),
         pd.DataFrame,
     )
 
@@ -1015,7 +1016,7 @@ def test_dataframe_clip() -> None:
         pd.DataFrame,
     )
     check(
-        assert_type(df.clip(lower=df), pd.DataFrame),
+        assert_type(df.clip(lower=df2), pd.DataFrame),
         pd.DataFrame,
     )
     check(
@@ -1031,7 +1032,7 @@ def test_dataframe_clip() -> None:
         pd.DataFrame,
     )
     check(
-        assert_type(df.clip(lower=df, inplace=True), pd.DataFrame),
+        assert_type(df.clip(lower=df2, inplace=True), pd.DataFrame),
         pd.DataFrame,
     )
 

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -903,6 +903,10 @@ def test_dataframe_clip() -> None:
         assert_type(df.clip(lower=None, upper=15, axis=0, inplace=True), pd.DataFrame),
         pd.DataFrame,
     )
+    check(
+        assert_type(df.clip(lower=df, upper=df, inplace=True), pd.DataFrame),
+        pd.DataFrame,
+    )
 
     # without lower
     check(assert_type(df.clip(upper=None, axis=None), pd.DataFrame), pd.DataFrame)
@@ -948,6 +952,10 @@ def test_dataframe_clip() -> None:
     )
     check(
         assert_type(df.clip(upper=15, axis=0, inplace=True), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.clip(upper=df, inplace=True), pd.DataFrame),
         pd.DataFrame,
     )
 
@@ -1008,6 +1016,10 @@ def test_dataframe_clip() -> None:
     )
     check(
         assert_type(df.clip(lower=5, axis=0, inplace=True), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.clip(lower=df, inplace=True), pd.DataFrame),
         pd.DataFrame,
     )
 

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -878,6 +878,10 @@ def test_dataframe_clip() -> None:
         pd.DataFrame,
     )
     check(
+        assert_type(df.clip(lower=df, upper=df), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
         assert_type(
             df.clip(lower=pd.Series([1, 2]), upper=None, axis="index"), pd.DataFrame
         ),
@@ -922,6 +926,10 @@ def test_dataframe_clip() -> None:
 
     check(assert_type(df.clip(upper=None, axis=0), pd.DataFrame), pd.DataFrame)
     check(assert_type(df.clip(upper=15, axis=0), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.clip(upper=df), pd.DataFrame),
+        pd.DataFrame,
+    )
     check(
         assert_type(df.clip(upper=pd.Series([1, 2]), axis=0), pd.DataFrame),
         pd.DataFrame,
@@ -1004,6 +1012,10 @@ def test_dataframe_clip() -> None:
     )
     check(
         assert_type(df.clip(lower=5, axis="index"), pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(
+        assert_type(df.clip(lower=df), pd.DataFrame),
         pd.DataFrame,
     )
     check(


### PR DESCRIPTION
- [x] Closes #1789
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Extended existing tests and added an overload.

Glad to make any changes if needed!