### PR TITLE
TST: #1799 enable `ty` in `tests/test_string_accessors.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -365,5 +365,4 @@ exclude = [
   "tests/test_extension.py",
   "tests/test_groupby.py",
   "tests/test_natype.py",
-  "tests/test_string_accessors.py",
 ]

--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -112,15 +112,15 @@ def test_string_accessors_boolean_series() -> None:
     _check(assert_type(sr.str.contains("kapow", na=False), "pd.Series[bool]"))
 
     if TYPE_CHECKING_INVALID_USAGE:
-        sr.str.startswith("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        sr.str.endswith("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        sr.str.contains("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        sr.str.startswith("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr.str.endswith("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr.str.contains("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
         sr_i = pd.Series([1])
 
-        sr_i.str.startswith("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.endswith("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.contains("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
+        sr_i.str.startswith("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.endswith("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.contains("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_string_accessors_boolean_index() -> None:
@@ -192,15 +192,15 @@ def test_string_accessors_boolean_index() -> None:
     _check(assert_type(idx.str.contains("kapow", na=False), np_1darray_bool))
 
     if TYPE_CHECKING_INVALID_USAGE:
-        idx.str.startswith("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        idx.str.endswith("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        idx.str.contains("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        idx.str.startswith("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx.str.endswith("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx.str.contains("kapow", na="baz")  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
         idx_i = pd.Index([1])
 
-        idx_i.str.startswith("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.endswith("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.contains("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
+        idx_i.str.startswith("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.endswith("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.contains("kapow")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_string_accessors_integer_series() -> None:
@@ -215,7 +215,7 @@ def test_string_accessors_integer_series() -> None:
 
     # unlike findall, find doesn't accept a compiled pattern
     with pytest.raises(TypeError):
-        s.str.find(re.compile(r"p"))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        s.str.find(re.compile(r"p"))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_string_accessors_integer_index() -> None:
@@ -230,7 +230,7 @@ def test_string_accessors_integer_index() -> None:
 
     # unlike findall, find doesn't accept a compiled pattern
     with pytest.raises(TypeError):
-        idx.str.find(re.compile(r"p"))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        idx.str.find(re.compile(r"p"))  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_string_accessors_string_series() -> None:
@@ -339,39 +339,39 @@ def test_string_accessors_string_series() -> None:
 
     # wrap doesn't accept positional arguments other than width
     if TYPE_CHECKING_INVALID_USAGE:
-        s.str.wrap(80, False)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
+        s.str.wrap(80, False)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
 
         sr_i = pd.Series([1])
 
-        sr_i.str.capitalize()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.casefold()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.cat(sep="X")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        sr_i.str.center(10)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.get(2)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.ljust(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.lower()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.lstrip("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.normalize("NFD")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.pad(80, "right")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.removeprefix("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.removesuffix("e")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.repeat(2)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.replace("a", "X")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        sr_i.str.replace(re.compile(r"a"), "X", regex=True)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        sr_i.str.rjust(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.rstrip()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.slice_replace(0, 2, "XX")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.strip()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.swapcase()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.title()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.translate({241: "n"})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.translate({241: 240})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.translate(trans_table)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.upper()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.wrap(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.zfill(10)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.decode("utf-8")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        sr_i.str.decode("utf-8", dtype=pd.StringDtype())  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
+        sr_i.str.capitalize()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.casefold()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.cat(sep="X")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
+        sr_i.str.center(10)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.get(2)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.ljust(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.lower()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.lstrip("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.normalize("NFD")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.pad(80, "right")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.removeprefix("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.removesuffix("e")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.repeat(2)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.replace("a", "X")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        sr_i.str.replace(re.compile(r"a"), "X", regex=True)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        sr_i.str.rjust(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.rstrip()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.slice_replace(0, 2, "XX")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.strip()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.swapcase()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.title()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.translate({241: "n"})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.translate({241: 240})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.translate(trans_table)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.upper()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.wrap(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.zfill(10)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.decode("utf-8")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        sr_i.str.decode("utf-8", dtype=pd.StringDtype())  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_string_accessors_string_index() -> None:
@@ -470,39 +470,39 @@ def test_string_accessors_string_index() -> None:
 
     # wrap doesn't accept positional arguments other than width
     if TYPE_CHECKING_INVALID_USAGE:
-        idx.str.wrap(80, False)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
+        idx.str.wrap(80, False)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
 
         idx_i = pd.Index([1])
 
-        idx_i.str.capitalize()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.casefold()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.cat(sep="X")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        idx_i.str.center(10)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.get(2)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.ljust(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.lower()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.lstrip("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.normalize("NFD")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.pad(80, "right")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.removeprefix("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.removesuffix("e")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.repeat(2)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.replace("a", "X")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        idx_i.str.replace(re.compile(r"a"), "X", regex=True)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        idx_i.str.rjust(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.rstrip()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.slice_replace(0, 2, "XX")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.strip()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.swapcase()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.title()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.translate({241: "n"})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.translate({241: 240})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.translate(trans_table)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.upper()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.wrap(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.zfill(5)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.decode("utf-8")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.decode("utf-8", dtype=pd.StringDtype())  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
+        idx_i.str.capitalize()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.casefold()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.cat(sep="X")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
+        idx_i.str.center(10)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.get(2)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.ljust(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.lower()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.lstrip("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.normalize("NFD")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.pad(80, "right")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.removeprefix("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.removesuffix("e")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.repeat(2)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.replace("a", "X")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        idx_i.str.replace(re.compile(r"a"), "X", regex=True)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        idx_i.str.rjust(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.rstrip()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.slice_replace(0, 2, "XX")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.strip()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.swapcase()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.title()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.translate({241: "n"})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.translate({241: 240})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.translate(trans_table)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.upper()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.wrap(80)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.zfill(5)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.decode("utf-8")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.decode("utf-8", dtype=pd.StringDtype())  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_string_accessors_bytes_series() -> None:
@@ -540,17 +540,17 @@ def test_string_accessors_list_series() -> None:
     if TYPE_CHECKING_INVALID_USAGE:
         # rsplit doesn't accept compiled pattern
         # it doesn't raise at runtime but produces a nan
-        _bad_rsplit_result = s.str.rsplit(re.compile(r"a"))  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        _bad_rsplit_result = s.str.rsplit(re.compile(r"a"))  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
         idx_i = pd.Index([1])
 
-        idx_i.str.findall("pp")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.findall(re.compile(r"pp"))  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.split("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.split(re.compile(r"a"))  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.split("a", expand=False)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        idx_i.str.rsplit("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.rsplit("a", expand=False)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        idx_i.str.findall("pp")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.findall(re.compile(r"pp"))  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.split("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.split(re.compile(r"a"))  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.split("a", expand=False)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        idx_i.str.rsplit("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.rsplit("a", expand=False)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_string_accessors_list_index() -> None:
@@ -578,17 +578,17 @@ def test_string_accessors_list_index() -> None:
     if TYPE_CHECKING_INVALID_USAGE:
         # rsplit doesn't accept compiled pattern
         # it doesn't raise at runtime but produces a nan
-        _bad_rsplit_result = idx.str.rsplit(re.compile(r"a"))  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        _bad_rsplit_result = idx.str.rsplit(re.compile(r"a"))  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
         idx_i = pd.Index([1])
 
-        idx_i.str.findall("pp")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.findall(re.compile(r"pp"))  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.split("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.split(re.compile(r"a"))  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.split("a", expand=False)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        idx_i.str.rsplit("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type]
-        idx_i.str.rsplit("a", expand=False)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        idx_i.str.findall("pp")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.findall(re.compile(r"pp"))  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.split("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.split(re.compile(r"a"))  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.split("a", expand=False)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        idx_i.str.rsplit("a")  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx_i.str.rsplit("a", expand=False)  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_string_accessors_expanding_series() -> None:
@@ -825,8 +825,8 @@ def test_series_str_replace() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        sr.str.replace(pat={"A": "a", "B": "b"}, repl="A")  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
+        sr.str.replace(pat={"A": "a", "B": "b"}, repl="A")  # type: ignore[call-overload]  # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
         sr_i = pd.Series([1], name="my_messy_col")
 
-        sr_i.str.replace(pat={"A": "a", "B": "b"})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        sr_i.str.replace(pat={"A": "a", "B": "b"})  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]


### PR DESCRIPTION
In `tests/test_string_accessors.py`, there are 368 `: ignore[`'s, which is a multiple of 4. In other words, we should have the same number of `ignore`s for all 4 type checkers in that script.

- [x] Addresses #1799 (Replace xxxx with the Github issue number)
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
