### PR TITLE
BUG: #1853 `.str.cat` can accept list-like objects other than `list`

### DIFF
--- a/pandas-stubs/core/strings/accessor.pyi
+++ b/pandas-stubs/core/strings/accessor.pyi
@@ -14,6 +14,8 @@ from typing import (
     type_check_only,
 )
 
+from pandas.core.arrays.categorical import Categorical
+from pandas.core.arrays.string_ import BaseStringArray
 from pandas.core.base import NoNewAttributesMixin
 from pandas.core.col import Expression
 from pandas.core.frame import DataFrame
@@ -50,7 +52,15 @@ class IndexStringMethods(StringMethods[S2]):
     @overload
     def cat(
         self: IndexStringMethods[str],
-        others: list[str] | np_ndarray_str | Index[str] | DataFrame,
+        others: (
+            tuple[str, ...]
+            | list[str]
+            | np_ndarray_str
+            | BaseStringArray
+            | Categorical[str]
+            | Index[str]
+            | DataFrame
+        ),
         sep: str | None = None,
         na_rep: str | None = None,
         join: AlignJoin = "left",
@@ -308,7 +318,16 @@ class SeriesStringMethods(StringMethods[S2]):
     @overload
     def cat(
         self: SeriesStringMethods[str],
-        others: list[str] | np_ndarray_str | Series[str] | Index[str] | DataFrame,
+        others: (
+            tuple[str, ...]
+            | list[str]
+            | np_ndarray_str
+            | BaseStringArray
+            | Categorical[str]
+            | Series[str]
+            | Index[str]
+            | DataFrame
+        ),
         sep: str | None = None,
         na_rep: str | None = None,
         join: AlignJoin = "left",

--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -732,14 +732,27 @@ def test_series_overloads_cat() -> None:
         pd.Series,
         str,
     )
+
+    shorter_s = pd.Series(["a"])
     check(
-        assert_type(s.str.cat(pd.Categorical(["b"])), "pd.Series[str]"), pd.Series, str
+        assert_type(shorter_s.str.cat(np.array(["b"])), "pd.Series[str]"),
+        pd.Series,
+        str,
     )
-    check(assert_type(s.str.cat(pd.array(["b"])), "pd.Series[str]"), pd.Series, str)
-    check(assert_type(s.str.cat(("b",)), "pd.Series[str]"), pd.Series, str)
+    check(
+        assert_type(shorter_s.str.cat(pd.Categorical(["b"])), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
+    check(
+        assert_type(shorter_s.str.cat(pd.array(["b"])), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
+    check(assert_type(shorter_s.str.cat(("b",)), "pd.Series[str]"), pd.Series, str)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.str.cat("a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        shorter_s.str.cat("a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_index_overloads_cat() -> None:
@@ -773,14 +786,27 @@ def test_index_overloads_cat() -> None:
         pd.Index,
         str,
     )
+
+    shorter_idx = pd.Index(["a"])
     check(
-        assert_type(idx.str.cat(pd.Categorical(["b"])), "pd.Index[str]"), pd.Index, str
+        assert_type(shorter_idx.str.cat(np.array(["b"])), "pd.Index[str]"),
+        pd.Index,
+        str,
     )
-    check(assert_type(idx.str.cat(pd.array(["b"])), "pd.Index[str]"), pd.Index, str)
-    check(assert_type(idx.str.cat(("b",)), "pd.Index[str]"), pd.Index, str)
+    check(
+        assert_type(shorter_idx.str.cat(pd.Categorical(["b"])), "pd.Index[str]"),
+        pd.Index,
+        str,
+    )
+    check(
+        assert_type(shorter_idx.str.cat(pd.array(["b"])), "pd.Index[str]"),
+        pd.Index,
+        str,
+    )
+    check(assert_type(shorter_idx.str.cat(("b",)), "pd.Index[str]"), pd.Index, str)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        idx.str.cat("a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        shorter_idx.str.cat("a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_series_overloads_extract() -> None:

--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -711,8 +711,7 @@ def test_series_overloads_cat() -> None:
     check(assert_type(s.str.cat(None, sep=";"), str), str)
     check(
         assert_type(
-            s.str.cat(["A", "B", "C", "D", "E", "F", "G"], sep=";"),
-            "pd.Series[str]",
+            s.str.cat(["A", "B", "C", "D", "E", "F", "G"], sep=";"), "pd.Series[str]"
         ),
         pd.Series,
         str,
@@ -733,6 +732,14 @@ def test_series_overloads_cat() -> None:
         pd.Series,
         str,
     )
+    check(
+        assert_type(s.str.cat(pd.Categorical(["b"])), "pd.Series[str]"), pd.Series, str
+    )
+    check(assert_type(s.str.cat(pd.array(["b"])), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.str.cat(("b",)), "pd.Series[str]"), pd.Series, str)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        s.str.cat("a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_index_overloads_cat() -> None:
@@ -741,8 +748,7 @@ def test_index_overloads_cat() -> None:
     check(assert_type(idx.str.cat(None, sep=";"), str), str)
     check(
         assert_type(
-            idx.str.cat(["A", "B", "C", "D", "E", "F", "G"], sep=";"),
-            "pd.Index[str]",
+            idx.str.cat(["A", "B", "C", "D", "E", "F", "G"], sep=";"), "pd.Index[str]"
         ),
         pd.Index,
         str,
@@ -767,6 +773,14 @@ def test_index_overloads_cat() -> None:
         pd.Index,
         str,
     )
+    check(
+        assert_type(idx.str.cat(pd.Categorical(["b"])), "pd.Index[str]"), pd.Index, str
+    )
+    check(assert_type(idx.str.cat(pd.array(["b"])), "pd.Index[str]"), pd.Index, str)
+    check(assert_type(idx.str.cat(("b",)), "pd.Index[str]"), pd.Index, str)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        idx.str.cat("a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_series_overloads_extract() -> None:


### PR DESCRIPTION
- [x] Closes #1853 (Replace xxxx with the Github issue number)
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
