### PR TITLE
TST: #1799 enable `ty` in `tests/test_windowing.py`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,17 +39,17 @@ jobs:
           os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
 
-      - name: Run mypy on 'tests' (using the local stubs) and on the local stubs
-        run: poetry run poe mypy
-
-      - name: Run ty on 'pandas-stubs' (using the local stubs) and on the local stubs
+      - name: Run ty on 'tests' (using the local stubs) and on the local stubs
         run: poetry run poe ty
 
-      - name: Run pyrefly on the local stubs
+      - name: Run pyrefly on 'tests' (using the local stubs) and on the local stubs
         run: poetry run poe pyrefly
 
       - name: Run pyright on 'tests' (using the local stubs) and on the local stubs
         run: poetry run poe pyright
+
+      - name: Run mypy on 'tests' (using the local stubs) and on the local stubs
+        run: poetry run poe mypy
 
       - name: Run pytest
         run: poetry run poe pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,11 @@ help = "Run all tests"
 script = "scripts.test:run_tests(src=True, dist=True)"
 
 [tool.poe.tasks.test]
-help = "Run local tests (includes 'mypy', 'pyright', 'pytest', and 'style')"
+help = "Run local tests (includes 'mypy', 'pyright', 'pyrefly', 'ty', 'pytest', and 'style')"
 script = "scripts.test:run_tests(src=True)"
 
 [tool.poe.tasks.test_dist]
-help = "Run tests on the installed stubs (includes 'mypy_dist' and 'pyright_dist')"
+help = "Run tests on the installed stubs (includes 'mypy_dist', 'pyright_dist', 'pyrefly_dist' and 'ty_dist')"
 script = "scripts.test:run_tests(dist=True)"
 
 [tool.poe.tasks.pytest]
