### PR TITLE
TST: #1799 enable `ty` in `tests/frame/*/**` except for `tests/frame/test_frame.py`

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -1073,40 +1073,36 @@ Function: TypeAlias = np.ufunc | Callable[..., Any]
 # type is need in a function that uses GroupByObjectNonScalar
 _HashableTa = TypeVar("_HashableTa", bound=Hashable, default=Any)
 if TYPE_CHECKING:
-    ByT = TypeVar(
-        "ByT",
-        bound=str
+    SeriesByT_bound: TypeAlias = (
+        str
         | bytes
         | datetime.date
+        | bool
+        | int
+        | float
+        | complex
+        | datetime.datetime
+        | datetime.timedelta
+        | Period
+        # TODO: can write Interval[int | float | Timestamp | Timedelta] after astral-sh/ty#3199 is resolved
+        | Interval[int]
+        | Interval[float]
+        | Interval[Timestamp]
+        | Interval[Timedelta]
+    )
+    ByT_bound: TypeAlias = (
+        SeriesByT_bound
         | datetime.datetime
         | datetime.timedelta
         | np.datetime64
         | np.timedelta64
-        | bool
-        | int
-        | float
-        | complex
         | Scalar
-        | Period
-        | Interval[int | float | Timestamp | Timedelta]
-        | tuple[Any, ...],
+        | tuple[Any, ...]
     )
+    ByT = TypeVar("ByT", bound=ByT_bound)
     # Use a distinct SeriesByT when using groupby with Series of known dtype.
     # Essentially, an intersection between Series S1 TypeVar, and ByT TypeVar
-    SeriesByT = TypeVar(
-        "SeriesByT",
-        bound=str
-        | bytes
-        | datetime.date
-        | bool
-        | int
-        | float
-        | complex
-        | datetime.datetime
-        | datetime.timedelta
-        | Period
-        | Interval[int | float | Timestamp | Timedelta],
-    )
+    SeriesByT = TypeVar("SeriesByT", bound=SeriesByT_bound)
     GroupByObjectNonScalar: TypeAlias = (
         tuple[_HashableTa, ...]
         | list[_HashableTa]

--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -11,7 +11,6 @@ from typing import (
     Generic,
     Literal,
     Never,
-    Protocol,
     Self,
     TypeAlias,
     TypeVar,
@@ -224,44 +223,20 @@ class SeriesGroupBy(GroupBy[Series[S2]], Generic[S2, ByT]):
 
 _TT = TypeVar("_TT", bound=Literal[True, False])
 
-class DFCallable1(Protocol[P]):
-    def __call__(
-        self, df: DataFrame, /, *args: P.args, **kwargs: P.kwargs
-    ) -> Scalar | list[Any] | dict[Hashable, Any]: ...
-
-class DFCallable2(Protocol[P]):
-    def __call__(
-        self, df: DataFrame, /, *args: P.args, **kwargs: P.kwargs
-    ) -> DataFrame | Series: ...
-
-class DFCallable3(Protocol[P]):
-    def __call__(
-        self, df: Iterable[Any], /, *args: P.args, **kwargs: P.kwargs
-    ) -> float: ...
-
 class DataFrameGroupBy(GroupBy[DataFrame], Generic[ByT, _TT]):
-    # error: Overload 3 for "apply" will never be used because its parameters overlap overload 1
-    @overload  # type: ignore[override]
-    def apply(  # pyrefly: ignore[bad-override]
+    @overload
+    def apply(
         self,
-        func: DFCallable1[P],
-        /,
+        func: Callable[
+            Concatenate[DataFrame, P], Scalar | list[Any] | dict[Hashable, Any]
+        ],
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> Series: ...
     @overload
     def apply(
         self,
-        func: DFCallable2[P],
-        /,
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ) -> DataFrame: ...
-    @overload
-    def apply(  # ty: ignore[invalid-method-override]
-        self,
-        func: DFCallable3[P],
-        /,
+        func: Callable[Concatenate[DataFrame, P], DataFrame | Series] | str,
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> DataFrame: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,7 +357,7 @@ exclude = [
   "tests/arrays/test_integer.py",
   "tests/arrays/test_string_.py",
   "tests/arrays/test_string_arrow.py",
-  "tests/frame/**/*",
+  "tests/frame/test_frame.py",
   "tests/indexes/**/*",
   "tests/scalars/**/*",
   "tests/series/**/*",

--- a/tests/frame/test_groupby.py
+++ b/tests/frame/test_groupby.py
@@ -435,7 +435,7 @@ def test_groupby_series_methods() -> None:
     check(assert_type(gb.nth((0, 1, 2)), pd.DataFrame | pd.Series), pd.Series)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        gb.pct_change(limit=3)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[unexpected-keyword]
+        gb.pct_change(limit=3)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
 
 
 def test_groupby_index() -> None:
@@ -563,7 +563,10 @@ def test_groupby_result_for_scalar_indexes() -> None:
         assert_type(interval_index, "pd.IntervalIndex[pd.Interval[pd.Timestamp]]"),
         pd.IntervalIndex,
     )
-    iterator4 = df.groupby(interval_index).__iter__()
+    # TODO: astral-sh/ty#0
+    iterator4 = df.groupby(
+        interval_index
+    ).__iter__()  # ty: ignore[invalid-argument-type]
     check(
         assert_type(
             iterator4, Iterator[tuple["pd.Interval[pd.Timestamp]", pd.DataFrame]]
@@ -588,7 +591,8 @@ def test_groupby_result_for_scalar_indexes() -> None:
     for _tdelta, _g in df.groupby(tdelta_index):
         pass
 
-    for _interval, _g in df.groupby(interval_index):
+    # TODO: astral-sh/ty#0
+    for _interval, _g in df.groupby(interval_index):  # ty: ignore[not-iterable]
         pass
 
 
@@ -637,7 +641,13 @@ def test_groupby_apply() -> None:
     )
 
     lfunc: Callable[[pd.DataFrame], float] = lambda x: x.sum().mean()
-    check(assert_type(df.groupby("col1").apply(lfunc), pd.Series), pd.Series)
+    # TODO: astral-sh/ty#0
+    check(
+        assert_type(  # ty: ignore[type-assertion-failure]
+            df.groupby("col1").apply(lfunc), pd.Series
+        ),
+        pd.Series,
+    )
 
     def sum_to_list(x: pd.DataFrame) -> list[Any]:
         return x.sum().tolist()

--- a/tests/frame/test_groupby.py
+++ b/tests/frame/test_groupby.py
@@ -563,10 +563,7 @@ def test_groupby_result_for_scalar_indexes() -> None:
         assert_type(interval_index, "pd.IntervalIndex[pd.Interval[pd.Timestamp]]"),
         pd.IntervalIndex,
     )
-    # TODO: astral-sh/ty#0
-    iterator4 = df.groupby(
-        interval_index
-    ).__iter__()  # ty: ignore[invalid-argument-type]
+    iterator4 = df.groupby(interval_index).__iter__()
     check(
         assert_type(
             iterator4, Iterator[tuple["pd.Interval[pd.Timestamp]", pd.DataFrame]]
@@ -591,8 +588,7 @@ def test_groupby_result_for_scalar_indexes() -> None:
     for _tdelta, _g in df.groupby(tdelta_index):
         pass
 
-    # TODO: astral-sh/ty#0
-    for _interval, _g in df.groupby(interval_index):  # ty: ignore[not-iterable]
+    for _interval, _g in df.groupby(interval_index):
         pass
 
 
@@ -635,19 +631,11 @@ def test_groupby_apply() -> None:
     def sum_mean(x: pd.DataFrame) -> float:
         return x.sum().mean()
 
-    check(
-        assert_type(df.groupby("col1").apply(sum_mean), pd.Series),
-        pd.Series,
-    )
+    check(assert_type(df.groupby("col1").apply(sum_mean), pd.Series), pd.Series)
 
-    lfunc: Callable[[pd.DataFrame], float] = lambda x: x.sum().mean()
-    # TODO: astral-sh/ty#0
-    check(
-        assert_type(  # ty: ignore[type-assertion-failure]
-            df.groupby("col1").apply(lfunc), pd.Series
-        ),
-        pd.Series,
-    )
+    # TODO: revert to the original once astral-sh/ty#4055 astral-sh/ty#4135 are fixed
+    lfunc: Callable[[pd.DataFrame], float] = lambda _: 1.0  # x: x.sum().mean()
+    check(assert_type(df.groupby("col1").apply(lfunc), pd.Series), pd.Series)
 
     def sum_to_list(x: pd.DataFrame) -> list[Any]:
         return x.sum().tolist()

--- a/tests/frame/test_groupby.py
+++ b/tests/frame/test_groupby.py
@@ -611,14 +611,9 @@ def test_groupby_result_for_ambiguous_indexes() -> None:
     check(assert_type(value, pd.DataFrame), pd.DataFrame)
 
     # categorical indexes are also ambiguous
-
-    # https://github.com/pandas-dev/pandas/issues/54054 needs to be fixed
     categorical_index = pd.CategoricalIndex(df.a)
     iterator2 = df.groupby(categorical_index).__iter__()
-    check(
-        assert_type(iterator2, Iterator[tuple[Any, pd.DataFrame]]),
-        Iterator,
-    )
+    check(assert_type(iterator2, Iterator[tuple[Any, pd.DataFrame]]), Iterator)
     index2, value2 = next(iterator2)
     check(
         assert_type((index2, value2), tuple[Any, pd.DataFrame]),

--- a/tests/frame/test_indexing.py
+++ b/tests/frame/test_indexing.py
@@ -665,4 +665,4 @@ def test_frame_iat() -> None:
     df.iat[0, 0] = 999
     df.iat[0, 0] = float("nan")
     if TYPE_CHECKING_INVALID_USAGE:
-        df.iat[(0,), 0] = 999  # type: ignore[index]  # pyright: ignore[reportArgumentType] # pyrefly: ignore[unsupported-operation]
+        df.iat[(0,), 0] = 999  # type: ignore[index] # pyright: ignore[reportArgumentType] # pyrefly: ignore[unsupported-operation] # ty: ignore[invalid-assignment]

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1112,12 +1112,11 @@ def test_groupby_result_for_ambiguous_indexes() -> None:
     check(assert_type(value, "pd.Series[int]"), pd.Series, np.integer)
 
     # categorical indexes are also ambiguous
-    # TODO: pandas-dev/pandas#54054, needs to be fixed
     categorical_index = pd.CategoricalIndex(s.index)
     iterator2 = s.groupby(categorical_index).__iter__()
     assert_type(iterator2, Iterator[tuple[Any, "pd.Series[int]"]])
     index2, value2 = next(iterator2)
-    assert_type((index2, value2), tuple[Any, "pd.Series[int]"])
+    check(assert_type((index2, value2), tuple[Any, "pd.Series[int]"]), tuple)
 
     check(assert_type(index2, Any), str)
     check(assert_type(value2, "pd.Series[int]"), pd.Series, np.integer)


### PR DESCRIPTION
Currently `ty` is stuck upon checking `tests/frame/test_frame.py`. Will investigate later.

- [x] Addresses #1799 (Replace xxxx with the Github issue number)
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
