### PR TITLE
TYP: stricter `pyright`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,9 +303,21 @@ typeCheckingMode = "strict"
 stubPath = "."
 include = ["tests", "pandas-stubs"]
 enableTypeIgnoreComments = false    # use pyright-specific ignores
-reportUnnecessaryTypeIgnoreComment = true
 # enable optional checks
-reportMissingModuleSource = true
+# https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults
+deprecateTypingAliases = true
+enableExperimentalFeatures = false
+reportCallInDefaultInitializer = true
+reportImplicitOverride = "none"
+reportImplicitStringConcatenation = true
+reportImportCycles = "none"
+reportMissingSuperCall = true
+reportPropertyTypeMismatch = "none"
+reportUninitializedInstanceVariable = "none"
+reportUnnecessaryTypeIgnoreComment = true
+reportUnreachable = "none"
+reportUnusedCallResult = "none"
+
 
 [tool.codespell]
 ignore-words-list = "indext, mose, sav, ser, ttest"

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -12,7 +12,7 @@ def mypy_src() -> None:
 
 
 def pyright_src() -> None:
-    cmd = ["pyright"]
+    cmd = ["pyright", "--warnings"]
     subprocess.run(cmd, check=True)
 
 
@@ -77,7 +77,7 @@ def mypy_dist() -> None:
 
 
 def pyright_dist() -> None:
-    cmd = ["pyright", "tests"]
+    cmd = ["pyright", "tests", "--warnings"]
     subprocess.run(cmd, check=True)
 
 

--- a/tests/extension/decimal/array.py
+++ b/tests/extension/decimal/array.py
@@ -76,6 +76,7 @@ class DecimalDtype(ExtensionDtype):
         return decimal.Decimal("NaN")
 
     def __init__(self, context: decimal.Context | None = None) -> None:
+        super().__init__()
         self.context = context or decimal.getcontext()
 
     def __repr__(self) -> str:
@@ -106,6 +107,7 @@ class DecimalArray(OpsMixin, ExtensionArray):
         copy: bool = False,
         context: decimal.Context | None = None,
     ) -> None:
+        super().__init__()
         for i, val in enumerate(values):
             if is_float(val):
                 if np.isnan(val):


### PR DESCRIPTION
 With #1171 and #1639 we have made `pandas-stubs` passing `pyright` in `strict` mode.

However there are still disabled `pyright` rules even in `strict` mode, see https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults.

In this PR I have included all of them in `pyproject.toml` and enabled some of them.

Enabling `reportMissingSuperCall` has led to two (non-functional) changes in `tests/extension/decimal/array.py`.

Note that `reportMissingModuleSource` always gives warning. We can make `pyright` return `1` upon having warnings by adding `--warnings` flag. I have added the flag and removed `reportMissingModuleSource = true`.