### PR TITLE
CLN: python/typeshed#16072 replace `SupportsGetItem`

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -42,7 +42,6 @@ from _typeshed import (
     SupportsMul,
     SupportsRAdd,
     SupportsRMul,
-    Viewable,
 )
 from matplotlib.axes import (
     Axes as PlotAxes,
@@ -1079,7 +1078,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def diff(self: Series[Interval], periods: int = ...) -> Never: ...
     @overload
-    def diff(self: Viewable[SupportsSelfSub[S2]], periods: int = ...) -> Series[S2]: ...
+    def diff(self: Iterable[SupportsSelfSub[S2]], periods: int = ...) -> Series[S2]: ...
     def autocorr(self, lag: int = 1) -> float: ...
     @overload
     def dot(self, other: Series[S1]) -> Scalar: ...
@@ -4218,7 +4217,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[int]: ...
     @overload
     def cumprod(
-        self: Viewable[_SupportsMul[S1]],
+        self: Iterable[_SupportsMul[S1]],
         axis: AxisIndex = ...,
         skipna: _bool = ...,
         *args: Any,
@@ -4342,7 +4341,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Timestamp: ...
     @overload
     def mean(
-        self: Viewable[SupportsTruedivInt[S2]],
+        self: Iterable[SupportsTruedivInt[S2]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
@@ -4372,7 +4371,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> float: ...
     @overload
     def median(
-        self: Viewable[SupportsTruedivInt[S2]],
+        self: Iterable[SupportsTruedivInt[S2]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
@@ -4537,7 +4536,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Timedelta: ...
     @overload
     def std(
-        self: Viewable[SupportsTruedivInt[S2]],
+        self: Iterable[SupportsTruedivInt[S2]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
@@ -4546,7 +4545,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         **kwargs: Any,
     ) -> S2: ...
     def sum(
-        self: Viewable[_SupportsAdd[_T]],
+        self: Iterable[_SupportsAdd[_T]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = ...,
@@ -4812,7 +4811,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> float: ...
     @overload
     def var(
-        self: Viewable[SupportsTruedivInt[S2]],
+        self: Iterable[SupportsTruedivInt[S2]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -39,10 +39,10 @@ from typing import (
 
 from _typeshed import (
     SupportsAdd,
-    SupportsGetItem,
     SupportsMul,
     SupportsRAdd,
     SupportsRMul,
+    Viewable,
 )
 from matplotlib.axes import (
     Axes as PlotAxes,
@@ -1079,9 +1079,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @overload
     def diff(self: Series[Interval], periods: int = ...) -> Never: ...
     @overload
-    def diff(
-        self: SupportsGetItem[Scalar, SupportsSelfSub[S2]], periods: int = ...
-    ) -> Series[S2]: ...
+    def diff(self: Viewable[SupportsSelfSub[S2]], periods: int = ...) -> Series[S2]: ...
     def autocorr(self, lag: int = 1) -> float: ...
     @overload
     def dot(self, other: Series[S1]) -> Scalar: ...
@@ -4220,7 +4218,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[int]: ...
     @overload
     def cumprod(
-        self: SupportsGetItem[Scalar, _SupportsMul[S1]],
+        self: Viewable[_SupportsMul[S1]],
         axis: AxisIndex = ...,
         skipna: _bool = ...,
         *args: Any,
@@ -4344,7 +4342,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Timestamp: ...
     @overload
     def mean(
-        self: SupportsGetItem[Scalar, SupportsTruedivInt[S2]],
+        self: Viewable[SupportsTruedivInt[S2]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
@@ -4374,7 +4372,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> float: ...
     @overload
     def median(
-        self: SupportsGetItem[Scalar, SupportsTruedivInt[S2]],
+        self: Viewable[SupportsTruedivInt[S2]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool = True,
@@ -4539,7 +4537,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Timedelta: ...
     @overload
     def std(
-        self: SupportsGetItem[Scalar, SupportsTruedivInt[S2]],
+        self: Viewable[SupportsTruedivInt[S2]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,
@@ -4548,7 +4546,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         **kwargs: Any,
     ) -> S2: ...
     def sum(
-        self: SupportsGetItem[Scalar, _SupportsAdd[_T]],
+        self: Viewable[_SupportsAdd[_T]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = ...,
@@ -4814,7 +4812,7 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> float: ...
     @overload
     def var(
-        self: SupportsGetItem[Scalar, SupportsTruedivInt[S2]],
+        self: Viewable[SupportsTruedivInt[S2]],
         *,
         axis: AxisIndex | None = 0,
         skipna: _bool | None = True,


### PR DESCRIPTION
`SupportsGetItem` has two slots, but in our application we never made use of the first slot. I figured out we could use ~~`Viewable`~~`Iterable` instead.

The initial idea was to use `SupportsIter`, but it turns out that it would require the annotation `SupportsIter[Iterator[S1]]` which is cumbersome, see python/typeshed#16072.

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
