### PR TITLE
TST: #1799 enable `ty` in three places

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -353,9 +353,7 @@ respect-type-ignore-comments = false
 
 [tool.ty.src]
 exclude = [
-  "tests/__init__.py",
   "tests/arrays/**/*",
-  "tests/extension/**/*",
   "tests/frame/**/*",
   "tests/indexes/**/*",
   "tests/scalars/**/*",
@@ -363,7 +361,6 @@ exclude = [
   "tests/test_api_types.py",
   "tests/test_extension.py",
   "tests/test_groupby.py",
-  "tests/test_interval.py",
   "tests/test_natype.py",
   "tests/test_pandas.py",
   "tests/test_resampler.py",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -94,7 +94,7 @@ def check(
         value = cast(pd.Index, actual)[index_to_check_for_type]
     elif isinstance(actual, BaseGroupBy):
         # `BaseGroupBy.obj` is internal and untyped
-        value = actual.obj  # type: ignore[attr-defined] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] # pyrefly: ignore[missing-attribute]
+        value = actual.obj  # type: ignore[attr-defined] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] # pyrefly: ignore[missing-attribute] # ty: ignore[unresolved-attribute]
     elif isinstance(actual, Iterable):
         # T_co in Iterable[T_co] does not have a default value and `actual` is Iterable[Unknown] by pyright
         value = next(iter(cast("Iterable[Any]", actual)))

--- a/tests/extension/decimal/array.py
+++ b/tests/extension/decimal/array.py
@@ -254,12 +254,9 @@ class DecimalArray(OpsMixin, ExtensionArray):
             assert isinstance(value, Iterable)
             if is_scalar(key):
                 raise ValueError("setting an array element with a sequence.")
-            value = [
-                decimal.Decimal(v)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-                for v in value
-            ]
+            value = [decimal.Decimal(v) for v in value]  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
         else:
-            value = decimal.Decimal(value)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+            value = decimal.Decimal(value)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
         key = check_array_indexer(self, key)
         self._data[key] = value

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -87,9 +87,10 @@ def test_interval_length() -> None:
 
     check(assert_type(idres, "pd.Interval[pd.Timestamp]"), pd.Interval, pd.Timestamp)
     if TYPE_CHECKING_INVALID_USAGE:
-        _00 = 20 in i1  # type: ignore[operator] # pyright: ignore[reportOperatorIssue] # pyrefly: ignore[unsupported-operation]
-        _01 = i1 + pd.Timestamp("2000-03-03")  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _02 = i1 * 3  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _00 = 20 in i1  # type: ignore[operator] # pyright: ignore[reportOperatorIssue] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _01 = i1 + pd.Timestamp("2000-03-03")  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _02 = i1 * 3  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        # TODO: astral-sh/ty#3898 missing a ty ignore
         _03 = i1 * pd.Timedelta(seconds=20)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
 
     i2 = pd.Interval(10, 20)
@@ -106,8 +107,8 @@ def test_interval_length() -> None:
     check(assert_type(i2 * 4.2, "pd.Interval[float]"), pd.Interval, float)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _10 = pd.Timestamp("2001-01-02") in i2  # type: ignore[operator] # pyright: ignore[reportOperatorIssue] # pyrefly: ignore[unsupported-operation]
-        _11 = i2 + pd.Timedelta(seconds=20)  # type: ignore[type-var] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _10 = pd.Timestamp("2001-01-02") in i2  # type: ignore[operator] # pyright: ignore[reportOperatorIssue] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _11 = i2 + pd.Timedelta(seconds=20)  # type: ignore[type-var] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
     i3 = pd.Interval(13.2, 19.5)
     check(assert_type(i3.length, float), float)
     check(assert_type(i3.left, float), float)
@@ -119,8 +120,8 @@ def test_interval_length() -> None:
     check(assert_type(i3 + 3, "pd.Interval[float]"), pd.Interval, float)
     check(assert_type(i3 * 3, "pd.Interval[float]"), pd.Interval, float)
     if TYPE_CHECKING_INVALID_USAGE:
-        _20 = pd.Timestamp("2001-01-02") in i3  # type: ignore[operator] # pyright: ignore[reportOperatorIssue] # pyrefly: ignore[unsupported-operation]
-        _21 = i3 + pd.Timedelta(seconds=20)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _20 = pd.Timestamp("2001-01-02") in i3  # type: ignore[operator] # pyright: ignore[reportOperatorIssue] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _21 = i3 + pd.Timedelta(seconds=20)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
 
 def test_interval_array_contains() -> None:


### PR DESCRIPTION
- [x] Addresses #1799 (Replace xxxx with the Github issue number)
- [x] Enables `ty` in  `tests/__init__.py`, `tests/extension/**/*` and `tests/test_interval.py`
- [x] Raises astral-sh/ty#3898
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
