### PR TITLE
Fix missing weekmask and calendar params in CustomBusinessMonth stubs

### DIFF
--- a/pandas-stubs/_libs/tslibs/offsets.pyi
+++ b/pandas-stubs/_libs/tslibs/offsets.pyi
@@ -222,8 +222,10 @@ class _CustomBusinessMonth(SingleConstructorOffset):
         self,
         n: int = ...,
         normalize: bool = ...,
-        offset: timedelta = ...,
+        weekmask: str = ...,
         holidays: list[Any] | None = ...,
+        calendar: AbstractHolidayCalendar | np.busdaycalendar | None = ...,
+        offset: timedelta = ...,
     ) -> None: ...
 
 class CustomBusinessDay(BusinessDay):
@@ -246,8 +248,27 @@ class CustomBusinessHour(BusinessHour):
         holidays: list[Any] | None = ...,
     ) -> None: ...
 
-class CustomBusinessMonthEnd(_CustomBusinessMonth): ...
-class CustomBusinessMonthBegin(_CustomBusinessMonth): ...
+class CustomBusinessMonthEnd(_CustomBusinessMonth):
+    def __init__(
+        self,
+        n: int = ...,
+        normalize: bool = ...,
+        weekmask: str = ...,
+        holidays: list[Any] | None = ...,
+        calendar: AbstractHolidayCalendar | np.busdaycalendar | None = ...,
+        offset: timedelta = ...,
+    ) -> None: ...
+
+class CustomBusinessMonthBegin(_CustomBusinessMonth):
+    def __init__(
+        self,
+        n: int = ...,
+        normalize: bool = ...,
+        weekmask: str = ...,
+        holidays: list[Any] | None = ...,
+        calendar: AbstractHolidayCalendar | np.busdaycalendar | None = ...,
+        offset: timedelta = ...,
+    ) -> None: ...
 
 class DateOffset(RelativeDeltaOffset):
     def __init__(

--- a/pandas-stubs/_libs/tslibs/offsets.pyi
+++ b/pandas-stubs/_libs/tslibs/offsets.pyi
@@ -248,27 +248,8 @@ class CustomBusinessHour(BusinessHour):
         holidays: list[Any] | None = ...,
     ) -> None: ...
 
-class CustomBusinessMonthEnd(_CustomBusinessMonth):
-    def __init__(
-        self,
-        n: int = ...,
-        normalize: bool = ...,
-        weekmask: str = ...,
-        holidays: list[Any] | None = ...,
-        calendar: AbstractHolidayCalendar | np.busdaycalendar | None = ...,
-        offset: timedelta = ...,
-    ) -> None: ...
-
-class CustomBusinessMonthBegin(_CustomBusinessMonth):
-    def __init__(
-        self,
-        n: int = ...,
-        normalize: bool = ...,
-        weekmask: str = ...,
-        holidays: list[Any] | None = ...,
-        calendar: AbstractHolidayCalendar | np.busdaycalendar | None = ...,
-        offset: timedelta = ...,
-    ) -> None: ...
+class CustomBusinessMonthEnd(_CustomBusinessMonth): ...
+class CustomBusinessMonthBegin(_CustomBusinessMonth): ...
 
 class DateOffset(RelativeDeltaOffset):
     def __init__(

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -5,6 +5,7 @@ from dateutil.relativedelta import MO
 import pandas as pd
 
 from tests import check
+import numpy as np
 
 from pandas.tseries.holiday import (
     AbstractHolidayCalendar,
@@ -45,3 +46,32 @@ def test_holiday_exclude_dates() -> None:
         exclude_dates=exclude,
     )
     check(assert_type(queens_jubilee_uk_spring_bank_holiday, Holiday), Holiday)
+
+def test_custom_business_month() -> None:
+
+    cal = np.busdaycalendar()
+
+    check(
+        assert_type(pd.offsets.CustomBusinessMonthBegin(calendar=cal),
+        pd.offsets.CustomBusinessMonthBegin),
+        pd.offsets.CustomBusinessMonthBegin,
+    )
+    check(
+        assert_type(pd.offsets.CustomBusinessMonthEnd(calendar=cal),
+        pd.offsets.CustomBusinessMonthEnd),
+        pd.offsets.CustomBusinessMonthEnd,
+    )
+    check(
+        assert_type(
+            pd.offsets.CustomBusinessMonthBegin(weekmask="Mon Tue Wed Thu Fri"),
+            pd.offsets.CustomBusinessMonthBegin,
+        ),
+        pd.offsets.CustomBusinessMonthBegin,
+    )
+    check(
+        assert_type(
+            pd.offsets.CustomBusinessMonthEnd(weekmask="Mon Tue Wed Thu Fri"),
+            pd.offsets.CustomBusinessMonthEnd,
+        ),
+        pd.offsets.CustomBusinessMonthEnd,
+    )

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -2,10 +2,10 @@ from datetime import datetime
 from typing import assert_type
 
 from dateutil.relativedelta import MO
+import numpy as np
 import pandas as pd
 
 from tests import check
-import numpy as np
 
 from pandas.tseries.holiday import (
     AbstractHolidayCalendar,
@@ -47,18 +47,23 @@ def test_holiday_exclude_dates() -> None:
     )
     check(assert_type(queens_jubilee_uk_spring_bank_holiday, Holiday), Holiday)
 
+
 def test_custom_business_month() -> None:
 
     cal = np.busdaycalendar()
 
     check(
-        assert_type(pd.offsets.CustomBusinessMonthBegin(calendar=cal),
-        pd.offsets.CustomBusinessMonthBegin),
+        assert_type(
+            pd.offsets.CustomBusinessMonthBegin(calendar=cal),
+            pd.offsets.CustomBusinessMonthBegin,
+        ),
         pd.offsets.CustomBusinessMonthBegin,
     )
     check(
-        assert_type(pd.offsets.CustomBusinessMonthEnd(calendar=cal),
-        pd.offsets.CustomBusinessMonthEnd),
+        assert_type(
+            pd.offsets.CustomBusinessMonthEnd(calendar=cal),
+            pd.offsets.CustomBusinessMonthEnd,
+        ),
         pd.offsets.CustomBusinessMonthEnd,
     )
     check(

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -1,4 +1,7 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timedelta,
+)
 from typing import assert_type
 
 from dateutil.relativedelta import MO
@@ -76,6 +79,20 @@ def test_custom_business_month() -> None:
     check(
         assert_type(
             pd.offsets.CustomBusinessMonthEnd(weekmask="Mon Tue Wed Thu Fri"),
+            pd.offsets.CustomBusinessMonthEnd,
+        ),
+        pd.offsets.CustomBusinessMonthEnd,
+    )
+    check(
+        assert_type(
+            pd.offsets.CustomBusinessMonthBegin(offset=timedelta(hours=1)),
+            pd.offsets.CustomBusinessMonthBegin,
+        ),
+        pd.offsets.CustomBusinessMonthBegin,
+    )
+    check(
+        assert_type(
+            pd.offsets.CustomBusinessMonthEnd(offset=timedelta(hours=1)),
             pd.offsets.CustomBusinessMonthEnd,
         ),
         pd.offsets.CustomBusinessMonthEnd,


### PR DESCRIPTION
- [x] Closes pandas-dev/pandas#66195
- [x] `CustomBusinessMonthBegin` and `CustomBusinessMonthEnd` were missing `weekmask` and `calendar` in their stubs. Added missing params to `_CustomBusinessMonth` base class and added tests in `test_holidays.py`