### PR TITLE
Allow `df.loc[Scalar, SequenceNotStr[Scalar]]`

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -267,7 +267,12 @@ class _LocIndexerFrame(_LocIndexer, Generic[_T]):
     def __getitem__(self, idx: Scalar) -> Series | _T: ...
     @overload
     def __getitem__(
-        self, idx: tuple[Scalar, slice] | tuple[slice, tuple[Scalar, ...]]
+        self,
+        idx: (
+            tuple[Scalar, slice]
+            | tuple[slice, tuple[Scalar, ...]]
+            | tuple[Scalar, SequenceNotStr[Scalar]]
+        ),
     ) -> Series | _T: ...
     @overload
     def __getitem__(

--- a/tests/frame/test_indexing.py
+++ b/tests/frame/test_indexing.py
@@ -575,8 +575,7 @@ def test_loc_list_str() -> None:
 
 def test_loc_returns_series() -> None:
     df = pd.DataFrame(
-      {"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]},
-      index=[10, 20, 30, 40]
+        {"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
     )
     check(assert_type(df.loc[10, :], pd.Series | pd.DataFrame), pd.Series)
     check(assert_type(df.loc[10, ["x", "y"]], pd.Series | pd.DataFrame), pd.Series)

--- a/tests/frame/test_indexing.py
+++ b/tests/frame/test_indexing.py
@@ -574,9 +574,13 @@ def test_loc_list_str() -> None:
 
 
 def test_loc_returns_series() -> None:
-    df1 = pd.DataFrame({"x": [1, 2, 3, 4]}, index=[10, 20, 30, 40])
-    df2 = df1.loc[10, :]
-    check(assert_type(df2, pd.Series | pd.DataFrame), pd.Series)
+    df = pd.DataFrame(
+      {"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]},
+      index=[10, 20, 30, 40]
+    )
+    check(assert_type(df.loc[10, :], pd.Series | pd.DataFrame), pd.Series)
+    check(assert_type(df.loc[10, ["x", "y"]], pd.Series | pd.DataFrame), pd.Series)
+    check(assert_type(df.loc[[10, 20], "x"], pd.Series), pd.Series)
 
 
 def test_frame_single_slice() -> None:

--- a/tests/frame/test_indexing.py
+++ b/tests/frame/test_indexing.py
@@ -577,8 +577,12 @@ def test_loc_returns_series() -> None:
     df = pd.DataFrame(
         {"x": [1, 2, 3, 4], "y": [10, 20, 30, 40]}, index=[10, 20, 30, 40]
     )
+    ind = pd.MultiIndex.from_product([[10, 20], [80, 90]])
+    df2 = df.set_index(ind)
+
     check(assert_type(df.loc[10, :], pd.Series | pd.DataFrame), pd.Series)
     check(assert_type(df.loc[10, ["x", "y"]], pd.Series | pd.DataFrame), pd.Series)
+    check(assert_type(df2.loc[10, ["x", "y"]], pd.Series | pd.DataFrame), pd.DataFrame)
     check(assert_type(df.loc[[10, 20], "x"], pd.Series), pd.Series)
 
 


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Currently when I run
```
df = pd.DataFrame(
  {"x": [1,2,3,4], "y": [10, 20, 30, 40],
  index=pd.Index[10, 20, 30, 40],
)
df.loc[10, ["x", "y"]]
```
mypy throws `Invalid Index Type`. I added a (failing) test and then patched the overload to make the test pass.

BTW, if it's preferred for me to open issues before submitting PRs, please let me know; I was just trying to streamline things.
