### PR TITLE
allow pd.col().str

### DIFF
--- a/pandas-stubs/core/col.pyi
+++ b/pandas-stubs/core/col.pyi
@@ -2,6 +2,7 @@ from collections.abc import Hashable
 from typing import Self
 
 from pandas.core.series import Series
+from pandas.core.strings.accessor import StrDescriptor
 
 from pandas._typing import Scalar
 
@@ -34,5 +35,8 @@ class Expression:
     def __xor__(self, other: Scalar | Series | Self) -> Expression: ...
     def __rxor__(self, other: Scalar | Series | Self) -> Expression: ...
     def __invert__(self) -> Expression: ...
+
+    # Special Series attributes
+    str = StrDescriptor()
 
 def col(col_name: Hashable) -> Expression: ...

--- a/pandas-stubs/core/strings/accessor.pyi
+++ b/pandas-stubs/core/strings/accessor.pyi
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from pandas.core.base import NoNewAttributesMixin
+from pandas.core.col import Expression
 from pandas.core.frame import DataFrame
 from pandas.core.indexes.base import Index
 from pandas.core.indexes.multi import MultiIndex
@@ -561,3 +562,7 @@ class StrDescriptor:
     def __get__(
         self, instance: Index[S2], owner: type[Index]
     ) -> IndexStringMethods[S2]: ...
+    @overload
+    def __get__(
+        self, instance: Expression, owner: type[Expression]
+    ) -> SeriesStringMethods[str]: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
   "pyarrow>=10.0.1",
   "pytest>=8.4.2",
   "pyright>=1.1.410",
-  "ty>=0.0.61",
+  "ty==0.0.61",
   "pyrefly>=1.1.0",
   "poethepoet>=0.16.5",
   "loguru>=0.6.0",

--- a/tests/test_col.py
+++ b/tests/test_col.py
@@ -88,3 +88,12 @@ def test_logical_operators_with_series() -> None:
     check(assert_type(x & s, Expression), Expression)
     check(assert_type(x | s, Expression), Expression)
     check(assert_type(x ^ s, Expression), Expression)
+
+
+def test_str_accessor() -> None:
+    """Test the str accessor for Expression."""
+    df = pd.DataFrame({"name": ["beluga", "narwhal"], "speed": [100, 110]})
+    check(
+        assert_type(df.assign(name_titlecase=pd.col("name").str.title()), pd.DataFrame),
+        pd.DataFrame,
+    )


### PR DESCRIPTION
Using `df.assign(x=pd.col["column"].str.title())` didn't work, so this fixes it.

Had to pin `ty` to 0.0.61 because 0.0.63 has failures for @cmp0xff to investigate

