### PR TITLE
GH1815 Fix nightly warnings and rollback function for nightly checks

### DIFF
--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import subprocess
 import sys
 
@@ -108,11 +109,13 @@ def nightly_pandas() -> None:
 
 
 def _get_version_from_pyproject(program: str) -> str:
+    """Find version of a package from the pyproject.toml file."""
     text = Path("pyproject.toml").read_text()
-    version_line = next(
-        line for line in text.splitlines() if line.startswith(f"{program} = ")
-    )
-    return version_line.split('"')[1]
+    # handle <, >, ==, <=, >= cases
+    match = re.search(rf'"{re.escape(program)}[=<>~!]+([^"]+)"', text)
+    if match is None:
+        raise AssertionError(f"Could not find {program} in pyproject.toml")
+    return match.group(1)
 
 
 def released_pandas() -> None:

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -114,7 +114,7 @@ def _get_version_from_pyproject(program: str) -> str:
     # handle <, >, ==, <=, >= cases
     match = re.search(rf'"{re.escape(program)}[=<>~!]+([^"]+)"', text)
     if match is None:
-        raise AssertionError(f"Could not find {program} in pyproject.toml")
+        raise KeyError(f"Could not find {program} in pyproject.toml")
     return match.group(1)
 
 

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -3791,9 +3791,15 @@ def test_align() -> None:
     aligned_df0, aligned_s0 = df0.align(s0, axis="index")
     check(assert_type(aligned_df0, pd.DataFrame), pd.DataFrame)
     check(assert_type(aligned_s0, "pd.Series[str]"), pd.Series, str)
-    aligned_df0, aligned_s0 = df0.align(s0, axis="index", fill_value=0)
-    check(assert_type(aligned_df0, pd.DataFrame), pd.DataFrame)
-    check(assert_type(aligned_s0, "pd.Series[str]"), pd.Series, str)
+
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "'int' is not supported as a fill value for str dtype. In",
+        lower="3.0.99",
+    ):
+        aligned_df0, aligned_s0 = df0.align(s0, axis="index", fill_value=0)
+        check(assert_type(aligned_df0, pd.DataFrame), pd.DataFrame)
+        check(assert_type(aligned_s0, "pd.Series[str]"), pd.Series, str)
 
     s1 = pd.Series(data={"A": "A", "D": "D"})
     aligned_df0, aligned_s1 = df0.align(s1, axis="columns")

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1467,14 +1467,19 @@ def test_types_values() -> None:
         pd.Categorical,
         str,
     )
-    check(
-        assert_type(
-            pd.Series(pd.date_range("20130101", periods=3, tz="US/Eastern")).values,
-            np_1darray | ExtensionArray | pd.Categorical,
-        ),
-        np_1darray,
-        np.datetime64,
-    )
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        match="Series.values returning an ndarray that drops timezone",
+        lower="3.0.99",
+    ):
+        check(
+            assert_type(
+                pd.Series(pd.date_range("20130101", periods=3, tz="US/Eastern")).values,
+                np_1darray | ExtensionArray | pd.Categorical,
+            ),
+            np_1darray,
+            np.datetime64,
+        )
 
 
 def test_types_rename() -> None:


### PR DESCRIPTION
- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
