### PR TITLE
docs: remove addressed note re pandas 3 coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ convention of providing stubs in a separate package, as specified in [PEP 561](h
 pandas.  In general, these stubs are narrower than what is possibly allowed by pandas,
 but follow a convention of suggesting best recommended practices for using pandas.
 
-The stubs are likely incomplete in terms of covering the published API of pandas.  NOTE: The current 3.0.x releases of pandas-stubs do not support all of the new features of pandas 3.0.  See this [tracker](https://github.com/pandas-dev/pandas-stubs/issues/1641) to understand the current compatibility with version 3.0.
+The stubs are likely incomplete in terms of covering the published API of pandas.
 
 The stubs are tested with [mypy](http://mypy-lang.org/) and [pyright](https://github.com/microsoft/pyright#readme) and are currently shipped with the Visual Studio Code extension
 [pylance](https://github.com/microsoft/pylance-release#readme).


### PR DESCRIPTION
- [x] ~Closes #xxxx (Replace xxxx with the Github issue number)~
- [x] ~Tests added (Please use `assert_type()` to assert the type of any return value)~
- [x] ~If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.~

It sounds like this isn't true any more based on https://github.com/pandas-dev/pandas-stubs/issues/1654#issuecomment-4479473657