### PR TITLE
GH1796 Add super class StringMethod with __iter__ banned

### DIFF
--- a/pandas-stubs/core/strings/accessor.pyi
+++ b/pandas-stubs/core/strings/accessor.pyi
@@ -32,10 +32,12 @@ from pandas._typing import (
     np_ndarray_str,
 )
 
-@type_check_only
-class IndexStringMethods(NoNewAttributesMixin, Generic[S2]):
-    def __getitem__(self, key: _slice | int) -> Index[str]: ...
+class StringMethods(NoNewAttributesMixin, Generic[S2]):
     def __iter__(self) -> Never: ...
+
+@type_check_only
+class IndexStringMethods(StringMethods[S2]):
+    def __getitem__(self, key: _slice | int) -> Index[str]: ...
     @overload
     def cat(
         self: IndexStringMethods[str],
@@ -292,9 +294,8 @@ class IndexStringMethods(NoNewAttributesMixin, Generic[S2]):
     def isascii(self: IndexStringMethods[str]) -> np_1darray_bool: ...
 
 @type_check_only
-class SeriesStringMethods(NoNewAttributesMixin, Generic[S2]):
+class SeriesStringMethods(StringMethods[S2]):
     def __getitem__(self, key: _slice | int) -> Series[str]: ...
-    def __iter__(self) -> Never: ...
     @overload
     def cat(
         self: SeriesStringMethods[str],

--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -4,6 +4,7 @@ from typing import assert_type
 
 import numpy as np
 import pandas as pd
+from pandas.core.strings.accessor import StringMethods
 import pytest
 
 from tests import (
@@ -14,6 +15,14 @@ from tests._typing import np_1darray_bool
 
 DATA = ["applep", "bananap", "Cherryp", "DATEp", "eGGpLANTp", "123p", "23.45p"]
 DATA_BYTES = [b"applep", b"bananap"]
+
+
+def test_accessors_isinstance() -> None:
+    """Test that Series.str and Index.str supertype is `StringMethods`."""
+    s_str = pd.Series(DATA)
+    i_str = pd.Series(DATA)
+    isinstance(s_str, StringMethods)
+    isinstance(i_str, StringMethods)
 
 
 def test_string_accessors_type_preserving_series() -> None:

--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -21,8 +21,8 @@ def test_accessors_isinstance() -> None:
     """Test that Series.str and Index.str supertype is `StringMethods`."""
     s_str = pd.Series(DATA)
     i_str = pd.Series(DATA)
-    isinstance(s_str, StringMethods)
-    isinstance(i_str, StringMethods)
+    assert isinstance(s_str.str, StringMethods)
+    assert isinstance(i_str.str, StringMethods)
 
 
 def test_string_accessors_type_preserving_series() -> None:


### PR DESCRIPTION
- [x] Closes #1796
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