@@ -102,6 +102,30 @@ args = [
 help = "Run pre-commit"
 script = "scripts.test.run:style"
 
+[tool.poe.tasks.ty]
+help = "Run ty on pandas-stubs"
+script = "scripts.test.run:ty"
+
+[tool.poe.tasks.ty_dist]
+help = "Run ty on 'tests' using the installed stubs"
+script = "scripts.test:run_tests(dist=True, type_checker='ty')"
+
+[tool.poe.tasks.pyrefly]
+help = "Run pyrefly on pandas-stubs"
+script = "scripts.test.run:pyrefly"
+
+[tool.poe.tasks.pyrefly_dist]
+help = "Run pyrefly on 'tests' using the installed stubs"
+script = "scripts.test:run_tests(dist=True, type_checker='pyrefly')"
+
+[tool.poe.tasks.pyright]
+help = "Run pyright on 'tests' (using the local stubs) and on the local stubs"
+script = "scripts.test.run:pyright_src"
+
+[tool.poe.tasks.pyright_dist]
+help = "Run pyright on 'tests' using the installed stubs"
+script = "scripts.test:run_tests(dist=True, type_checker='pyright')"
+
 [tool.poe.tasks.mypy]
 help = "Run mypy on 'tests' (using the local stubs) and on the local stubs"
 args = [
@@ -112,22 +136,6 @@ script = "scripts.test:mypy_src(mypy_nightly)"
 [tool.poe.tasks.mypy_dist]
 help = "Run mypy on 'tests' using the installed stubs"
 script = "scripts.test:run_tests(dist=True, type_checker='mypy')"
-
-[tool.poe.tasks.ty]
-help = "Run ty on pandas-stubs"
-script = "scripts.test.run:ty"
-
-[tool.poe.tasks.pyrefly]
-help = "Run pyrefly on pandas-stubs"
-script = "scripts.test.run:pyrefly"
-
-[tool.poe.tasks.pyright]
-help = "Run pyright on 'tests' (using the local stubs) and on the local stubs"
-script = "scripts.test.run:pyright_src"
-
-[tool.poe.tasks.pyright_dist]
-help = "Run pyright on 'tests' using the installed stubs"
-script = "scripts.test:run_tests(dist=True, type_checker='pyright')"
 
 [tool.poe.tasks.stubtest]
 script = "scripts.test:stubtest(allowlist, check_missing, nightly)"
@@ -342,3 +350,26 @@ possibly-unresolved-reference = "error"
 
 [tool.ty.analysis]
 respect-type-ignore-comments = false
+
+[tool.ty.src]
+exclude = [
+  "tests/__init__.py",
+  "tests/arrays/**/*",
+  "tests/extension/**/*",
+  "tests/frame/**/*",
+  "tests/indexes/**/*",
+  "tests/scalars/**/*",
+  "tests/series/**/*",
+  "tests/test_api_types.py",
+  "tests/test_dtypes.py",
+  "tests/test_extension.py",
+  "tests/test_groupby.py",
+  "tests/test_interval.py",
+  "tests/test_io.py",
+  "tests/test_natype.py",
+  "tests/test_pandas.py",
+  "tests/test_resampler.py",
+  "tests/test_string_accessors.py",
+  "tests/test_testing.py",
+  "tests/test_timefuncs.py",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,16 +103,16 @@ help = "Run pre-commit"
 script = "scripts.test.run:style"
 
 [tool.poe.tasks.ty]
-help = "Run ty on pandas-stubs"
-script = "scripts.test.run:ty"
+help = "Run ty on 'tests' (using the local stubs) and on the local stubs"
+script = "scripts.test.run:ty_src"
 
 [tool.poe.tasks.ty_dist]
 help = "Run ty on 'tests' using the installed stubs"
 script = "scripts.test:run_tests(dist=True, type_checker='ty')"
 
 [tool.poe.tasks.pyrefly]
-help = "Run pyrefly on pandas-stubs"
-script = "scripts.test.run:pyrefly"
+help = "Run pyrefly on 'tests' (using the local stubs) and on the local stubs"
+script = "scripts.test.run:pyrefly_src"
 
 [tool.poe.tasks.pyrefly_dist]
 help = "Run pyrefly on 'tests' using the installed stubs"

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -24,7 +24,7 @@ _DIST_STEPS = [
     _step.install_dist,
     _step.rename_src,
     _step.ty_dist,
-    _step.pyrefly_dist,
+    # _step.pyrefly_dist,
     _step.pyright_dist,
     _step.mypy_dist,
 ]

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -24,7 +24,7 @@ _DIST_STEPS = [
     _step.install_dist,
     _step.rename_src,
     _step.ty_dist,
-    # _step.pyrefly_dist,
+    # _step.pyrefly_dist,  TODO: pandas-dev/pandas-stubs#1801
     _step.pyright_dist,
     _step.mypy_dist,
 ]

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -1,14 +1,20 @@
 import dataclasses
 from functools import partial
-from typing import Literal
+from typing import (
+    TYPE_CHECKING,
+    Literal,
+)
 
 from scripts._job import run_job
 from scripts.test import _step
 
+if TYPE_CHECKING:
+    from scripts._job import Step
+
 _SRC_STEPS = [
-    _step.mypy_src,
     _step.ty_src,
     _step.pyrefly_src,
+    _step.mypy_src,
     _step.pyright_src,
     _step.pytest,
     _step.style,
@@ -17,17 +23,19 @@ _DIST_STEPS = [
     _step.build_dist,
     _step.install_dist,
     _step.rename_src,
-    _step.mypy_dist,
+    _step.ty_dist,
+    _step.pyrefly_dist,
     _step.pyright_dist,
+    _step.mypy_dist,
 ]
 
 
 def run_tests(
     src: bool = False,
     dist: bool = False,
-    type_checker: Literal["", "mypy", "pyright"] = "",
+    type_checker: Literal["", "mypy", "pyright", "pyrefly", "ty"] = "",
 ) -> None:
-    steps = []
+    steps: list[Step] = []
     if src:
         steps.extend(_SRC_STEPS)
 

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -34,6 +34,12 @@ mypy_dist = Step(
 pyright_dist = Step(
     name="Run pyright on 'tests' using the installed stubs", run=run.pyright_dist
 )
+pyrefly_dist = Step(
+    name="Run pyrefly on 'tests' using the installed stubs", run=run.pyrefly_dist
+)
+ty_dist = Step(
+    name="Run ty on 'tests' using the installed stubs", run=run.ty_dist
+)
 stubtest = Step(
     name="Run stubtest to compare the installed stubs against pandas", run=run.stubtest
 )

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -3,11 +3,11 @@ from scripts.test import run
 
 ty_src = Step(
     name="Run ty on 'tests' (using the local stubs) and on the local stubs",
-    run=run.ty,
+    run=run.ty_src,
 )
 pyrefly_src = Step(
     name="Run pyrefly on 'tests' (using the local stubs) and on the local stubs",
-    run=run.pyrefly,
+    run=run.pyrefly_src,
 )
 pyright_src = Step(
     name="Run pyright on 'tests' (using the local stubs) and on the local stubs",

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -1,21 +1,21 @@
 from scripts._job import Step
 from scripts.test import run
 
-mypy_src = Step(
-    name="Run mypy on 'tests' (using the local stubs) and on the local stubs",
-    run=run.mypy_src,
-)
 ty_src = Step(
-    name="Run ty on 'pandas-stubs' (using the local stubs) and on the local stubs",
+    name="Run ty on 'tests' (using the local stubs) and on the local stubs",
     run=run.ty,
 )
 pyrefly_src = Step(
-    name="Run pyrefly on the local stubs",
+    name="Run pyrefly on 'tests' (using the local stubs) and on the local stubs",
     run=run.pyrefly,
 )
 pyright_src = Step(
     name="Run pyright on 'tests' (using the local stubs) and on the local stubs",
     run=run.pyright_src,
+)
+mypy_src = Step(
+    name="Run mypy on 'tests' (using the local stubs) and on the local stubs",
+    run=run.mypy_src,
 )
 pytest = Step(name="Run pytest", run=run.pytest)
 style = Step(name="Run pre-commit", run=run.style)
@@ -37,9 +37,7 @@ pyright_dist = Step(
 pyrefly_dist = Step(
     name="Run pyrefly on 'tests' using the installed stubs", run=run.pyrefly_dist
 )
-ty_dist = Step(
-    name="Run ty on 'tests' using the installed stubs", run=run.ty_dist
-)
+ty_dist = Step(name="Run ty on 'tests' using the installed stubs", run=run.ty_dist)
 stubtest = Step(
     name="Run stubtest to compare the installed stubs against pandas", run=run.stubtest
 )

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -70,6 +70,16 @@ def pyright_dist() -> None:
     subprocess.run(cmd, check=True)
 
 
+def pyrefly_dist() -> None:
+    cmd = ["pyrefly", "check", "tests"]
+    subprocess.run(cmd, check=True)
+
+
+def ty_dist() -> None:
+    cmd = ["ty", "check", "tests"]
+    subprocess.run(cmd, check=True)
+
+
 def uninstall_dist() -> None:
     cmd = [sys.executable, "-m", "pip", "uninstall", "-y", "pandas-stubs"]
     subprocess.run(cmd, check=True)
@@ -148,13 +158,7 @@ def released_mypy() -> None:
 
 
 def ty() -> None:
-    cmd = [
-        "ty",
-        "check",
-        "pandas-stubs",
-        "--python",
-        sys.executable,
-    ]
+    cmd = ["ty", "check", "pandas-stubs", "tests", "--python", sys.executable]
     subprocess.run(cmd, check=True)
 
 

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -157,12 +157,12 @@ def released_mypy() -> None:
     )
 
 
-def ty() -> None:
+def ty_src() -> None:
     cmd = ["ty", "check", "pandas-stubs", "tests", "--python", sys.executable]
     subprocess.run(cmd, check=True)
 
 
-def pyrefly() -> None:
+def pyrefly_src() -> None:
     cmd = ["pyrefly", "check", "pandas-stubs", "tests"]
     subprocess.run(cmd, check=True)
 

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -326,9 +326,9 @@ def test_ewm_aggregate() -> None:
 
     # TODO: pandas-dev/pandas#63855, see if ewm.aggregate(any callable) is implemented
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = DF.ewm(span=10).aggregate(np.mean)  # type: ignore[arg-type]  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        _1 = DF.ewm(span=10).aggregate(["mean", np.mean])  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        _2 = DF.ewm(span=10).aggregate({"col1": "mean", "col2": np.mean})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        _0 = DF.ewm(span=10).aggregate(np.mean)  # type: ignore[arg-type]  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _1 = DF.ewm(span=10).aggregate(["mean", np.mean])  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _2 = DF.ewm(span=10).aggregate({"col1": "mean", "col2": np.mean})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_ewm_basic_math_series() -> None:
@@ -343,9 +343,9 @@ def test_ewm_basic_math_series() -> None:
 def test_ewm_aggregate_series() -> None:
     # TODO: pandas-dev/pandas#63855, only str function names are possible, not callable, add tests
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = S.ewm(span=10).aggregate(np.mean)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        _1 = S.ewm(span=10).aggregate(["mean", np.mean])  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        _2 = S.ewm(span=10).aggregate({"col1": "mean", "col2": np.mean})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        _0 = S.ewm(span=10).aggregate(np.mean)  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _1 = S.ewm(span=10).aggregate(["mean", np.mean])  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _2 = S.ewm(span=10).aggregate({"col1": "mean", "col2": np.mean})  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
     check(assert_type(S.ewm(span=10).agg("sum"), Series), Series)
 


### PR DESCRIPTION
- [x] Addresses #1799
- [x] Enable `ty` in `tests/test_windowing.py`
- [x] Add `ty_dist` and `pyrefly_dist`
- [x] Rename `ty_src` and `pyrefly_src`
- [x] Change the order of type checkers so that the fastest `ty` runs first
- [x] Update descriptions
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
