### PR TITLE
BUG: #1861 support `Series[str].replace({str: pd.NA})`

### DIFF
--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -1137,8 +1137,8 @@ StataDateFormat: TypeAlias = Literal[
     "%ty",
 ]
 
-# Can be passed to `to_replace`, `value`, or `regex` in `Series.replace`.
-# `DataFrame.replace` also accepts mappings of these.
+# Can be passed to `to_replace`, `value`, or `regex` in `DataFrame.replace`.
+# `Series.replace` has a specialised `_ReplaceValueStr`.
 ReplaceValue: TypeAlias = (
     Scalar
     | Pattern[str]

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -21,6 +21,7 @@ from datetime import (
     timedelta,
 )
 from pathlib import Path
+from re import Pattern
 from typing import (
     Any,
     ClassVar,
@@ -163,6 +164,7 @@ from pandas._typing import (
     CategoryDtypeArg,
     ComplexDtypeArg,
     CompressionOptions,
+    CovariantList,
     DropKeep,
     Dtype,
     DTypeLike,
@@ -213,7 +215,6 @@ from pandas._typing import (
     RandomState,
     ReindexMethod,
     Renamer,
-    ReplaceValue,
     S2_contra,
     S2_NDT_contra,
     Scalar,
@@ -363,6 +364,15 @@ class _CatDescriptor:
     ) -> CategoricalAccessor[CategoricalValueT]: ...
     @overload
     def __get__(self, instance: Series, owner: Any) -> CategoricalAccessor[Any]: ...
+
+_StrOrPattern: TypeAlias = str | Pattern[str]
+_ReplaceValueStr: TypeAlias = (
+    _StrOrPattern
+    | CovariantList[_StrOrPattern]
+    | Mapping[_StrOrPattern, _StrOrPattern | NAType]
+    | Series[str]
+    | None
+)
 
 class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     # Define __index__ because mypy thinks Series follows protocol `SupportsIndex` https://github.com/pandas-dev/pandas-stubs/pull/1332#discussion_r2285648790
@@ -1395,14 +1405,33 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
         limit: int | None = ...,
         inplace: _bool = False,
     ) -> Series[S1]: ...
+    @overload
+    def replace(
+        self: Series[_str],
+        to_replace: _ReplaceValueStr = None,
+        value: _ReplaceValueStr | NoDefault = ...,
+        *,
+        regex: _bool = False,
+        inplace: _bool = False,
+    ) -> Series[_str]: ...
+    @overload
+    def replace(
+        self: Series[_str],
+        to_replace: None = None,
+        value: _ReplaceValueStr | NoDefault = ...,
+        *,
+        regex: _ReplaceValueStr,
+        inplace: _bool = False,
+    ) -> Series[_str]: ...
+    @overload
     def replace(
         self,
-        to_replace: ReplaceValue = ...,
-        value: ReplaceValue = ...,
+        to_replace: S1 | Mapping[S1, S1] | CovariantList[S1] | Self | None = None,
+        value: S1 | Mapping[S1, S1] | CovariantList[S1] | None = ...,
         *,
-        regex: ReplaceValue = ...,
+        regex: Literal[False] = False,
         inplace: _bool = False,
-    ) -> Series[S1]: ...
+    ) -> Self: ...
     @overload
     def shift(
         self,

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -365,12 +365,13 @@ class _CatDescriptor:
     @overload
     def __get__(self, instance: Series, owner: Any) -> CategoricalAccessor[Any]: ...
 
-_StrOrPattern: TypeAlias = str | Pattern[str]
+_StrOrPattern: TypeAlias = _str | Pattern[_str]
 _ReplaceValueStr: TypeAlias = (
     _StrOrPattern
     | CovariantList[_StrOrPattern]
-    | Mapping[_StrOrPattern, _StrOrPattern | NAType]
-    | Series[str]
+    | Mapping[_str, _StrOrPattern | NAType]  # _KT is invariant, hence has to split
+    | Mapping[Pattern[_str], _StrOrPattern | NAType]
+    | Series[_str]
     | None
 )
 

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1659,42 +1659,62 @@ def test_series_replace() -> None:
     s: pd.Series[str] = pd.DataFrame({"col1": ["a", "ab", "ba"]})["col1"]
     pattern = re.compile(r"^a.*")
     replace_dict = {"a": "b"}
-    check(assert_type(s.replace("a", "x"), "pd.Series[str]"), pd.Series)
-    check(assert_type(s.replace(pattern, "x"), "pd.Series[str]"), pd.Series)
+    check(assert_type(s.replace("a", "x"), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.replace(pattern, "x"), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.replace({"a": "z"}), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.replace(replace_dict), "pd.Series[str]"), pd.Series, str)
     check(
-        assert_type(s.replace({"a": "z"}), "pd.Series[str]"),
-        pd.Series,
-    )
-    check(
-        assert_type(s.replace(replace_dict), "pd.Series[str]"),
-        pd.Series,
-    )
-    check(
-        assert_type(s.replace(pd.Series({"a": "z"})), "pd.Series[str]"),
-        pd.Series,
+        assert_type(s.replace(pd.Series({"a": "z"})), "pd.Series[str]"), pd.Series, str
     )
     check(
         assert_type(s.replace({pattern: "z"}, regex=True), "pd.Series[str]"),
         pd.Series,
+        str,
     )
-    check(assert_type(s.replace(["a"], ["x"]), "pd.Series[str]"), pd.Series)
+    check(assert_type(s.replace(["a"], ["x"]), "pd.Series[str]"), pd.Series, str)
     check(
         assert_type(s.replace([pattern], ["x"], regex=True), "pd.Series[str]"),
         pd.Series,
+        str,
     )
-    check(assert_type(s.replace(r"^a.*", "x", regex=True), "pd.Series[str]"), pd.Series)
-    check(assert_type(s.replace(value="x", regex=r"^a.*"), "pd.Series[str]"), pd.Series)
     check(
-        assert_type(s.replace(value="x", regex=[r"^a.*"]), "pd.Series[str]"), pd.Series
+        assert_type(s.replace(r"^a.*", "x", regex=True), "pd.Series[str]"),
+        pd.Series,
+        str,
     )
-    check(assert_type(s.replace(value="x", regex=pattern), "pd.Series[str]"), pd.Series)
     check(
-        assert_type(s.replace(value="x", regex=[pattern]), "pd.Series[str]"), pd.Series
+        assert_type(s.replace(value="x", regex=r"^a.*"), "pd.Series[str]"),
+        pd.Series,
+        str,
     )
-    check(assert_type(s.replace(regex={"a": "x"}), "pd.Series[str]"), pd.Series)
     check(
-        assert_type(s.replace(regex=pd.Series({"a": "x"})), "pd.Series[str]"), pd.Series
+        assert_type(s.replace(value="x", regex=[r"^a.*"]), "pd.Series[str]"),
+        pd.Series,
+        str,
     )
+    check(
+        assert_type(s.replace(value="x", regex=pattern), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
+    check(
+        assert_type(s.replace(value="x", regex=[pattern]), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
+    check(assert_type(s.replace(regex={"a": "x"}), "pd.Series[str]"), pd.Series, str)
+    check(
+        assert_type(s.replace(regex=pd.Series({"a": "x"})), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
+    check(assert_type(s.replace({"": pd.NA}), "pd.Series[str]"), pd.Series, str)
+
+    s_i = pd.Series([1])
+    check(assert_type(s_i.replace({1: 2}), "pd.Series[int]"), pd.Series, np.integer)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        s.replace({"1": "2"}, regex={"1": "2"})  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
 def test_cat_accessor() -> None:

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1662,9 +1662,11 @@ def test_series_replace() -> None:
         str,
     )
     pattern = re.compile(r"^a.*")
+    replace_dict = {"a": "b"}
     check(assert_type(s.replace("a", "x"), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.replace(pattern, "x"), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.replace({"a": "z"}), "pd.Series[str]"), pd.Series, str)
+    check(assert_type(s.replace(replace_dict), "pd.Series[str]"), pd.Series, str)
     check(
         assert_type(s.replace({"a": "b", "": pd.NA}), "pd.Series[str]"), pd.Series, str
     )

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1667,9 +1667,6 @@ def test_series_replace() -> None:
     check(assert_type(s.replace(pattern, "x"), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.replace({"a": "z"}), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.replace(replace_dict), "pd.Series[str]"), pd.Series, str)
-    check(
-        assert_type(s.replace({"a": "b", "": pd.NA}), "pd.Series[str]"), pd.Series, str
-    )
     # pandas-dev/pandas-stubs#1861
     check(assert_type(s.replace({"": pd.NA}), "pd.Series[str]"), pd.Series, str)
     check(

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1656,13 +1656,20 @@ def test_types_replace() -> None:
 
 
 def test_series_replace() -> None:
-    s: pd.Series[str] = pd.DataFrame({"col1": ["a", "ab", "ba"]})["col1"]
+    s = check(
+        assert_type(pd.Series(["a", "ab", "ba"], name="col1"), "pd.Series[str]"),
+        pd.Series,
+        str,
+    )
     pattern = re.compile(r"^a.*")
-    replace_dict = {"a": "b"}
     check(assert_type(s.replace("a", "x"), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.replace(pattern, "x"), "pd.Series[str]"), pd.Series, str)
     check(assert_type(s.replace({"a": "z"}), "pd.Series[str]"), pd.Series, str)
-    check(assert_type(s.replace(replace_dict), "pd.Series[str]"), pd.Series, str)
+    check(
+        assert_type(s.replace({"a": "b", "": pd.NA}), "pd.Series[str]"), pd.Series, str
+    )
+    # pandas-dev/pandas-stubs#1861
+    check(assert_type(s.replace({"": pd.NA}), "pd.Series[str]"), pd.Series, str)
     check(
         assert_type(s.replace(pd.Series({"a": "z"})), "pd.Series[str]"), pd.Series, str
     )
@@ -1708,7 +1715,6 @@ def test_series_replace() -> None:
         pd.Series,
         str,
     )
-    check(assert_type(s.replace({"": pd.NA}), "pd.Series[str]"), pd.Series, str)
 
     s_i = pd.Series([1])
     check(assert_type(s_i.replace({1: 2}), "pd.Series[int]"), pd.Series, np.integer)


### PR DESCRIPTION
- [x] Closes #1861 (Replace xxxx with the Github issue number)
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
