### PR TITLE
BUG: #1856 `df.groupby().apply((df) -> Series)` can be `Series` or `DataFrame`

### DIFF
--- a/pandas-stubs/core/groupby/generic.pyi
+++ b/pandas-stubs/core/groupby/generic.pyi
@@ -236,7 +236,14 @@ class DataFrameGroupBy(GroupBy[DataFrame], Generic[ByT, _TT]):
     @overload
     def apply(
         self,
-        func: Callable[Concatenate[DataFrame, P], DataFrame | Series] | str,
+        func: Callable[Concatenate[DataFrame, P], Series],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> Series | DataFrame: ...
+    @overload
+    def apply(
+        self,
+        func: Callable[Concatenate[DataFrame, P], DataFrame] | str,
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> DataFrame: ...

--- a/tests/frame/test_groupby.py
+++ b/tests/frame/test_groupby.py
@@ -650,11 +650,11 @@ def test_groupby_apply() -> None:
         assert_type(df_gb.apply(sum_to_series), pd.Series | pd.DataFrame), pd.DataFrame
     )
 
-    def different_size(_: pd.DataFrame) -> pd.Series:
-        return pd.Series([])
+    def same_len(x: pd.DataFrame) -> pd.Series:
+        return x["col2"]
 
     check(
-        assert_type(df_gb.apply(different_size), pd.Series | pd.DataFrame), pd.DataFrame
+        assert_type(df_gb.apply(same_len), pd.Series | pd.DataFrame), pd.Series
     )
 
     def sample_to_df(x: pd.DataFrame) -> pd.DataFrame:

--- a/tests/frame/test_groupby.py
+++ b/tests/frame/test_groupby.py
@@ -627,27 +627,34 @@ def test_groupby_result_for_ambiguous_indexes() -> None:
 def test_groupby_apply() -> None:
     # GH 167
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [4, 5, 6]})
+    df_gb = df.groupby("col1")
 
     def sum_mean(x: pd.DataFrame) -> float:
         return x.sum().mean()
 
-    check(assert_type(df.groupby("col1").apply(sum_mean), pd.Series), pd.Series)
+    check(assert_type(df_gb.apply(sum_mean), pd.Series), pd.Series)
 
     # TODO: revert to the original once astral-sh/ty#4055 astral-sh/ty#4135 are fixed
     lfunc: Callable[[pd.DataFrame], float] = lambda _: 1.0  # x: x.sum().mean()
-    check(assert_type(df.groupby("col1").apply(lfunc), pd.Series), pd.Series)
+    check(assert_type(df_gb.apply(lfunc), pd.Series), pd.Series)
 
     def sum_to_list(x: pd.DataFrame) -> list[Any]:
         return x.sum().tolist()
 
-    check(assert_type(df.groupby("col1").apply(sum_to_list), pd.Series), pd.Series)
+    check(assert_type(df_gb.apply(sum_to_list), pd.Series), pd.Series)
 
     def sum_to_series(x: pd.DataFrame) -> pd.Series:
         return x.sum()
 
     check(
-        assert_type(df.groupby("col1").apply(sum_to_series), pd.DataFrame),
-        pd.DataFrame,
+        assert_type(df_gb.apply(sum_to_series), pd.Series | pd.DataFrame), pd.DataFrame
+    )
+
+    def different_size(_: pd.DataFrame) -> pd.Series:
+        return pd.Series([])
+
+    check(
+        assert_type(df_gb.apply(different_size), pd.Series | pd.DataFrame), pd.DataFrame
     )
 
     def sample_to_df(x: pd.DataFrame) -> pd.DataFrame:

--- a/tests/frame/test_groupby.py
+++ b/tests/frame/test_groupby.py
@@ -653,9 +653,7 @@ def test_groupby_apply() -> None:
     def same_len(x: pd.DataFrame) -> pd.Series:
         return x["col2"]
 
-    check(
-        assert_type(df_gb.apply(same_len), pd.Series | pd.DataFrame), pd.Series
-    )
+    check(assert_type(df_gb.apply(same_len), pd.Series | pd.DataFrame), pd.Series)
 
     def sample_to_df(x: pd.DataFrame) -> pd.DataFrame:
         return x.sample()

--- a/tests/test_groupby.py
+++ b/tests/test_groupby.py
@@ -218,15 +218,7 @@ def test_frame_groupby_resample() -> None:
     def resample_interpolate_linear(x: DataFrame) -> DataFrame:
         return x.resample("ME").interpolate(method="linear")
 
-    check(
-        assert_type(
-            GB_DF.apply(
-                resample_interpolate_linear,
-            ),
-            DataFrame,
-        ),
-        DataFrame,
-    )
+    check(assert_type(GB_DF.apply(resample_interpolate_linear), DataFrame), DataFrame)
 
     # mypy cannot infer the return type of raw lambdas against Protocol-based overloads;
     # use typed Callable variables to work around this limitation.


### PR DESCRIPTION
- [x] Closes #1856
- [x] Tests added
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
