### PR TITLE
ENH: support pd.col expressions in DataFrame indexing

### DIFF
--- a/pandas-stubs/core/col.pyi
+++ b/pandas-stubs/core/col.pyi
@@ -1,5 +1,8 @@
 from collections.abc import Hashable
-from typing import Self
+from typing import (
+    ClassVar,
+    Self,
+)
 
 from pandas.core.series import Series
 from pandas.core.strings.accessor import StrDescriptor
@@ -7,6 +10,9 @@ from pandas.core.strings.accessor import StrDescriptor
 from pandas._typing import Scalar
 
 class Expression:
+    # `__eq__` returns an `Expression`, so instances are unhashable at runtime
+    __hash__: ClassVar[None]  # type: ignore[assignment]  # pyright: ignore[reportIncompatibleMethodOverride]
+
     # binary ops
     def __add__(self, other: Scalar | Series | Self) -> Expression: ...
     def __radd__(self, other: Scalar | Series | Self) -> Expression: ...

--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -49,6 +49,7 @@ from pandas._stubs_only import (
 )
 from pandas.core.arraylike import OpsMixin
 from pandas.core.base import IndexOpsMixin
+from pandas.core.col import Expression
 from pandas.core.generic import NDFrame
 from pandas.core.groupby.generic import DataFrameGroupBy
 from pandas.core.indexers import BaseIndexer
@@ -191,7 +192,13 @@ _iLocSetItemKey: TypeAlias = (
     | tuple[int, IndexType]
 )
 _LocSetItemKey: TypeAlias = (
-    MaskType | Hashable | _IndexSliceTuple | Iterable[Scalar] | IndexingInt | slice
+    Expression
+    | MaskType
+    | Hashable
+    | _IndexSliceTuple
+    | Iterable[Scalar]
+    | IndexingInt
+    | slice
 )
 _SetItemValueNotDataFrame: TypeAlias = (
     ScalarOrNA
@@ -233,6 +240,14 @@ class _iLocIndexerFrame(_iLocIndexer, Generic[_T]):
     ) -> None: ...
 
 class _LocIndexerFrame(_LocIndexer, Generic[_T]):
+    @overload
+    def __getitem__(self, idx: Expression) -> _T: ...
+    @overload
+    def __getitem__(self, idx: tuple[Expression, Scalar]) -> Series: ...
+    @overload
+    def __getitem__(
+        self, idx: tuple[Expression, list[HashableT] | Index | slice]
+    ) -> _T: ...
     @overload
     def __getitem__(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
         self,
@@ -323,6 +338,8 @@ class _AtIndexerFrame(_AtIndexer):
     ) -> None: ...
 
 class _GetItemHack:
+    @overload
+    def __getitem__(self, key: Expression) -> Self: ...
     @overload
     def __getitem__(self, key: Scalar | tuple[Hashable, ...]) -> Series: ...  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
     # With python 3.12+, the second overload needs a type-ignore statement

--- a/tests/test_col.py
+++ b/tests/test_col.py
@@ -5,7 +5,10 @@ from typing import assert_type
 import pandas as pd
 from pandas.api.typing import Expression
 
-from tests import check
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    check,
+)
 
 
 def test_constructor() -> None:
@@ -97,3 +100,25 @@ def test_str_accessor() -> None:
         assert_type(df.assign(name_titlecase=pd.col("name").str.title()), pd.DataFrame),
         pd.DataFrame,
     )
+
+
+def test_indexing() -> None:
+    """Test DataFrame indexing with Expression."""
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+
+    check(assert_type(df.loc[pd.col("a") > 1], pd.DataFrame), pd.DataFrame)
+    check(assert_type(df[pd.col("a") > 1], pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.loc[(pd.col("a") > 1) & (pd.col("b") < 6.0)], pd.DataFrame),
+        pd.DataFrame,
+    )
+    check(assert_type(df.loc[pd.col("a") > 1, "b"], pd.Series), pd.Series, float)
+    check(assert_type(df.loc[pd.col("a") > 1, ["a", "b"]], pd.DataFrame), pd.DataFrame)
+
+    df.loc[pd.col("a") > 1] = 0
+
+    # `Series` has no columns, so expression indexing fails at runtime
+    if TYPE_CHECKING_INVALID_USAGE:
+        s = df["a"]
+        _0 = s.loc[pd.col("a") > 1]  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue,reportUnknownVariableType] # ty: ignore[invalid-argument-type] # pyrefly: ignore[bad-index]
+        _1 = s[pd.col("a") > 1]  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue,reportUnknownVariableType] # ty: ignore[invalid-argument-type] # pyrefly: ignore[bad-index]


### PR DESCRIPTION
- [X] Closes #1846 
- [X] Tests added
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Changelog
1) Adds `Expression` overloads to the DataFrame indexers in `core/frame.pyi` so `df.loc[expr]`, `df[expr]`, `df.loc[expr, cols]` and `df.loc[expr] = value` type-check properly (e.g. when `expr = pd.col("a") > 1`, with the expression syntax introduced in [Pandas 3.0.0](https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html#initial-support-for-pd-col-syntax-to-create-expressions)).

2) Explicitly declares `Expression.__hash__` as `ClassVar[None]` in `core/col.pyi` to prevent mypy from treating `Expression` as a `Hashable` type, which would cause the new `_GetItemHack` overload to collide with the existing `Hashable -> Series` one.

## Verification
`poe test_all` confirmed to pass locally.
