### PR TITLE
BUG: #1786 resume supporting `numpy` 2.5

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -4568,7 +4568,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def to_numpy(
         self: Series[Timestamp],
-        dtype: type[np.datetime64] | None = None,
+        dtype: type[np.datetime64[Never]] | None = None,
         copy: bool = False,
         na_value: Scalar = ...,
         **kwargs: Any,
@@ -4584,7 +4584,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def to_numpy(
         self: Series[Timedelta],
-        dtype: type[np.timedelta64] | None = None,
+        dtype: type[np.timedelta64[Never]] | None = None,
         copy: bool = False,
         na_value: Scalar = ...,
         **kwargs: Any,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -4568,7 +4568,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def to_numpy(
         self: Series[Timestamp],
-        dtype: type[np.datetime64[Never]] | None = None,
+        dtype: type[np.datetime64] | None = None,
         copy: bool = False,
         na_value: Scalar = ...,
         **kwargs: Any,
@@ -4584,7 +4584,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def to_numpy(
         self: Series[Timedelta],
-        dtype: type[np.timedelta64[Never]] | None = None,
+        dtype: type[np.timedelta64] | None = None,
         copy: bool = False,
         na_value: Scalar = ...,
         **kwargs: Any,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ Documentation = "https://pandas.pydata.org/pandas-docs/stable"
 dev = [
   "mypy>=2.2.0",
   "pandas==3.0.3",
+  "numpy>=2.5.1;python_version>='3.12'",
   "pyarrow>=10.0.1",
   "pytest>=8.4.2",
   "pyright>=1.1.410",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Stubs Only",
 ]
-dependencies = ["numpy>=1.23.5,<2.5"]  # TODO: pandas-dev/pandas-stubs#1786 remove <2.5
+dependencies = ["numpy>=1.23.5"]
 
 [project.urls]
 Homepage = "https://pandas.pydata.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
   "pytz>=2025.2",
   "types-pytz>=2022.1.1",
   "pyiceberg>=0.10.0",
-  "numpy-typing-compat>=20260602",
+  "optype[numpy]"
 ]
 
 [build-system]

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -49,8 +49,18 @@ def build_dist() -> None:
 
 def install_dist() -> None:
     path = sorted(Path("dist/").glob("pandas_stubs-*.whl"))[-1]
-    cmd = [sys.executable, "-m", "pip", "install", "--force-reinstall", str(path)]
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        str(path),
+        "numpy-typing-compat",
+    ]
     subprocess.run(cmd, check=True)
+    subprocess.run([sys.executable, "-m", "pip", "check"], check=True)
 
 
 def rename_src() -> None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -40,6 +40,7 @@ LINUX = sys.platform == "linux"
 WINDOWS = sys.platform in {"win32", "cygwin"}
 MAC = sys.platform == "darwin"
 PD_LTE_31 = Version(pd.__version__) < Version("3.0.99")
+NP_GTE_25 = Version(np.__version__) >= Version("2.5.0")
 
 
 def check(
@@ -189,7 +190,16 @@ def pytest_warns_bounded(
         current = Version(pd.__version__)
     else:
         current = Version(version_str)
-    if lb < current < ub:
+    return pytest_warns_conditioned(warning, match, lb < current < ub, upper_exception)
+
+
+def pytest_warns_conditioned(
+    warning: type[Warning],
+    match: str,
+    condition: bool,
+    upper_exception: type[Exception] | None = None,
+) -> AbstractContextManager[Any]:
+    if condition:
         return pytest.warns(warning, match=match)
     if upper_exception is None:
         return nullcontext()

--- a/tests/arrays/test_datetime_array.py
+++ b/tests/arrays/test_datetime_array.py
@@ -104,6 +104,12 @@ def test_construction_sequence_pandas(
                 ),
                 DatetimeArray,
             )
+            assert_type(  # type: ignore[assert-type]
+                pd.array(
+                    [np.datetime64("2131-01-05 01:25"), np.datetime64("1748-01-06")]
+                ),
+                DatetimeArray,
+            )
         else:
             assert_type(
                 pd.array(
@@ -111,11 +117,12 @@ def test_construction_sequence_pandas(
                 ),
                 DatetimeArray,
             )
-        # TODO: pandas-dev/pandas-stubs#1786
-        assert_type(  # type: ignore[assert-type]
-            pd.array([np.datetime64("2131-01-05 01:25"), np.datetime64("1748-01-06")]),
-            DatetimeArray,
-        )
+            assert_type(
+                pd.array(
+                    [np.datetime64("2131-01-05 01:25"), np.datetime64("1748-01-06")]
+                ),
+                DatetimeArray,
+            )
         assert_type(
             pd.array([np.datetime64("2130-01-01 01:25"), datetime(1749, 1, 6)]),
             DatetimeArray,

--- a/tests/arrays/test_datetime_array.py
+++ b/tests/arrays/test_datetime_array.py
@@ -79,11 +79,14 @@ def test_construction_sequence_pandas(
             pd.array([pd.Timestamp(2026, 1, 5, tzinfo=ZoneInfo("Africa/Ouagadougou"))]),
             DatetimeArray,
         )
-        # TODO: pandas-dev/pandas-stubs#1786
         if sys.version_info >= (3, 14):
+            # TODO: pandas-dev/pandas-stubs#1786
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray
             )
+        elif sys.version_info >= (3, 12):
+            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+            pass
         else:
             assert_type(pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray)
 
@@ -96,8 +99,8 @@ def test_construction_sequence_pandas(
         assert_type(
             pd.array([datetime(2052, 1, 5), pd.Timestamp(2, 1, 6)]), DatetimeArray
         )
-        # TODO: pandas-dev/pandas-stubs#1786
         if sys.version_info >= (3, 14):
+            # TODO: pandas-dev/pandas-stubs#1786
             assert_type(  # type: ignore[assert-type]
                 pd.array(
                     [np.datetime64("2026-01-05 23:27:59"), np.datetime64("1748-01-06")]
@@ -110,6 +113,9 @@ def test_construction_sequence_pandas(
                 ),
                 DatetimeArray,
             )
+        elif sys.version_info >= (3, 12):
+            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+            pass
         else:
             assert_type(
                 pd.array(
@@ -134,11 +140,14 @@ def test_construction_sequence_pandas(
 
         assert_type(pd.array([datetime(2061, 1, 5, 1), None]), DatetimeArray)
         assert_type(pd.array([pd.Timestamp(1902, 1, 5, 3), None]), DatetimeArray)
-        # TODO: pandas-dev/pandas-stubs#1786
         if sys.version_info >= (3, 14):
+            # TODO: pandas-dev/pandas-stubs#1786
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray
             )
+        elif sys.version_info >= (3, 12):
+            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+            pass
         else:
             assert_type(pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray)
 
@@ -150,11 +159,14 @@ def test_construction_sequence_pandas(
         assert_type(
             pd.array([pd.Timestamp(2102, 1, 5, 3), None, pd.NaT]), DatetimeArray
         )
-        # TODO: pandas-dev/pandas-stubs#1786
         if sys.version_info >= (3, 14):
+            # TODO: pandas-dev/pandas-stubs#1786
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
             )
+        elif sys.version_info >= (3, 12):
+            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+            pass
         else:
             assert_type(
                 pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
@@ -162,10 +174,13 @@ def test_construction_sequence_pandas(
 
         assert_type(pd.array((datetime(2026, 1, 5),)), DatetimeArray)
         assert_type(pd.array(UserList([pd.Timestamp(2026, 1, 5)])), DatetimeArray)
-        # TODO: pandas-dev/pandas-stubs#1786
         if sys.version_info >= (3, 14):
+            # TODO: pandas-dev/pandas-stubs#1786
             assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)  # type: ignore[assert-type]
             assert_type(pd.array(UserList([np.datetime64("1701-01-05")])), DatetimeArray)  # type: ignore[assert-type]
+        elif sys.version_info >= (3, 12):
+            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+            pass
         else:
             assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)
             assert_type(
@@ -359,9 +374,12 @@ def test_constructor() -> None:
     check(assert_type(pd.array([np_dt]), DatetimeArray), DatetimeArray)
     check(assert_type(pd.array([np_dt, None]), DatetimeArray), DatetimeArray)
     dt_nat = cast(list[np.datetime64 | NaTType], [np_dt, pd.NaT])
-    # TODO: pandas-dev/pandas-stubs#1786
     if sys.version_info >= (3, 14):
+        # TODO: pandas-dev/pandas-stubs#1786
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)  # type: ignore[assert-type]
+    elif sys.version_info >= (3, 12):
+        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+        pass
     else:
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)
 

--- a/tests/arrays/test_datetime_array.py
+++ b/tests/arrays/test_datetime_array.py
@@ -8,6 +8,7 @@ from datetime import (
     datetime,
     time,
 )
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -78,7 +79,13 @@ def test_construction_sequence_pandas(
             pd.array([pd.Timestamp(2026, 1, 5, tzinfo=ZoneInfo("Africa/Ouagadougou"))]),
             DatetimeArray,
         )
-        assert_type(pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray)
+        # TODO: pandas-dev/pandas-stubs#1786
+        if sys.version_info >= (3, 12):
+            assert_type(  # type: ignore[assert-type]
+                pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray
+            )
+        else:
+            assert_type(pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray)
 
         assert_type(
             pd.array([datetime(2100, 1, 5, 1), datetime(1, 1, 6, 2)]), DatetimeArray
@@ -89,7 +96,23 @@ def test_construction_sequence_pandas(
         assert_type(
             pd.array([datetime(2052, 1, 5), pd.Timestamp(2, 1, 6)]), DatetimeArray
         )
-        assert_type(
+        # TODO: pandas-dev/pandas-stubs#1786
+        if sys.version_info >= (3, 12):
+            assert_type(  # type: ignore[assert-type]
+                pd.array(
+                    [np.datetime64("2026-01-05 23:27:59"), np.datetime64("1748-01-06")]
+                ),
+                DatetimeArray,
+            )
+        else:
+            assert_type(
+                pd.array(
+                    [np.datetime64("2026-01-05 23:27:59"), np.datetime64("1748-01-06")]
+                ),
+                DatetimeArray,
+            )
+        # TODO: pandas-dev/pandas-stubs#1786
+        assert_type(  # type: ignore[assert-type]
             pd.array([np.datetime64("2131-01-05 01:25"), np.datetime64("1748-01-06")]),
             DatetimeArray,
         )
@@ -104,7 +127,13 @@ def test_construction_sequence_pandas(
 
         assert_type(pd.array([datetime(2061, 1, 5, 1), None]), DatetimeArray)
         assert_type(pd.array([pd.Timestamp(1902, 1, 5, 3), None]), DatetimeArray)
-        assert_type(pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray)
+        # TODO: pandas-dev/pandas-stubs#1786
+        if sys.version_info >= (3, 12):
+            assert_type(  # type: ignore[assert-type]
+                pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray
+            )
+        else:
+            assert_type(pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray)
 
         assert_type(pd.array([datetime(1921, 1, 5, 1), pd.NaT]), DatetimeArray)
         assert_type(pd.array([pd.Timestamp(1872, 1, 5, 3), pd.NaT]), DatetimeArray)
@@ -114,14 +143,27 @@ def test_construction_sequence_pandas(
         assert_type(
             pd.array([pd.Timestamp(2102, 1, 5, 3), None, pd.NaT]), DatetimeArray
         )
-        assert_type(
-            pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
-        )
+        # TODO: pandas-dev/pandas-stubs#1786
+        if sys.version_info >= (3, 12):
+            assert_type(  # type: ignore[assert-type]
+                pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
+            )
+        else:
+            assert_type(
+                pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
+            )
 
         assert_type(pd.array((datetime(2026, 1, 5),)), DatetimeArray)
         assert_type(pd.array(UserList([pd.Timestamp(2026, 1, 5)])), DatetimeArray)
-        assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)
-        assert_type(pd.array(UserList([np.datetime64("1701-01-05")])), DatetimeArray)
+        # TODO: pandas-dev/pandas-stubs#1786
+        if sys.version_info >= (3, 12):
+            assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)  # type: ignore[assert-type]
+            assert_type(pd.array(UserList([np.datetime64("1701-01-05")])), DatetimeArray)  # type: ignore[assert-type]
+        else:
+            assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)
+            assert_type(
+                pd.array(UserList([np.datetime64("1701-01-05")])), DatetimeArray
+            )
 
 
 @pytest.mark.parametrize(
@@ -310,7 +352,11 @@ def test_constructor() -> None:
     check(assert_type(pd.array([np_dt]), DatetimeArray), DatetimeArray)
     check(assert_type(pd.array([np_dt, None]), DatetimeArray), DatetimeArray)
     dt_nat = cast(list[np.datetime64 | NaTType], [np_dt, pd.NaT])
-    check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)
+    # TODO: pandas-dev/pandas-stubs#1786
+    if sys.version_info >= (3, 12):
+        check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)  # type: ignore[assert-type]
+    else:
+        check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)
 
     np_arr = np.array([dt], np.datetime64)
     check(assert_type(pd.array(np_arr), DatetimeArray), DatetimeArray)

--- a/tests/arrays/test_datetime_array.py
+++ b/tests/arrays/test_datetime_array.py
@@ -80,10 +80,8 @@ def test_construction_sequence_pandas(
             DatetimeArray,
         )
         if sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786
-            assert_type(  # type: ignore[assert-type]
-                pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray
-            )
+            # TODO: python/mypy#21733
+            assert_type(pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray)
 
@@ -97,19 +95,9 @@ def test_construction_sequence_pandas(
             pd.array([datetime(2052, 1, 5), pd.Timestamp(2, 1, 6)]), DatetimeArray
         )
         if sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786
-            assert_type(  # type: ignore[assert-type]
-                pd.array(
-                    [np.datetime64("2026-01-05 23:27:59"), np.datetime64("1748-01-06")]
-                ),
-                DatetimeArray,
-            )
-            assert_type(  # type: ignore[assert-type]
-                pd.array(
-                    [np.datetime64("2131-01-05 01:25"), np.datetime64("1748-01-06")]
-                ),
-                DatetimeArray,
-            )
+            # TODO: python/mypy#21733
+            assert_type(pd.array([np.datetime64("2026-01-05 23:27:59"), np.datetime64("1748-01-06")]), DatetimeArray)  # type: ignore[assert-type]
+            assert_type(pd.array([np.datetime64("2131-01-05 01:25"), np.datetime64("1748-01-06")]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(
                 pd.array(
@@ -135,10 +123,8 @@ def test_construction_sequence_pandas(
         assert_type(pd.array([datetime(2061, 1, 5, 1), None]), DatetimeArray)
         assert_type(pd.array([pd.Timestamp(1902, 1, 5, 3), None]), DatetimeArray)
         if sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786
-            assert_type(  # type: ignore[assert-type]
-                pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray
-            )
+            # TODO: python/mypy#21733
+            assert_type(pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray)
 
@@ -151,10 +137,8 @@ def test_construction_sequence_pandas(
             pd.array([pd.Timestamp(2102, 1, 5, 3), None, pd.NaT]), DatetimeArray
         )
         if sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786
-            assert_type(  # type: ignore[assert-type]
-                pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
-            )
+            # TODO: python/mypy#21733
+            assert_type(pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(
                 pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
@@ -163,7 +147,7 @@ def test_construction_sequence_pandas(
         assert_type(pd.array((datetime(2026, 1, 5),)), DatetimeArray)
         assert_type(pd.array(UserList([pd.Timestamp(2026, 1, 5)])), DatetimeArray)
         if sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786
+            # TODO: python/mypy#21733
             assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)  # type: ignore[assert-type]
             assert_type(pd.array(UserList([np.datetime64("1701-01-05")])), DatetimeArray)  # type: ignore[assert-type]
         else:
@@ -360,7 +344,7 @@ def test_constructor() -> None:
     check(assert_type(pd.array([np_dt, None]), DatetimeArray), DatetimeArray)
     dt_nat = cast(list[np.datetime64 | NaTType], [np_dt, pd.NaT])
     if sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786
+        # TODO: python/mypy#21733
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)  # type: ignore[assert-type]
     else:
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)

--- a/tests/arrays/test_datetime_array.py
+++ b/tests/arrays/test_datetime_array.py
@@ -80,7 +80,7 @@ def test_construction_sequence_pandas(
             DatetimeArray,
         )
         # TODO: pandas-dev/pandas-stubs#1786
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 14):
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray
             )
@@ -97,7 +97,7 @@ def test_construction_sequence_pandas(
             pd.array([datetime(2052, 1, 5), pd.Timestamp(2, 1, 6)]), DatetimeArray
         )
         # TODO: pandas-dev/pandas-stubs#1786
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 14):
             assert_type(  # type: ignore[assert-type]
                 pd.array(
                     [np.datetime64("2026-01-05 23:27:59"), np.datetime64("1748-01-06")]
@@ -135,7 +135,7 @@ def test_construction_sequence_pandas(
         assert_type(pd.array([datetime(2061, 1, 5, 1), None]), DatetimeArray)
         assert_type(pd.array([pd.Timestamp(1902, 1, 5, 3), None]), DatetimeArray)
         # TODO: pandas-dev/pandas-stubs#1786
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 14):
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray
             )
@@ -151,7 +151,7 @@ def test_construction_sequence_pandas(
             pd.array([pd.Timestamp(2102, 1, 5, 3), None, pd.NaT]), DatetimeArray
         )
         # TODO: pandas-dev/pandas-stubs#1786
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 14):
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
             )
@@ -163,7 +163,7 @@ def test_construction_sequence_pandas(
         assert_type(pd.array((datetime(2026, 1, 5),)), DatetimeArray)
         assert_type(pd.array(UserList([pd.Timestamp(2026, 1, 5)])), DatetimeArray)
         # TODO: pandas-dev/pandas-stubs#1786
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 14):
             assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)  # type: ignore[assert-type]
             assert_type(pd.array(UserList([np.datetime64("1701-01-05")])), DatetimeArray)  # type: ignore[assert-type]
         else:
@@ -360,7 +360,7 @@ def test_constructor() -> None:
     check(assert_type(pd.array([np_dt, None]), DatetimeArray), DatetimeArray)
     dt_nat = cast(list[np.datetime64 | NaTType], [np_dt, pd.NaT])
     # TODO: pandas-dev/pandas-stubs#1786
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 14):
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)  # type: ignore[assert-type]
     else:
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)

--- a/tests/arrays/test_datetime_array.py
+++ b/tests/arrays/test_datetime_array.py
@@ -80,7 +80,7 @@ def test_construction_sequence_pandas(
             DatetimeArray,
         )
         if sys.version_info >= (3, 12):
-            # TODO: python/mypy#21733
+            # TODO: python/mypy#21733 the mypy bug has manifested in numpy >= 2.5
             assert_type(pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray)
@@ -95,7 +95,7 @@ def test_construction_sequence_pandas(
             pd.array([datetime(2052, 1, 5), pd.Timestamp(2, 1, 6)]), DatetimeArray
         )
         if sys.version_info >= (3, 12):
-            # TODO: python/mypy#21733
+            # TODO: python/mypy#21733 the mypy bug has manifested in numpy >= 2.5
             assert_type(pd.array([np.datetime64("2131-01-05 23:27:59"), np.datetime64("1748-01-06")]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(
@@ -116,7 +116,7 @@ def test_construction_sequence_pandas(
         assert_type(pd.array([datetime(2061, 1, 5, 1), None]), DatetimeArray)
         assert_type(pd.array([pd.Timestamp(1902, 1, 5, 3), None]), DatetimeArray)
         if sys.version_info >= (3, 12):
-            # TODO: python/mypy#21733
+            # TODO: python/mypy#21733 the mypy bug has manifested in numpy >= 2.5
             assert_type(pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray)
@@ -130,7 +130,7 @@ def test_construction_sequence_pandas(
             pd.array([pd.Timestamp(2102, 1, 5, 3), None, pd.NaT]), DatetimeArray
         )
         if sys.version_info >= (3, 12):
-            # TODO: python/mypy#21733
+            # TODO: python/mypy#21733 the mypy bug has manifested in numpy >= 2.5
             assert_type(pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(
@@ -140,7 +140,7 @@ def test_construction_sequence_pandas(
         assert_type(pd.array((datetime(2026, 1, 5),)), DatetimeArray)
         assert_type(pd.array(UserList([pd.Timestamp(2026, 1, 5)])), DatetimeArray)
         if sys.version_info >= (3, 12):
-            # TODO: python/mypy#21733
+            # TODO: python/mypy#21733 the mypy bug has manifested in numpy >= 2.5
             assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)  # type: ignore[assert-type]
             assert_type(pd.array(UserList([np.datetime64("1701-01-05")])), DatetimeArray)  # type: ignore[assert-type]
         else:
@@ -337,7 +337,7 @@ def test_constructor() -> None:
     check(assert_type(pd.array([np_dt, None]), DatetimeArray), DatetimeArray)
     dt_nat = cast(list[np.datetime64 | NaTType], [np_dt, pd.NaT])
     if sys.version_info >= (3, 12):
-        # TODO: python/mypy#21733
+        # TODO: python/mypy#21733 the mypy bug has manifested in numpy >= 2.5
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)  # type: ignore[assert-type]
     else:
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)

--- a/tests/arrays/test_datetime_array.py
+++ b/tests/arrays/test_datetime_array.py
@@ -79,14 +79,11 @@ def test_construction_sequence_pandas(
             pd.array([pd.Timestamp(2026, 1, 5, tzinfo=ZoneInfo("Africa/Ouagadougou"))]),
             DatetimeArray,
         )
-        if sys.version_info >= (3, 14):
+        if sys.version_info >= (3, 12):
             # TODO: pandas-dev/pandas-stubs#1786
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray
             )
-        elif sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-            pass
         else:
             assert_type(pd.array([np.datetime64("2026-01-05 23:27:59")]), DatetimeArray)
 
@@ -99,7 +96,7 @@ def test_construction_sequence_pandas(
         assert_type(
             pd.array([datetime(2052, 1, 5), pd.Timestamp(2, 1, 6)]), DatetimeArray
         )
-        if sys.version_info >= (3, 14):
+        if sys.version_info >= (3, 12):
             # TODO: pandas-dev/pandas-stubs#1786
             assert_type(  # type: ignore[assert-type]
                 pd.array(
@@ -113,9 +110,6 @@ def test_construction_sequence_pandas(
                 ),
                 DatetimeArray,
             )
-        elif sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-            pass
         else:
             assert_type(
                 pd.array(
@@ -140,14 +134,11 @@ def test_construction_sequence_pandas(
 
         assert_type(pd.array([datetime(2061, 1, 5, 1), None]), DatetimeArray)
         assert_type(pd.array([pd.Timestamp(1902, 1, 5, 3), None]), DatetimeArray)
-        if sys.version_info >= (3, 14):
+        if sys.version_info >= (3, 12):
             # TODO: pandas-dev/pandas-stubs#1786
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray
             )
-        elif sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-            pass
         else:
             assert_type(pd.array([np.datetime64("2111-01-05"), None]), DatetimeArray)
 
@@ -159,14 +150,11 @@ def test_construction_sequence_pandas(
         assert_type(
             pd.array([pd.Timestamp(2102, 1, 5, 3), None, pd.NaT]), DatetimeArray
         )
-        if sys.version_info >= (3, 14):
+        if sys.version_info >= (3, 12):
             # TODO: pandas-dev/pandas-stubs#1786
             assert_type(  # type: ignore[assert-type]
                 pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
             )
-        elif sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-            pass
         else:
             assert_type(
                 pd.array([np.datetime64("2114-01-05"), None, pd.NaT]), DatetimeArray
@@ -174,13 +162,10 @@ def test_construction_sequence_pandas(
 
         assert_type(pd.array((datetime(2026, 1, 5),)), DatetimeArray)
         assert_type(pd.array(UserList([pd.Timestamp(2026, 1, 5)])), DatetimeArray)
-        if sys.version_info >= (3, 14):
+        if sys.version_info >= (3, 12):
             # TODO: pandas-dev/pandas-stubs#1786
             assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)  # type: ignore[assert-type]
             assert_type(pd.array(UserList([np.datetime64("1701-01-05")])), DatetimeArray)  # type: ignore[assert-type]
-        elif sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-            pass
         else:
             assert_type(pd.array((np.datetime64("1959-01-05"),)), DatetimeArray)
             assert_type(
@@ -374,12 +359,9 @@ def test_constructor() -> None:
     check(assert_type(pd.array([np_dt]), DatetimeArray), DatetimeArray)
     check(assert_type(pd.array([np_dt, None]), DatetimeArray), DatetimeArray)
     dt_nat = cast(list[np.datetime64 | NaTType], [np_dt, pd.NaT])
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 12):
         # TODO: pandas-dev/pandas-stubs#1786
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)  # type: ignore[assert-type]
-    elif sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-        pass
     else:
         check(assert_type(pd.array(dt_nat), DatetimeArray), DatetimeArray)
 

--- a/tests/arrays/test_datetime_array.py
+++ b/tests/arrays/test_datetime_array.py
@@ -96,18 +96,11 @@ def test_construction_sequence_pandas(
         )
         if sys.version_info >= (3, 12):
             # TODO: python/mypy#21733
-            assert_type(pd.array([np.datetime64("2026-01-05 23:27:59"), np.datetime64("1748-01-06")]), DatetimeArray)  # type: ignore[assert-type]
-            assert_type(pd.array([np.datetime64("2131-01-05 01:25"), np.datetime64("1748-01-06")]), DatetimeArray)  # type: ignore[assert-type]
+            assert_type(pd.array([np.datetime64("2131-01-05 23:27:59"), np.datetime64("1748-01-06")]), DatetimeArray)  # type: ignore[assert-type]
         else:
             assert_type(
                 pd.array(
-                    [np.datetime64("2026-01-05 23:27:59"), np.datetime64("1748-01-06")]
-                ),
-                DatetimeArray,
-            )
-            assert_type(
-                pd.array(
-                    [np.datetime64("2131-01-05 01:25"), np.datetime64("1748-01-06")]
+                    [np.datetime64("2131-01-05 23:27:59"), np.datetime64("1748-01-06")]
                 ),
                 DatetimeArray,
             )

--- a/tests/arrays/test_integer.py
+++ b/tests/arrays/test_integer.py
@@ -49,7 +49,7 @@ def test_construction_sequence(
         assert_type(pd.array([-2, 3]), IntegerArray)
         # TODO: pandas-dev/pandas-stubs#1786
         if sys.version_info >= (3, 12):
-            assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)  # type: ignore[assert-type]
+            assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         else:
             assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)
 

--- a/tests/arrays/test_integer.py
+++ b/tests/arrays/test_integer.py
@@ -3,6 +3,7 @@ from collections.abc import (
     Callable,
     Sequence,
 )
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -46,7 +47,11 @@ def test_construction_sequence(
 
     if TYPE_CHECKING:
         assert_type(pd.array([-2, 3]), IntegerArray)
-        assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)
+        # TODO: pandas-dev/pandas-stubs#1786
+        if sys.version_info >= (3, 12):
+            assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)  # type: ignore[assert-type]
+        else:
+            assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)
 
         assert_type(pd.array([2, np.int8(3)]), IntegerArray)
 

--- a/tests/arrays/test_integer.py
+++ b/tests/arrays/test_integer.py
@@ -46,7 +46,10 @@ def test_construction_sequence(
 
     if TYPE_CHECKING:
         assert_type(pd.array([-2, 3]), IntegerArray)
-        assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)
+        # TODO: pandas-dev/pandas-stubs#1786 investigate and report to pyrefly
+        assert_type(  # pyrefly: ignore[assert-type]
+            pd.array([1 << 32, np.int8(1) << 6]), IntegerArray
+        )
 
         assert_type(pd.array([2, np.int8(3)]), IntegerArray)
 

--- a/tests/arrays/test_integer.py
+++ b/tests/arrays/test_integer.py
@@ -3,7 +3,6 @@ from collections.abc import (
     Callable,
     Sequence,
 )
-import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -47,13 +46,7 @@ def test_construction_sequence(
 
     if TYPE_CHECKING:
         assert_type(pd.array([-2, 3]), IntegerArray)
-        # TODO: pandas-dev/pandas-stubs#1786
-        if sys.version_info >= (3, 12):
-            assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)
-        else:
-            assert_type(  # pyrefly: ignore[assert-type]
-                pd.array([1 << 32, np.int8(1) << 6]), IntegerArray
-            )
+        assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)
 
         assert_type(pd.array([2, np.int8(3)]), IntegerArray)
 

--- a/tests/arrays/test_integer.py
+++ b/tests/arrays/test_integer.py
@@ -49,9 +49,11 @@ def test_construction_sequence(
         assert_type(pd.array([-2, 3]), IntegerArray)
         # TODO: pandas-dev/pandas-stubs#1786
         if sys.version_info >= (3, 12):
-            assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
-        else:
             assert_type(pd.array([1 << 32, np.int8(1) << 6]), IntegerArray)
+        else:
+            assert_type(  # pyrefly: ignore[assert-type]
+                pd.array([1 << 32, np.int8(1) << 6]), IntegerArray
+            )
 
         assert_type(pd.array([2, np.int8(3)]), IntegerArray)
 

--- a/tests/arrays/test_timedeltas.py
+++ b/tests/arrays/test_timedeltas.py
@@ -35,7 +35,7 @@ def test_construction() -> None:
     """Test pd.array method for TimedeltaArray."""
 
     td = timedelta(2025, 11, 10)
-    np_dt = np.timedelta64(td)
+    np_dt = np.timedelta64(td, "D")
     check(assert_type(pd.array([td]), TimedeltaArray), TimedeltaArray)
     check(
         assert_type(pd.array([td, pd.Timedelta(td), np_dt]), TimedeltaArray),

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -1759,7 +1759,10 @@ def test_period_add_subtract() -> None:
     check(assert_type(as_np_td + p, pd.Period), pd.Period)
     check(assert_type(p.__radd__(as_np_td), pd.Period), pd.Period)
 
-    check(assert_type(as_np_i64 + p, pd.Period), pd.Period)
+    # TODO: pandas-dev/pandas-stubs#1786
+    check(
+        assert_type(as_np_i64 + p, pd.Period), pd.Period  # pyrefly: ignore[assert-type]
+    )
     check(assert_type(p.__radd__(as_np_i64), pd.Period), pd.Period)
 
     check(assert_type(as_int + p, pd.Period), pd.Period)

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import datetime as dt
+import sys
 from typing import (
     Any,
     Literal,
@@ -558,7 +559,7 @@ def test_timedelta_add_sub() -> None:
     check(assert_type(as_datetime64 + td, pd.Timestamp), pd.Timestamp)
     # pyright can't know that as_td_timedelta + td calls
     # td.__radd__(as_td_timedelta),  not timedelta.__add__
-    # https://github.com/microsoft/pyright/issues/4088
+    # TODO: https://github.com/microsoft/pyright/issues/4088
     check(
         assert_type(  # pyrefly: ignore[assert-type]
             as_dt_timedelta + td,  # pyright: ignore[reportAssertTypeFailure]
@@ -566,13 +567,16 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    check(
-        assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
-            as_timedelta64 + td,  # pyright: ignore[reportAssertTypeFailure]
+    if sys.version_info >= (3, 12):
+        check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)
+    else:
+        check(
+            assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
+                as_timedelta64 + td,  # pyright: ignore[reportAssertTypeFailure]
+                pd.Timedelta,
+            ),
             pd.Timedelta,
-        ),
-        pd.Timedelta,
-    )
+        )
     check(assert_type(as_timedelta_index + td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(as_period_index + td, pd.PeriodIndex), pd.PeriodIndex)
     check(assert_type(as_datetime_index + td, pd.DatetimeIndex), pd.DatetimeIndex)
@@ -614,13 +618,16 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    check(
-        assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
-            as_timedelta64 - td,  # pyright: ignore[reportAssertTypeFailure]
+    if sys.version_info >= (3, 12):
+        check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)
+    else:
+        check(
+            assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
+                as_timedelta64 - td,  # pyright: ignore[reportAssertTypeFailure]
+                pd.Timedelta,
+            ),
             pd.Timedelta,
-        ),
-        pd.Timedelta,
-    )
+        )
     check(assert_type(as_timedelta_index - td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(as_period_index - td, pd.PeriodIndex), pd.PeriodIndex)
     check(assert_type(as_datetime_index - td, pd.DatetimeIndex), pd.DatetimeIndex)
@@ -903,24 +910,39 @@ def test_timedelta_cmp_array() -> None:
     assert (lt_1d2 != ge_1d2).all()
 
     # ==, !=
-    # TODO: https://github.com/facebook/pyrefly/issues/3977
-    eq_nd1 = check(
-        assert_type(td == arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
-        np_ndarray_bool,
-        np.bool,
-    )
-    ne_nd1 = check(
-        assert_type(td != arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
-        np_ndarray_bool,
-        np.bool,
-    )
-    assert (eq_nd1 != ne_nd1).all()
-    eq_2d1 = check(assert_type(td == arr_2d, np_2darray[np.bool]), np_2darray[np.bool])
-    ne_2d1 = check(assert_type(td != arr_2d, np_2darray[np.bool]), np_2darray[np.bool])
-    assert (eq_2d1 != ne_2d1).all()
-    eq_1d1 = check(assert_type(td == arr_1d, np_1darray_bool), np_1darray_bool)
-    ne_1d1 = check(assert_type(td != arr_1d, np_1darray_bool), np_1darray_bool)
-    assert (eq_1d1 != ne_1d1).all()
+    # TODO: pandas-dev/pandas-stubs#1786 facebook/pyrefly#3977
+    if sys.version_info >= (3, 12):
+        eq_nd1 = check(assert_type(td == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
+        ne_nd1 = check(assert_type(td != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
+        assert (eq_nd1 != ne_nd1).all()
+        eq_2d1 = check(assert_type(td == arr_2d, np_2darray[np.bool]), np_2darray[np.bool])  # type: ignore[assert-type]
+        ne_2d1 = check(assert_type(td != arr_2d, np_2darray[np.bool]), np_2darray[np.bool])  # type: ignore[assert-type]
+        assert (eq_2d1 != ne_2d1).all()
+        eq_1d1 = check(assert_type(td == arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
+        ne_1d1 = check(assert_type(td != arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
+        assert (eq_1d1 != ne_1d1).all()
+    else:
+        eq_nd1 = check(
+            assert_type(td == arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
+            np_ndarray_bool,
+            np.bool,
+        )
+        ne_nd1 = check(
+            assert_type(td != arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
+            np_ndarray_bool,
+            np.bool,
+        )
+        assert (eq_nd1 != ne_nd1).all()
+        eq_2d1 = check(
+            assert_type(td == arr_2d, np_2darray[np.bool]), np_2darray[np.bool]
+        )
+        ne_2d1 = check(
+            assert_type(td != arr_2d, np_2darray[np.bool]), np_2darray[np.bool]
+        )
+        assert (eq_2d1 != ne_2d1).all()
+        eq_1d1 = check(assert_type(td == arr_1d, np_1darray_bool), np_1darray_bool)
+        ne_1d1 = check(assert_type(td != arr_1d, np_1darray_bool), np_1darray_bool)
+        assert (eq_1d1 != ne_1d1).all()
 
     # ==, != (td on the rhs, use == and != of lhs)
     eq_rhs_nd1 = check(assert_type(arr_nd == td, Any), np_ndarray_bool)
@@ -1322,24 +1344,39 @@ def test_timestamp_cmp_array() -> None:
     assert (lt_1d2 != ge_1d2).all()
 
     # ==, !=
-    # TODO: https://github.com/facebook/pyrefly/issues/3977
-    eq_nd1 = check(
-        assert_type(ts == arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
-        np_ndarray_bool,
-        np.bool,
-    )
-    ne_nd1 = check(
-        assert_type(ts != arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
-        np_ndarray_bool,
-        np.bool,
-    )
-    assert (eq_nd1 != ne_nd1).all()
-    eq_2d1 = check(assert_type(ts == arr_2d, np_2darray[np.bool]), np_2darray[np.bool])
-    ne_2d1 = check(assert_type(ts != arr_2d, np_2darray[np.bool]), np_2darray[np.bool])
-    assert (eq_2d1 != ne_2d1).all()
-    eq_1d1 = check(assert_type(ts == arr_1d, np_1darray_bool), np_1darray_bool)
-    ne_1d1 = check(assert_type(ts != arr_1d, np_1darray_bool), np_1darray_bool)
-    assert (eq_1d1 != ne_1d1).all()
+    # TODO: pandas-dev/pandas-stubs#1786 facebook/pyrefly#3977
+    if sys.version_info >= (3, 12):
+        eq_nd1 = check(assert_type(ts == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
+        ne_nd1 = check(assert_type(ts != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
+        assert (eq_nd1 != ne_nd1).all()
+        eq_2d1 = check(assert_type(ts == arr_2d, np_2darray[np.bool]), np_2darray[np.bool])  # type: ignore[assert-type]
+        ne_2d1 = check(assert_type(ts != arr_2d, np_2darray[np.bool]), np_2darray[np.bool])  # type: ignore[assert-type]
+        assert (eq_2d1 != ne_2d1).all()
+        eq_1d1 = check(assert_type(ts == arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
+        ne_1d1 = check(assert_type(ts != arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
+        assert (eq_1d1 != ne_1d1).all()
+    else:
+        eq_nd1 = check(
+            assert_type(ts == arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
+            np_ndarray_bool,
+            np.bool,
+        )
+        ne_nd1 = check(
+            assert_type(ts != arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
+            np_ndarray_bool,
+            np.bool,
+        )
+        assert (eq_nd1 != ne_nd1).all()
+        eq_2d1 = check(
+            assert_type(ts == arr_2d, np_2darray[np.bool]), np_2darray[np.bool]
+        )
+        ne_2d1 = check(
+            assert_type(ts != arr_2d, np_2darray[np.bool]), np_2darray[np.bool]
+        )
+        assert (eq_2d1 != ne_2d1).all()
+        eq_1d1 = check(assert_type(ts == arr_1d, np_1darray_bool), np_1darray_bool)
+        ne_1d1 = check(assert_type(ts != arr_1d, np_1darray_bool), np_1darray_bool)
+        assert (eq_1d1 != ne_1d1).all()
 
     # ==, != (td on the rhs, use == and != of lhs)
     eq_rhs_nd1 = check(assert_type(arr_nd == ts, Any), np_ndarray_bool)

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -573,6 +573,9 @@ def test_timedelta_add_sub() -> None:
     )
     if sys.version_info >= (3, 14):
         check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)
+    elif sys.version_info >= (3, 12):
+        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+        pass
     else:
         check(
             assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
@@ -624,6 +627,9 @@ def test_timedelta_add_sub() -> None:
     )
     if sys.version_info >= (3, 14):
         check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)
+    elif sys.version_info >= (3, 12):
+        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+        pass
     else:
         check(
             assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import datetime as dt
 import sys
 from typing import (
@@ -20,9 +19,11 @@ from pandas._libs.tslibs.timedeltas import Components
 from pandas.errors import Pandas4Warning
 
 from tests import (
+    NP_GTE_25,
     TYPE_CHECKING_INVALID_USAGE,
     check,
     pytest_warns_bounded,
+    pytest_warns_conditioned,
 )
 from tests._typing import (
     np_1darray_bool,
@@ -509,11 +510,18 @@ def test_timedelta_properties_methods() -> None:
     check(assert_type(td.to_pytimedelta(), dt.timedelta), dt.timedelta)
     check(assert_type(td.to_timedelta64(), np.timedelta64), np.timedelta64)
     check(assert_type(td.total_seconds(), float), float)
-    # TODO: pandas-dev/pandas-stubs#1786
-    if sys.version_info >= (3, 12):
-        pass
-    else:
+    # TODO: pandas-dev/pandas-stubs#1786 remove the conditional warning
+    with pytest_warns_conditioned(
+        DeprecationWarning,
+        r"The 'generic' unit for NumPy timedelta is deprecated",
+        NP_GTE_25,
+    ):
         check(assert_type(td.view(np.int64), object), np.int64)
+    with pytest_warns_conditioned(
+        DeprecationWarning,
+        r"The 'generic' unit for NumPy timedelta is deprecated",
+        NP_GTE_25,
+    ):
         check(assert_type(td.view("i8"), object), np.int64)
 
     check(assert_type(td.as_unit("s"), pd.Timedelta), pd.Timedelta)
@@ -1626,13 +1634,11 @@ def test_period_construction() -> None:
     )
     check(assert_type(pd.Period(freq="Q", year=2012, quarter=2), pd.Period), pd.Period)
     check(
-        assert_type(
-            pd.Period(value=datetime.datetime(2012, 1, 1), freq="D"), pd.Period
-        ),
+        assert_type(pd.Period(value=dt.datetime(2012, 1, 1), freq="D"), pd.Period),
         pd.Period,
     )
     check(
-        assert_type(pd.Period(value=datetime.date(2012, 1, 1), freq="D"), pd.Period),
+        assert_type(pd.Period(value=dt.date(2012, 1, 1), freq="D"), pd.Period),
         pd.Period,
     )
     check(
@@ -1982,9 +1988,9 @@ def test_nattype_hashable() -> None:
 
 
 def test_nat_comparison_with_date() -> None:
-    # 2.0.0: inequality comparisons of NaT with datetime.date now raise TypeError
+    # 2.0.0: inequality comparisons of NaT with dt.date now raise TypeError
     # pandas-dev/pandas#39196
-    date_obj = datetime.date(2023, 1, 1)
+    date_obj = dt.date(2023, 1, 1)
 
     # Equality comparisons should still work
     check(assert_type(pd.NaT == date_obj, bool), bool)

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -509,8 +509,12 @@ def test_timedelta_properties_methods() -> None:
     check(assert_type(td.to_pytimedelta(), dt.timedelta), dt.timedelta)
     check(assert_type(td.to_timedelta64(), np.timedelta64), np.timedelta64)
     check(assert_type(td.total_seconds(), float), float)
-    check(assert_type(td.view(np.int64), object), np.int64)
-    check(assert_type(td.view("i8"), object), np.int64)
+    # TODO: pandas-dev/pandas-stubs#1786
+    if sys.version_info >= (3, 12):
+        pass
+    else:
+        check(assert_type(td.view(np.int64), object), np.int64)
+        check(assert_type(td.view("i8"), object), np.int64)
 
     check(assert_type(td.as_unit("s"), pd.Timedelta), pd.Timedelta)
     check(assert_type(td.as_unit("ms"), pd.Timedelta), pd.Timedelta)
@@ -911,7 +915,7 @@ def test_timedelta_cmp_array() -> None:
 
     # ==, !=
     # TODO: pandas-dev/pandas-stubs#1786 facebook/pyrefly#3977
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 14):
         eq_nd1 = check(assert_type(td == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         ne_nd1 = check(assert_type(td != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         assert (eq_nd1 != ne_nd1).all()
@@ -1345,7 +1349,7 @@ def test_timestamp_cmp_array() -> None:
 
     # ==, !=
     # TODO: pandas-dev/pandas-stubs#1786 facebook/pyrefly#3977
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 14):
         eq_nd1 = check(assert_type(ts == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         ne_nd1 = check(assert_type(ts != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         assert (eq_nd1 != ne_nd1).all()

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -567,7 +567,7 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 14):
         check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)
     else:
         check(
@@ -618,7 +618,7 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 14):
         check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)
     else:
         check(

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -1769,10 +1769,7 @@ def test_period_add_subtract() -> None:
     check(assert_type(as_np_td + p, pd.Period), pd.Period)
     check(assert_type(p.__radd__(as_np_td), pd.Period), pd.Period)
 
-    # TODO: pandas-dev/pandas-stubs#1786
-    check(
-        assert_type(as_np_i64 + p, pd.Period), pd.Period  # pyrefly: ignore[assert-type]
-    )
+    check(assert_type(as_np_i64 + p, pd.Period), pd.Period)
     check(assert_type(p.__radd__(as_np_i64), pd.Period), pd.Period)
 
     check(assert_type(as_int + p, pd.Period), pd.Period)

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -931,6 +931,9 @@ def test_timedelta_cmp_array() -> None:
         eq_1d1 = check(assert_type(td == arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
         ne_1d1 = check(assert_type(td != arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
         assert (eq_1d1 != ne_1d1).all()
+    elif sys.version_info >= (3, 12):
+        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+        pass
     else:
         eq_nd1 = check(
             assert_type(td == arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
@@ -1365,6 +1368,9 @@ def test_timestamp_cmp_array() -> None:
         eq_1d1 = check(assert_type(ts == arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
         ne_1d1 = check(assert_type(ts != arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
         assert (eq_1d1 != ne_1d1).all()
+    elif sys.version_info >= (3, 12):
+        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+        pass
     else:
         eq_nd1 = check(
             assert_type(ts == arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -1769,7 +1769,10 @@ def test_period_add_subtract() -> None:
     check(assert_type(as_np_td + p, pd.Period), pd.Period)
     check(assert_type(p.__radd__(as_np_td), pd.Period), pd.Period)
 
-    check(assert_type(as_np_i64 + p, pd.Period), pd.Period)
+    # TODO: pandas-dev/pandas-stubs#1786 investigate and report to pyrefly
+    check(
+        assert_type(as_np_i64 + p, pd.Period), pd.Period  # pyrefly: ignore[assert-type]
+    )
     check(assert_type(p.__radd__(as_np_i64), pd.Period), pd.Period)
 
     check(assert_type(as_int + p, pd.Period), pd.Period)

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -571,11 +571,8 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 12):
         check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)
-    elif sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-        pass
     else:
         check(
             assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
@@ -625,11 +622,8 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 12):
         check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)
-    elif sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-        pass
     else:
         check(
             assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
@@ -921,7 +915,7 @@ def test_timedelta_cmp_array() -> None:
 
     # ==, !=
     # TODO: pandas-dev/pandas-stubs#1786 facebook/pyrefly#3977
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 12):
         eq_nd1 = check(assert_type(td == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         ne_nd1 = check(assert_type(td != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         assert (eq_nd1 != ne_nd1).all()
@@ -931,9 +925,6 @@ def test_timedelta_cmp_array() -> None:
         eq_1d1 = check(assert_type(td == arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
         ne_1d1 = check(assert_type(td != arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
         assert (eq_1d1 != ne_1d1).all()
-    elif sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-        pass
     else:
         eq_nd1 = check(
             assert_type(td == arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]
@@ -1358,7 +1349,7 @@ def test_timestamp_cmp_array() -> None:
 
     # ==, !=
     # TODO: pandas-dev/pandas-stubs#1786 facebook/pyrefly#3977
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 12):
         eq_nd1 = check(assert_type(ts == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         ne_nd1 = check(assert_type(ts != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         assert (eq_nd1 != ne_nd1).all()
@@ -1368,9 +1359,6 @@ def test_timestamp_cmp_array() -> None:
         eq_1d1 = check(assert_type(ts == arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
         ne_1d1 = check(assert_type(ts != arr_1d, np_1darray_bool), np_1darray_bool)  # type: ignore[assert-type]
         assert (eq_1d1 != ne_1d1).all()
-    elif sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-        pass
     else:
         eq_nd1 = check(
             assert_type(ts == arr_nd, np_ndarray_bool),  # pyrefly: ignore[assert-type]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -922,7 +922,7 @@ def test_timedelta_cmp_array() -> None:
     assert (lt_1d2 != ge_1d2).all()
 
     # ==, !=
-    # TODO: pandas-dev/pandas-stubs#1786 facebook/pyrefly#3977
+    # TODO: python/mypy#21733 facebook/pyrefly#3977
     if sys.version_info >= (3, 12):
         eq_nd1 = check(assert_type(td == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         ne_nd1 = check(assert_type(td != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
@@ -1356,7 +1356,7 @@ def test_timestamp_cmp_array() -> None:
     assert (lt_1d2 != ge_1d2).all()
 
     # ==, !=
-    # TODO: pandas-dev/pandas-stubs#1786 facebook/pyrefly#3977
+    # TODO: python/mypy#21733 facebook/pyrefly#3977
     if sys.version_info >= (3, 12):
         eq_nd1 = check(assert_type(ts == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         ne_nd1 = check(assert_type(ts != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -580,15 +580,10 @@ def test_timedelta_add_sub() -> None:
         pd.Timedelta,
     )
     if sys.version_info >= (3, 12):
+        # numpy >= 2.5 has eliminated the type checking errors
         check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)
     else:
-        check(
-            assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
-                as_timedelta64 + td,  # pyright: ignore[reportAssertTypeFailure]
-                pd.Timedelta,
-            ),
-            pd.Timedelta,
-        )
+        check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type]
     check(assert_type(as_timedelta_index + td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(as_period_index + td, pd.PeriodIndex), pd.PeriodIndex)
     check(assert_type(as_datetime_index + td, pd.DatetimeIndex), pd.DatetimeIndex)
@@ -631,15 +626,10 @@ def test_timedelta_add_sub() -> None:
         pd.Timedelta,
     )
     if sys.version_info >= (3, 12):
+        # numpy >= 2.5 has eliminated the type checking errors
         check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)
     else:
-        check(
-            assert_type(  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
-                as_timedelta64 - td,  # pyright: ignore[reportAssertTypeFailure]
-                pd.Timedelta,
-            ),
-            pd.Timedelta,
-        )
+        check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type]
     check(assert_type(as_timedelta_index - td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(as_period_index - td, pd.PeriodIndex), pd.PeriodIndex)
     check(assert_type(as_datetime_index - td, pd.DatetimeIndex), pd.DatetimeIndex)
@@ -922,8 +912,9 @@ def test_timedelta_cmp_array() -> None:
     assert (lt_1d2 != ge_1d2).all()
 
     # ==, !=
-    # TODO: python/mypy#21733 facebook/pyrefly#3977
+    # TODO: facebook/pyrefly#3977
     if sys.version_info >= (3, 12):
+        # TODO: python/mypy#21733 the mypy bugs have manifested in numpy >= 2.5
         eq_nd1 = check(assert_type(td == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         ne_nd1 = check(assert_type(td != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         assert (eq_nd1 != ne_nd1).all()
@@ -1356,8 +1347,9 @@ def test_timestamp_cmp_array() -> None:
     assert (lt_1d2 != ge_1d2).all()
 
     # ==, !=
-    # TODO: python/mypy#21733 facebook/pyrefly#3977
+    # TODO: facebook/pyrefly#3977
     if sys.version_info >= (3, 12):
+        # TODO: python/mypy#21733 the mypy bugs have manifested in numpy >= 2.5
         eq_nd1 = check(assert_type(ts == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         ne_nd1 = check(assert_type(ts != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         assert (eq_nd1 != ne_nd1).all()

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2645,7 +2645,7 @@ def test_types_to_numpy() -> None:
     )
     # DateTime64DType — parametric, use np.dtype(...)
     if sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 np_1darray[np.timedelta64[int]] is not ideal
+        # TODO: pandas-dev/pandas-stubs#1786 mypy >= 2.5 gives np_1darray[np.datetime64[int]] for now, which is not ideal
         check(
             assert_type(
                 s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
@@ -2665,7 +2665,7 @@ def test_types_to_numpy() -> None:
         )
     # TimeDelta64DType — parametric, use np.dtype(...)
     if sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 np_1darray[np.timedelta64[int]] is not ideal
+        # TODO: pandas-dev/pandas-stubs#1786 mypy >= 2.5 gives np_1darray[np.timedelta64[int]] for now, which is not ideal
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -15,7 +15,6 @@ import io
 import math
 from pathlib import Path
 import re
-import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -2644,59 +2643,27 @@ def test_types_to_numpy() -> None:
         np.str_,
     )
     # DateTime64DType — parametric, use np.dtype(...)
-    if sys.version_info >= (3, 12):
-        check(
-            assert_type(
-                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
-                "np_1darray[np.datetime64[int]]",
-            ),
-            np_1darray,
-            np.datetime64,
-        )
-    else:
-        # TODO: pandas-dev/pandas-stubs#1786
-        check(
-            assert_type(  # pyrefly: ignore[assert-type]
-                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt
-            ),
-            np_1darray,
-            np.datetime64,
-        )
+    check(
+        assert_type(s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt),
+        np_1darray,
+        np.datetime64,
+    )
     # TimeDelta64DType — parametric, use np.dtype(...)
-    if sys.version_info >= (3, 12):
-        check(
-            assert_type(
-                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                "np_1darray[np.timedelta64[int]]",
-            ),
-            np_1darray,
-            np.timedelta64,
-        )
-        check(
-            assert_type(
-                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                "np_1darray[np.timedelta64[int]]",
-            ),
-            np_1darray,
-            np.timedelta64,
-        )
-    else:
-        # TODO: pandas-dev/pandas-stubs#1786
-        check(
-            assert_type(  # pyrefly: ignore[assert-type]
-                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                np_1darray_td,
-            ),
-            np_1darray,
-            np.timedelta64,
-        )
-        check(
-            assert_type(  # pyrefly: ignore[assert-type]
-                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
-            ),
-            np_1darray,
-            np.timedelta64,
-        )
+    check(
+        assert_type(
+            s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+            np_1darray_td,
+        ),
+        np_1darray,
+        np.timedelta64,
+    )
+    check(
+        assert_type(
+            s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
+        ),
+        np_1darray,
+        np.timedelta64,
+    )
 
     # VoidDType — parametric, use np.dtype(...)
     check(

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2664,8 +2664,9 @@ def test_types_to_numpy() -> None:
             np.datetime64,
         )
     else:
+        # TODO: pandas-dev/pandas-stubs#1786
         check(
-            assert_type(
+            assert_type(  # pyrefly: ignore[assert-type]
                 s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt
             ),
             np_1darray,
@@ -2707,8 +2708,9 @@ def test_types_to_numpy() -> None:
             np.timedelta64,
         )
     else:
+        # TODO: pandas-dev/pandas-stubs#1786
         check(
-            assert_type(
+            assert_type(  # pyrefly: ignore[assert-type]
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
                 np_1darray_td,
             ),
@@ -2716,7 +2718,7 @@ def test_types_to_numpy() -> None:
             np.timedelta64,
         )
         check(
-            assert_type(
+            assert_type(  # pyrefly: ignore[assert-type]
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
             ),
             np_1darray,

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -89,6 +89,7 @@ from tests.dtypes import (
 from tests.extension.decimal.array import DecimalDtype
 
 if TYPE_CHECKING:
+    from datetime import date, timedelta  # noqa: F401
     from typing import Any  # noqa: F401
 
 from pandas.io.formats.format import EngFormatter
@@ -2644,11 +2645,20 @@ def test_types_to_numpy() -> None:
         np.str_,
     )
     # DateTime64DType — parametric, use np.dtype(...)
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 14):
         check(
             assert_type(
                 s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
                 np_1darray[np.datetime64[int]],
+            ),
+            np_1darray,
+            np.datetime64,
+        )
+    elif sys.version_info >= (3, 12):
+        check(
+            assert_type(
+                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
+                np_1darray[np.datetime64[date | int | None]],
             ),
             np_1darray,
             np.datetime64,
@@ -2662,7 +2672,7 @@ def test_types_to_numpy() -> None:
             np.datetime64,
         )
     # TimeDelta64DType — parametric, use np.dtype(...)
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 14):
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
@@ -2675,6 +2685,23 @@ def test_types_to_numpy() -> None:
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
                 np_1darray[np.timedelta64[int]],
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+    elif sys.version_info >= (3, 12):
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+                np_1darray[np.timedelta64[timedelta | int | None]],
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+                np_1darray[np.timedelta64[timedelta | int | None]],
             ),
             np_1darray,
             np.timedelta64,

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -89,7 +89,6 @@ from tests.dtypes import (
 from tests.extension.decimal.array import DecimalDtype
 
 if TYPE_CHECKING:
-    from datetime import date, timedelta  # noqa: F401
     from typing import Any  # noqa: F401
 
 from pandas.io.formats.format import EngFormatter
@@ -2655,14 +2654,8 @@ def test_types_to_numpy() -> None:
             np.datetime64,
         )
     elif sys.version_info >= (3, 12):
-        check(
-            assert_type(
-                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
-                "np_1darray[np.datetime64[date | int | None]]",
-            ),
-            np_1darray,
-            np.datetime64,
-        )
+        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+        pass
     else:
         # TODO: pandas-dev/pandas-stubs#1786
         check(
@@ -2691,22 +2684,8 @@ def test_types_to_numpy() -> None:
             np.timedelta64,
         )
     elif sys.version_info >= (3, 12):
-        check(
-            assert_type(
-                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                "np_1darray[np.timedelta64[timedelta | int | None]]",
-            ),
-            np_1darray,
-            np.timedelta64,
-        )
-        check(
-            assert_type(
-                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                "np_1darray[np.timedelta64[timedelta | int | None]]",
-            ),
-            np_1darray,
-            np.timedelta64,
-        )
+        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+        pass
     else:
         # TODO: pandas-dev/pandas-stubs#1786
         check(

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -15,6 +15,7 @@ import io
 import math
 from pathlib import Path
 import re
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -2643,27 +2644,61 @@ def test_types_to_numpy() -> None:
         np.str_,
     )
     # DateTime64DType — parametric, use np.dtype(...)
-    check(
-        assert_type(s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt),
-        np_1darray,
-        np.datetime64,
-    )
+    if sys.version_info >= (3, 12):
+        # TODO: pandas-dev/pandas-stubs#1786 np_1darray[np.timedelta64[int]] is not ideal
+        check(
+            assert_type(
+                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
+                "np_1darray[np.datetime64[int]]",
+            ),
+            np_1darray,
+            np.datetime64,
+        )
+    else:
+        # TODO: pandas-dev/pandas-stubs#1786 investigate and report to pyrefly
+        check(
+            assert_type(  # pyrefly: ignore[assert-type]
+                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt
+            ),
+            np_1darray,
+            np.datetime64,
+        )
     # TimeDelta64DType — parametric, use np.dtype(...)
-    check(
-        assert_type(
-            s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-            np_1darray_td,
-        ),
-        np_1darray,
-        np.timedelta64,
-    )
-    check(
-        assert_type(
-            s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
-        ),
-        np_1darray,
-        np.timedelta64,
-    )
+    if sys.version_info >= (3, 12):
+        # TODO: pandas-dev/pandas-stubs#1786 np_1darray[np.timedelta64[int]] is not ideal
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+                "np_1darray[np.timedelta64[int]]",
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+                "np_1darray[np.timedelta64[int]]",
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+    else:
+        # TODO: pandas-dev/pandas-stubs#1786 investigate and report to pyrefly
+        check(
+            assert_type(  # pyrefly: ignore[assert-type]
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+                np_1darray_td,
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+        check(
+            assert_type(  # pyrefly: ignore[assert-type]
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
 
     # VoidDType — parametric, use np.dtype(...)
     check(

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2644,7 +2644,7 @@ def test_types_to_numpy() -> None:
         np.str_,
     )
     # DateTime64DType — parametric, use np.dtype(...)
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 12):
         check(
             assert_type(
                 s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
@@ -2653,9 +2653,6 @@ def test_types_to_numpy() -> None:
             np_1darray,
             np.datetime64,
         )
-    elif sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-        pass
     else:
         # TODO: pandas-dev/pandas-stubs#1786
         check(
@@ -2666,7 +2663,7 @@ def test_types_to_numpy() -> None:
             np.datetime64,
         )
     # TimeDelta64DType — parametric, use np.dtype(...)
-    if sys.version_info >= (3, 14):
+    if sys.version_info >= (3, 12):
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
@@ -2683,9 +2680,6 @@ def test_types_to_numpy() -> None:
             np_1darray,
             np.timedelta64,
         )
-    elif sys.version_info >= (3, 12):
-        # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-        pass
     else:
         # TODO: pandas-dev/pandas-stubs#1786
         check(

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -15,6 +15,7 @@ import io
 import math
 from pathlib import Path
 import re
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -2643,26 +2644,58 @@ def test_types_to_numpy() -> None:
         np.str_,
     )
     # DateTime64DType — parametric, use np.dtype(...)
-    check(
-        assert_type(s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt),
-        np_1darray,
-        np.datetime64,
-    )
+    if sys.version_info >= (3, 12):
+        check(
+            assert_type(
+                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
+                np_1darray[np.datetime64[int]],
+            ),
+            np_1darray,
+            np.datetime64,
+        )
+    else:
+        check(
+            assert_type(
+                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt
+            ),
+            np_1darray,
+            np.datetime64,
+        )
     # TimeDelta64DType — parametric, use np.dtype(...)
-    check(
-        assert_type(
-            s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
-        ),
-        np_1darray,
-        np.timedelta64,
-    )
-    check(
-        assert_type(
-            s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
-        ),
-        np_1darray,
-        np.timedelta64,
-    )
+    if sys.version_info >= (3, 12):
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+                np_1darray[np.timedelta64[int]],
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+                np_1darray[np.timedelta64[int]],
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+    else:
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
+                np_1darray_td,
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+
     # VoidDType — parametric, use np.dtype(...)
     check(
         assert_type(

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2649,7 +2649,7 @@ def test_types_to_numpy() -> None:
         check(
             assert_type(
                 s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
-                np_1darray[np.datetime64[int]],
+                "np_1darray[np.datetime64[int]]",
             ),
             np_1darray,
             np.datetime64,
@@ -2658,7 +2658,7 @@ def test_types_to_numpy() -> None:
         check(
             assert_type(
                 s_date.to_numpy(dtype=np.dtype("datetime64[ns]")),
-                np_1darray[np.datetime64[date | int | None]],
+                "np_1darray[np.datetime64[date | int | None]]",
             ),
             np_1darray,
             np.datetime64,
@@ -2677,7 +2677,7 @@ def test_types_to_numpy() -> None:
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                np_1darray[np.timedelta64[int]],
+                "np_1darray[np.timedelta64[int]]",
             ),
             np_1darray,
             np.timedelta64,
@@ -2685,7 +2685,7 @@ def test_types_to_numpy() -> None:
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                np_1darray[np.timedelta64[int]],
+                "np_1darray[np.timedelta64[int]]",
             ),
             np_1darray,
             np.timedelta64,
@@ -2694,7 +2694,7 @@ def test_types_to_numpy() -> None:
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                np_1darray[np.timedelta64[timedelta | int | None]],
+                "np_1darray[np.timedelta64[timedelta | int | None]]",
             ),
             np_1darray,
             np.timedelta64,
@@ -2702,7 +2702,7 @@ def test_types_to_numpy() -> None:
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")),
-                np_1darray[np.timedelta64[timedelta | int | None]],
+                "np_1darray[np.timedelta64[timedelta | int | None]]",
             ),
             np_1darray,
             np.timedelta64,

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -31,8 +31,10 @@ import pyarrow as pa
 import pytest
 
 from tests import (
+    NP_GTE_25,
     TYPE_CHECKING_INVALID_USAGE,
     check,
+    pytest_warns_conditioned,
 )
 from tests._typing import TimeUnit
 
@@ -141,7 +143,12 @@ def test_sparse_dtype() -> None:
     check(assert_type(pd.SparseDtype(float), pd.SparseDtype), pd.SparseDtype)
     # TODO: pandas-dev/pandas-stubs#1786, also disable "datetime64"
     if sys.version_info >= (3, 12):
-        pass
+        check(
+            assert_type(pd.SparseDtype(np.datetime64), pd.SparseDtype), pd.SparseDtype
+        )
+        check(
+            assert_type(pd.SparseDtype(np.timedelta64), pd.SparseDtype), pd.SparseDtype
+        )
     else:
         check(
             assert_type(pd.SparseDtype(np.datetime64), pd.SparseDtype), pd.SparseDtype
@@ -171,13 +178,15 @@ def test_sparse_dtype_fill_value_subtype_compatibility() -> None:
     check(assert_type(s_dt_bool.fill_value, Scalar | None), bool)
 
     # datetime64 subtype: default fill_value is NaT
-    # TODO: pandas-dev/pandas-stubs#1786, also disable "datetime64"
-    if sys.version_info >= (3, 12):
-        pass
-    else:
+    # TODO: pandas-dev/pandas-stubs#1786 remove the conditional warning
+    with pytest_warns_conditioned(
+        DeprecationWarning,
+        r"The 'generic' unit for NumPy timedelta is deprecated",
+        NP_GTE_25,
+    ):
         s_dt_dt = pd.SparseDtype(np.datetime64)
-        check(assert_type(s_dt_dt.subtype, np.dtype), np.dtypes.DateTime64DType)
-        check(assert_type(s_dt_dt.fill_value, Scalar | None), np.datetime64)
+    check(assert_type(s_dt_dt.subtype, np.dtype), np.dtypes.DateTime64DType)
+    check(assert_type(s_dt_dt.fill_value, Scalar | None), np.datetime64)
 
     # passing a fill_value incompatible with the subtype is both a static type error
     # and a runtime ValueError

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -4,6 +4,7 @@ from datetime import (
     timedelta,
     timezone,
 )
+import sys
 from typing import (
     TYPE_CHECKING,
     Literal,
@@ -138,9 +139,17 @@ def test_sparse_dtype() -> None:
     check(assert_type(pd.SparseDtype(np.int64), pd.SparseDtype), pd.SparseDtype)
     check(assert_type(pd.SparseDtype(str), pd.SparseDtype), pd.SparseDtype)
     check(assert_type(pd.SparseDtype(float), pd.SparseDtype), pd.SparseDtype)
-    check(assert_type(pd.SparseDtype(np.datetime64), pd.SparseDtype), pd.SparseDtype)
-    check(assert_type(pd.SparseDtype(np.timedelta64), pd.SparseDtype), pd.SparseDtype)
-    check(assert_type(pd.SparseDtype("datetime64"), pd.SparseDtype), pd.SparseDtype)
+    # TODO: pandas-dev/pandas-stubs#1786, also disable "datetime64"
+    if sys.version_info >= (3, 12):
+        pass
+    else:
+        check(
+            assert_type(pd.SparseDtype(np.datetime64), pd.SparseDtype), pd.SparseDtype
+        )
+        check(
+            assert_type(pd.SparseDtype(np.timedelta64), pd.SparseDtype), pd.SparseDtype
+        )
+    check(assert_type(pd.SparseDtype("datetime64[ms]"), pd.SparseDtype), pd.SparseDtype)
     check(assert_type(pd.SparseDtype(), pd.SparseDtype), pd.SparseDtype)
     check(assert_type(s_dt.fill_value, Scalar | None), int)
 
@@ -162,9 +171,13 @@ def test_sparse_dtype_fill_value_subtype_compatibility() -> None:
     check(assert_type(s_dt_bool.fill_value, Scalar | None), bool)
 
     # datetime64 subtype: default fill_value is NaT
-    s_dt_dt = pd.SparseDtype(np.datetime64)
-    check(assert_type(s_dt_dt.subtype, np.dtype), np.dtypes.DateTime64DType)
-    check(assert_type(s_dt_dt.fill_value, Scalar | None), np.datetime64)
+    # TODO: pandas-dev/pandas-stubs#1786, also disable "datetime64"
+    if sys.version_info >= (3, 12):
+        pass
+    else:
+        s_dt_dt = pd.SparseDtype(np.datetime64)
+        check(assert_type(s_dt_dt.subtype, np.dtype), np.dtypes.DateTime64DType)
+        check(assert_type(s_dt_dt.fill_value, Scalar | None), np.datetime64)
 
     # passing a fill_value incompatible with the subtype is both a static type error
     # and a runtime ValueError

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -4,7 +4,6 @@ from datetime import (
     timedelta,
     timezone,
 )
-import sys
 from typing import (
     TYPE_CHECKING,
     Literal,

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -141,18 +141,20 @@ def test_sparse_dtype() -> None:
     check(assert_type(pd.SparseDtype(np.int64), pd.SparseDtype), pd.SparseDtype)
     check(assert_type(pd.SparseDtype(str), pd.SparseDtype), pd.SparseDtype)
     check(assert_type(pd.SparseDtype(float), pd.SparseDtype), pd.SparseDtype)
-    # TODO: pandas-dev/pandas-stubs#1786, also disable "datetime64"
-    if sys.version_info >= (3, 12):
+    # TODO: pandas-dev/pandas-stubs#1786 remove the conditional warning
+    with pytest_warns_conditioned(
+        DeprecationWarning,
+        r"The 'generic' unit for NumPy timedelta is deprecated",
+        NP_GTE_25,
+    ):
         check(
             assert_type(pd.SparseDtype(np.datetime64), pd.SparseDtype), pd.SparseDtype
         )
-        check(
-            assert_type(pd.SparseDtype(np.timedelta64), pd.SparseDtype), pd.SparseDtype
-        )
-    else:
-        check(
-            assert_type(pd.SparseDtype(np.datetime64), pd.SparseDtype), pd.SparseDtype
-        )
+    with pytest_warns_conditioned(
+        DeprecationWarning,
+        r"The 'generic' unit for NumPy timedelta is deprecated",
+        NP_GTE_25,
+    ):
         check(
             assert_type(pd.SparseDtype(np.timedelta64), pd.SparseDtype), pd.SparseDtype
         )

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -554,11 +554,11 @@ def test_isna() -> None:
     assert check(assert_type(pd.notna(np_dt), bool), bool)
     assert not check(assert_type(pd.isna(np_dt), bool), bool)
 
-    np_td = np.timedelta64(py_td)
+    np_td = np.timedelta64(py_td, "us")
     assert check(assert_type(pd.notna(np_td), bool), bool)
     assert not check(assert_type(pd.isna(np_td), bool), bool)
 
-    np_nat = np.timedelta64("NaT")
+    np_nat = np.timedelta64("NaT", "Y")
     assert check(assert_type(pd.isna(np_nat), bool), bool)
     assert not check(assert_type(pd.notna(np_nat), bool), bool)
 

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -111,12 +111,9 @@ def test_types_arithmetic() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         # TODO: pandas-dev/pandas-stubs#1511 numpy.datetime64.__sub__ gives datetime.timedelta, which has higher priority
-        if sys.version_info >= (3, 14):
+        if sys.version_info >= (3, 12):
             assert_type(ts_np - ts, dt.timedelta)
             assert_type(ts_np_time - ts, dt.timedelta)
-        elif sys.version_info >= (3, 12):
-            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
-            pass
         else:
             assert_type(  # pyrefly: ignore[assert-type]
                 ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -115,13 +115,8 @@ def test_types_arithmetic() -> None:
             assert_type(ts_np - ts, dt.timedelta)
             assert_type(ts_np_time - ts, dt.timedelta)
         elif sys.version_info >= (3, 12):
-            assert_type(
-                ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
-            )
-            assert_type(
-                ts_np_time - ts,  # pyright: ignore[reportAssertTypeFailure]
-                dt.timedelta,
-            )
+            # TODO: pandas-dev/pandas-stubs#1786 inconsistecy between the stubs repo and the installed stubs
+            pass
         else:
             assert_type(  # pyrefly: ignore[assert-type]
                 ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -119,8 +119,8 @@ def test_types_arithmetic() -> None:
                 ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
             )
             assert_type(  # pyrefly: ignore[assert-type]
-                ts_np_time - ts,
-                dt.timedelta,  # pyright: ignore[reportAssertTypeFailure]
+                ts_np_time - ts,  # pyright: ignore[reportAssertTypeFailure]
+                dt.timedelta,
             )
 
 

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -110,11 +110,12 @@ def test_types_arithmetic() -> None:
     check(assert_type(ts - dt.datetime(2021, 1, 3), pd.Timedelta), pd.Timedelta)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        # TODO: pandas-dev/pandas-stubs#1511 numpy.datetime64.__sub__ gives datetime.timedelta, which has higher priority
         if sys.version_info >= (3, 12):
+            # numpy >= 2.5 has eliminated the type checking errors
             assert_type(ts_np - ts, dt.timedelta)
             assert_type(ts_np_time - ts, dt.timedelta)
         else:
+            # TODO: pandas-dev/pandas-stubs#1511 for numpy < 2.5, numpy.datetime64.__sub__ gives datetime.timedelta, which has higher priority
             assert_type(  # pyrefly: ignore[assert-type]
                 ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
             )

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -123,10 +123,10 @@ def test_types_arithmetic() -> None:
                 dt.timedelta,
             )
         else:
-            assert_type(
+            assert_type(  # pyrefly: ignore[assert-type]
                 ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
             )
-            assert_type(
+            assert_type(  # pyrefly: ignore[assert-type]
                 ts_np_time - ts,  # pyright: ignore[reportAssertTypeFailure]
                 dt.timedelta,
             )

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import sys
 from typing import (
     assert_never,
     assert_type,
@@ -110,12 +111,17 @@ def test_types_arithmetic() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         # TODO: pandas-dev/pandas-stubs#1511 numpy.datetime64.__sub__ gives datetime.timedelta, which has higher priority
-        assert_type(  # pyrefly: ignore[assert-type]
-            ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
-        )
-        assert_type(  # pyrefly: ignore[assert-type]
-            ts_np_time - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
-        )
+        if sys.version_info >= (3, 12):
+            assert_type(ts_np - ts, dt.timedelta)
+            assert_type(ts_np_time - ts, dt.timedelta)
+        else:
+            assert_type(  # pyrefly: ignore[assert-type]
+                ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
+            )
+            assert_type(  # pyrefly: ignore[assert-type]
+                ts_np_time - ts,
+                dt.timedelta,  # pyright: ignore[reportAssertTypeFailure]
+            )
 
 
 def test_types_comparison() -> None:
@@ -1666,8 +1672,8 @@ def test_timedelta_range() -> None:
     check(
         assert_type(
             pd.timedelta_range(
-                np.timedelta64(86400000000000),
-                np.timedelta64(864000000000000),
+                np.timedelta64(86400000000000, "ns"),
+                np.timedelta64(864000000000000, "ns"),
                 periods=10,
             ),
             pd.TimedeltaIndex,

--- a/tests/test_timefuncs.py
+++ b/tests/test_timefuncs.py
@@ -111,14 +111,22 @@ def test_types_arithmetic() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         # TODO: pandas-dev/pandas-stubs#1511 numpy.datetime64.__sub__ gives datetime.timedelta, which has higher priority
-        if sys.version_info >= (3, 12):
+        if sys.version_info >= (3, 14):
             assert_type(ts_np - ts, dt.timedelta)
             assert_type(ts_np_time - ts, dt.timedelta)
-        else:
-            assert_type(  # pyrefly: ignore[assert-type]
+        elif sys.version_info >= (3, 12):
+            assert_type(
                 ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
             )
-            assert_type(  # pyrefly: ignore[assert-type]
+            assert_type(
+                ts_np_time - ts,  # pyright: ignore[reportAssertTypeFailure]
+                dt.timedelta,
+            )
+        else:
+            assert_type(
+                ts_np - ts, dt.timedelta  # pyright: ignore[reportAssertTypeFailure]
+            )
+            assert_type(
                 ts_np_time - ts,  # pyright: ignore[reportAssertTypeFailure]
                 dt.timedelta,
             )


### PR DESCRIPTION
- [x] Partially addresses #1786
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
