### PR TITLE
DOC: update markdowns

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,22 +7,24 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+## Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
+
 1. Provide a minimal runnable `pandas` example that is not properly checked by the stubs.
-2. Indicate which type checker you are using (`mypy` or  `pyright`).
+2. Indicate which type checker you are using (`mypy`, `pyright`, `pyrefly` or `ty`).
 3. Show the error message received from that type checker while checking your example.
 
+## System specifications
 
-**Please complete the following information:**
- - OS: [e.g. Windows, Linux, MacOS]
- - OS Version [e.g. 22]
- - python version
- - version of type checker
- - version of installed `pandas-stubs`
+- OS: [e.g. Windows, Linux, MacOS]
+- OS Version [e.g. 22]
+- python version
+- version of type checker
+- version of installed `pandas-stubs`
 
+## Additional context
 
-**Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,10 +19,10 @@ A clear and concise description of what the bug is.
 
 ## System specifications
 
-- OS and its version: [e.g. Windows 11 10.0.26200, Linux 6.6.87.1 / Ubuntu 26.04, macOS 26]
-- python version
-- type checker and its version
-- version of installed `pandas-stubs`
+- OS and its version: [e.g. Windows 11 10.0.26200, Linux 6.6.87.1 / Ubuntu 26.04, macOS 26]: 
+- python version: 
+- type checker and its version: 
+- version of installed `pandas-stubs`: 
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,10 +19,9 @@ A clear and concise description of what the bug is.
 
 ## System specifications
 
-- OS: [e.g. Windows, Linux, MacOS]
-- OS Version [e.g. 22]
+- OS and its version: [e.g. Windows 11 10.0.26200, Linux 6.6.87.1 / Ubuntu 26.04, macOS 26]
 - python version
-- version of type checker
+- type checker and its version
 - version of installed `pandas-stubs`
 
 ## Additional context

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ poetry run poe test_all
 
 All checks must pass before submitting changes. These commands verify:
 
-- Type stubs are correctly annotated (mypy, pyright, pyrefly)
+- Type stubs are correctly annotated (`mypy`, `pyright`, `pyrefly`)
 - Invalid usage is properly rejected by type checkers (ty)
 - Tests execute successfully at runtime (test)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ but follow a convention of suggesting best recommended practices for using panda
 
 The stubs are likely incomplete in terms of covering the published API of pandas.
 
-The stubs are tested with [mypy](http://mypy-lang.org/) and [pyright](https://github.com/microsoft/pyright#readme) and are currently shipped with the Visual Studio Code extension
+The stubs are tested with [mypy](http://mypy-lang.org/),
+[pyright](https://github.com/microsoft/pyright#readme) and
+[pyrefly](https://pyrefly.org/), and are currently shipped with the Visual Studio Code extension
 [pylance](https://github.com/microsoft/pylance-release#readme).
 
 ## Usage
@@ -75,6 +77,7 @@ decimals = pd.Series({'TSLA': 2, 'AMZN': 1})
 ## Versioning
 
 The version number of `pandas-stubs` follows the format **`x.y.z.yymmdd`**, where:
+
 - **`x.y.z`**: The version of pandas this release was **tested against** (e.g., `3.0.0` for pandas 3.0.0).
 - **`yymmdd`**: The release date of the stubs (year, month, day).
 
@@ -82,6 +85,7 @@ It is anticipated that the stubs will be released more frequently than pandas as
 public visibility.
 
 ### Compatibility with pandas
+
 - **No strict dependency**: `pandas-stubs` does **not** enforce a dependency on a specific pandas version. This allows you to use newer stubs with older pandas versions for forward compatibility.
 - **Recommended usage**:
   - Use the **latest `pandas-stubs`** to catch deprecations and API changes early, even if your pandas version is older.
@@ -184,7 +188,6 @@ Further, the [pandas-dev mailing list](https://mail.python.org/mailman/listinfo/
 There are also frequent [community meetings](https://pandas.pydata.org/docs/dev/development/community.html#community-meeting) for project maintainers open to the community as well as monthly [new contributor meetings](https://pandas.pydata.org/docs/dev/development/community.html#new-contributor-meeting) to help support new contributors.
 
 Additional information on the communication channels can be found on the [contributor community](https://pandas.pydata.org/docs/development/community.html) page.
-
 
 ## Contributing to pandas-stubs
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -98,7 +98,7 @@ at runtime.  Users are invited to verify the results provided progressivly by th
 type checkers and be warned if they are unreasonable.
 
 When there are several possible valid outcomes of an arithmetic expression,
-for example numeric types `Series[bool]`, `Series[int]`, etc., `Series[Any]` 
+for example numeric types `Series[bool]`, `Series[int]`, etc., `Series[Any]`
 will be given as the resulting type of the arithmetic operation.
 
 ### Interval is Generic
@@ -112,7 +112,8 @@ interval of `Timestamp`s.
 ## Testing the Type Stubs
 
 A set of (most likely incomplete) tests for testing the type stubs is in the pandas-stubs
-repository in the `tests` directory.  The tests are used with `mypy` and `pyright` to
+repository in the `tests` directory.  The tests are used with `mypy`, `pyright`
+and `pyrefly` to
 validate correct typing, and also with `pytest` to validate that the provided code
 actually executes.  The recent decision for Python 3.11 to include `assert_type()`,
 which is supported by `typing_extensions` version 4.2 and beyond makes it easier
@@ -164,12 +165,14 @@ Type checkers report errors
 - when writing `overload`s that return incompatible return values, or
 - when type checkers have bugs themselves.
 
-Since mypy and pyright behave slightly differently, we use separate ignore comments
+Since type checkers behave slightly differently, we use separate ignore comments
 for them.
 
-- If mypy reports an error, please use `# type: ignore[<error code>]`
-- If pyright reports an error, please use `# pyright: ignore[<error code>]`
+- If `mypy` reports an error, please use `# type: ignore[<error code>]`
+- If `pyright` reports an error, please use `# pyright: ignore[<error code>]`
+- If `pyrefly` reports an error, please use `# pyrefly: ignore[<error code>]`
+- If `ty` reports an error, please use `# ty: ignore[<error code>]`
 
-If mypy and pyright report errors, for example, inside a `TYPE_CHECKING_INVALID_USAGE`
+If type checkers report errors, for example, inside a `TYPE_CHECKING_INVALID_USAGE`
 block, please ensure that the comment for mypy comes first:
-`# type: ignore[<error code>] # pyright: ignore[<error code>]`.
+`# type: ignore[<error code>] # pyright: ignore[<error code>] # pyrefly: ignore[<error code>] # ty: ignore[<error code>]`.


### PR DESCRIPTION
After pandas-dev/pandas-stubs#1767, we should add `pyrefly` to the list of officially supported type checkers.