### PR TITLE
TYP: pandas-dev/pandas#30546 disallow `tuple` in `groupby`

### DIFF
--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -36,6 +36,7 @@ from pandas._typing import (
     AggFuncTypeFrame,
     ByT,
     CorrelationMethod,
+    CovariantList,
     Dtype,
     IndexLabel,
     Level,
@@ -319,10 +320,10 @@ class DataFrameGroupBy(GroupBy[DataFrame], Generic[ByT, _TT]):
         **kwargs: P.kwargs,
     ) -> DataFrame: ...
     @overload
-    def __getitem__(self, key: Scalar) -> SeriesGroupBy[Any, ByT]: ...  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+    def __getitem__(self, key: Scalar) -> SeriesGroupBy[Any, ByT]: ...
     @overload
     def __getitem__(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self, key: Iterable[Hashable]
+        self, key: CovariantList[Hashable]
     ) -> DataFrameGroupBy[ByT, _TT]: ...
     def nunique(self, dropna: bool = True) -> DataFrame: ...
     def idxmax(

--- a/pandas-stubs/core/groupby/groupby.pyi
+++ b/pandas-stubs/core/groupby/groupby.pyi
@@ -20,7 +20,10 @@ from typing import (
 
 import numpy as np
 from pandas.core.frame import DataFrame
-from pandas.core.groupby import generic
+from pandas.core.groupby.generic import (
+    DataFrameGroupBy,
+    SeriesGroupBy,
+)
 from pandas.core.groupby.indexing import (
     GroupByIndexingMixin,
     GroupByNthSelector,
@@ -47,6 +50,7 @@ from pandas._typing import (
     Axis,
     AxisInt,
     CalculationMethod,
+    CovariantList,
     Dtype,
     Frequency,
     IndexLabel,
@@ -410,15 +414,17 @@ class BaseGroupBy(GroupByIndexingMixin, Generic[NDFrameT]):
     @final
     def __iter__(self) -> Iterator[tuple[Hashable, NDFrameT]]: ...
     @overload
-    def __getitem__(self: BaseGroupBy[DataFrame], key: Scalar) -> generic.SeriesGroupBy[Any, Any]: ...  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+    def __getitem__(
+        self: BaseGroupBy[DataFrame], key: Scalar
+    ) -> SeriesGroupBy[Any, Any]: ...
     @overload
     def __getitem__(
-        self: BaseGroupBy[DataFrame], key: Iterable[Hashable]
-    ) -> generic.DataFrameGroupBy[Any, Any]: ...
+        self: BaseGroupBy[DataFrame], key: CovariantList[Hashable]
+    ) -> DataFrameGroupBy[Any, Any]: ...
     @overload
     def __getitem__(
         self: BaseGroupBy[Series[S1]],
         idx: list[str] | Index | Series[S1] | MaskType | tuple[Hashable | slice, ...],
-    ) -> generic.SeriesGroupBy[Any, Any]: ...
+    ) -> SeriesGroupBy[Any, Any]: ...
     @overload
     def __getitem__(self: BaseGroupBy[Series[S1]], idx: Scalar) -> S1: ...

--- a/tests/test_groupby.py
+++ b/tests/test_groupby.py
@@ -897,6 +897,9 @@ def test_groupby_getitem() -> None:
     check(assert_type(df.groupby("a")["b"].sum(), Series), Series, float)
     check(assert_type(df.groupby("a")[["b", "c"]].sum(), DataFrame), DataFrame)
 
+    if TYPE_CHECKING_INVALID_USAGE:
+        df.groupby("a")[("b", "c")]  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[bad-index]
+
 
 def test_series_value_counts() -> None:
     df = DataFrame({"a": [1, 1, 2], "b": [4, 5, 6]})


### PR DESCRIPTION
Restricts `DataFrameGroupBy.__getitem__` to return Never when a tuple is passed, aligning with pandas 2.0 behaviour where subsetting columns with a tuple is no longer supported (use a list instead).

- [x] Addresses #1579
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
