### PR TITLE
CLN: update `ruff` and enable `A`, `ERA` except `ERA001`, and `RUF`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
     autofix_prs: false
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.15.22
     hooks:
     -   id: ruff-check
         args: [--exit-non-zero-on-fix]

--- a/pandas-stubs/__init__.pyi
+++ b/pandas-stubs/__init__.pyi
@@ -66,7 +66,7 @@ from pandas.core.api import (
 )
 from pandas.core.arrays.sparse import SparseDtype as SparseDtype
 from pandas.core.col import col as col
-from pandas.core.computation.api import eval as eval
+from pandas.core.computation.api import eval as eval  # noqa: A004
 from pandas.core.reshape.api import (
     concat as concat,
     crosstab as crosstab,

--- a/pandas-stubs/core/computation/api.pyi
+++ b/pandas-stubs/core/computation/api.pyi
@@ -1,1 +1,1 @@
-from pandas.core.computation.eval import eval as eval
+from pandas.core.computation.eval import eval as eval  # noqa: A004

--- a/pandas-stubs/core/computation/eval.pyi
+++ b/pandas-stubs/core/computation/eval.pyi
@@ -18,7 +18,7 @@ from pandas._typing import (
     np_ndarray,
 )
 
-def eval(
+def eval(  # noqa: A001
     expr: str | BinOp,
     parser: Literal["pandas", "python"] = "pandas",
     engine: Literal["python", "numexpr"] | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ ignore = [
   # The following rules are ignored temporarily. Either fix them or move to the permanent list above.
   "PYI042", # https://docs.astral.sh/ruff/rules/snake-case-type-alias/
   "SLF001", # https://docs.astral.sh/ruff/rules/private-member-access/
-  "ERA",
+  "ERA001",  # https://docs.astral.sh/ruff/rules/commented-out-code/
   "RUF",
   "SIM",
   "TRY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,8 +206,6 @@ ignore = [
   "N",      # https://docs.astral.sh/ruff/rules/#pep8-naming-n
   "TD002",  # https://docs.astral.sh/ruff/rules/missing-todo-author/
   # The following rules are ignored temporarily. Either fix them or move to the permanent list above.
-  "A001",    # https://docs.astral.sh/ruff/rules/builtin-variable-shadowing/
-  "A004",    # https://docs.astral.sh/ruff/rules/builtin-import-shadowing/
   "PYI001",  # https://docs.astral.sh/ruff/rules/unprefixed-type-param/
   "PYI042",  # https://docs.astral.sh/ruff/rules/snake-case-type-alias/
   "ERA001",
@@ -234,7 +232,6 @@ ignore = [
   "S101",    # https://docs.astral.sh/ruff/rules/assert/
   "TD002",   # https://docs.astral.sh/ruff/rules/missing-todo-author/
   # The following rules are ignored temporarily. Either fix them or move to the permanent list above.
-  "A001",   # https://docs.astral.sh/ruff/rules/builtin-variable-shadowing/
   "PYI042", # https://docs.astral.sh/ruff/rules/snake-case-type-alias/
   "SLF001", # https://docs.astral.sh/ruff/rules/private-member-access/
   "ERA",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,6 @@ ignore = [
   "PYI042", # https://docs.astral.sh/ruff/rules/snake-case-type-alias/
   "SLF001", # https://docs.astral.sh/ruff/rules/private-member-access/
   "ERA001",  # https://docs.astral.sh/ruff/rules/commented-out-code/
-  "RUF",
   "SIM",
   "TRY",
   "PT",

--- a/tests/_typing.py
+++ b/tests/_typing.py
@@ -1,4 +1,3 @@
-# ruff: noqa: PLC0414
 # This file serves as a stub file for static type checkers
 # (pyright does not like it if I call the file tests/_typing.pyi).
 # It can only import from pandas._typing.
@@ -95,9 +94,9 @@ __all__ = [
     "BuiltinBooleanDtypeArg",
     "BuiltinBytesDtypeArg",
     "BuiltinComplexDtypeArg",
-    "BuiltinNotObjDtypeArg",
     "BuiltinFloatDtypeArg",
     "BuiltinIntDtypeArg",
+    "BuiltinNotObjDtypeArg",
     "BuiltinNotStrObjDtypeArg",
     "BuiltinObjectDtypeArg",
     "BuiltinStrDtypeArg",
@@ -138,9 +137,9 @@ __all__ = [
     "PyArrowTimestampDtypeArg",
     "PyArrowUIntDtypeArg",
     "StrDtypeArg",
+    "TimeUnit",
     "TimedeltaDtypeArg",
     "TimestampDtypeArg",
-    "TimeUnit",
     "UIntDtypeArg",
     "VoidDtypeArg",
     "np_1darray",

--- a/tests/extension/decimal/array.py
+++ b/tests/extension/decimal/array.py
@@ -174,9 +174,7 @@ class DecimalArray(OpsMixin, ExtensionArray):
     def __array_ufunc__(
         self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any
     ) -> Any:
-        if not all(
-            isinstance(t, self._HANDLED_TYPES + (DecimalArray,)) for t in inputs
-        ):
+        if not all(isinstance(t, (*self._HANDLED_TYPES, DecimalArray)) for t in inputs):
             return NotImplemented
 
         if "out" in kwargs:

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -1350,19 +1350,19 @@ def test_index_delete() -> None:
 def test_index_dict() -> None:
     """Test passing an ordered iterables to Index and subclasses constructor GH828."""
     check(
-        assert_type(pd.Index({"Jan. 1, 2008": "New Year’s Day"}), "pd.Index[str]"),
+        assert_type(pd.Index({"Jan. 1, 2008": "New Year's Day"}), "pd.Index[str]"),
         pd.Index,
         str,
     )
     check(
         assert_type(
-            pd.DatetimeIndex({"Jan. 1, 2008": "New Year’s Day"}), pd.DatetimeIndex
+            pd.DatetimeIndex({"Jan. 1, 2008": "New Year's Day"}), pd.DatetimeIndex
         ),
         pd.DatetimeIndex,
     )
     check(
         assert_type(
-            pd.TimedeltaIndex({pd.Timedelta(days=1): "New Year’s Day"}),
+            pd.TimedeltaIndex({pd.Timedelta(days=1): "New Year's Day"}),
             pd.TimedeltaIndex,
         ),
         pd.TimedeltaIndex,

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2817,9 +2817,9 @@ def test_series_iloc_series_bool() -> None:
 
 
 def test_change_to_dict_return_type() -> None:
-    id = [1, 2, 3]
+    id_ = [1, 2, 3]
     value = ["a", "b", "c"]
-    df = pd.DataFrame(zip(id, value), columns=["id", "value"])
+    df = pd.DataFrame(zip(id_, value), columns=["id", "value"])
     fd = df.set_index("id")["value"].to_dict()
     check(assert_type(fd, dict[Hashable, Any]), dict)
 
@@ -3443,13 +3443,11 @@ def test_map() -> None:
         str,
     )
 
-    def callable(x: int) -> str:
+    def to_str(x: int) -> str:
         return str(x)
 
     check(
-        assert_type(s.map(callable, na_action="ignore"), "pd.Series[str]"),
-        pd.Series,
-        str,
+        assert_type(s.map(to_str, na_action="ignore"), "pd.Series[str]"), pd.Series, str
     )
 
     series = pd.Series(["a", "b", "c"])
@@ -3478,13 +3476,13 @@ def test_map_na() -> None:
         assert_type(s.map(user_dict, na_action=None), "pd.Series[str]"), pd.Series, str
     )
 
-    def callable(x: int | NAType) -> str | NAType:
+    def to_str_na(x: int | NAType) -> str | NAType:
         if isinstance(x, int):
             return str(x)
         return x
 
     check(
-        assert_type(s.map(callable, na_action=None), "pd.Series[str]"), pd.Series, str
+        assert_type(s.map(to_str_na, na_action=None), "pd.Series[str]"), pd.Series, str
     )
 
     series = pd.Series(["a", "b", "c"])

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -89,7 +89,7 @@ from tests.dtypes import (
 from tests.extension.decimal.array import DecimalDtype
 
 if TYPE_CHECKING:
-    from typing import Any  # noqa: F401
+    from typing import Any
 
 from pandas.io.formats.format import EngFormatter
 from pandas.tseries.offsets import (

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -28,16 +28,19 @@ from pandas.tseries.offsets import BaseOffset
 
 def test_custom_calendar() -> None:
     class ExampleCalendar(AbstractHolidayCalendar):
-        rules = [
-            USMemorialDay,
-            Holiday("July 4th", month=7, day=4, observance=nearest_workday),
-            Holiday(
-                "Columbus Day",
-                month=10,
-                day=1,
-                offset=pd.DateOffset(weekday=1),
-            ),
-        ]
+        def __init__(self, name: str = "", rules: list[Holiday] | None = None) -> None:
+            if rules is None:
+                rules = [
+                    USMemorialDay,
+                    Holiday("July 4th", month=7, day=4, observance=nearest_workday),
+                    Holiday(
+                        "Columbus Day",
+                        month=10,
+                        day=1,
+                        offset=pd.DateOffset(weekday=1),
+                    ),
+                ]
+            super().__init__(name=name, rules=rules)
 
     cal = ExampleCalendar()
 
@@ -120,10 +123,13 @@ def test_holiday_attributes() -> None:
 
 def test_calendar_attributes() -> None:
     class ExampleCalendar(AbstractHolidayCalendar):
-        rules = [
-            USMemorialDay,
-            Holiday("July 4th", month=7, day=4, observance=nearest_workday),
-        ]
+        def __init__(self, name: str = "", rules: list[Holiday] | None = None) -> None:
+            if rules is None:
+                rules = [
+                    USMemorialDay,
+                    Holiday("July 4th", month=7, day=4, observance=nearest_workday),
+                ]
+            super().__init__(name=name, rules=rules)
 
     cal = ExampleCalendar(name="example")
     check(assert_type(cal.name, str), str)


### PR DESCRIPTION
We may not want [`A001`](https://docs.astral.sh/ruff/rules/builtin-variable-shadowing/) and [`A004`](https://docs.astral.sh/ruff/rules/builtin-import-shadowing/) since `pandas` does shadow the built-in `eval`. But this is the only case.
