### PR TITLE
BUG: #1868 `Series.explode`

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -163,6 +163,7 @@ from pandas._typing import (
     CategoryDtypeArg,
     ComplexDtypeArg,
     CompressionOptions,
+    CovariantList,
     DropKeep,
     Dtype,
     DTypeLike,
@@ -1209,7 +1210,12 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     ) -> Series[S1]: ...
     def swaplevel(self, i: Level = -2, j: Level = -1) -> Series[S1]: ...
     def reorder_levels(self, order: Sequence[int | np.integer]) -> Series[S1]: ...
-    def explode(self, ignore_index: _bool = ...) -> Series[S1]: ...
+    @overload
+    def explode(
+        self: Iterable[CovariantList[S2]], ignore_index: _bool = False
+    ) -> Series[S2]: ...
+    @overload
+    def explode(self, ignore_index: _bool = False) -> Series[S1]: ...
     def unstack(
         self,
         level: IndexLabel = -1,

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -3810,6 +3810,9 @@ def test_series_explode() -> None:
     check(assert_type(s.explode(), pd.Series), pd.Series)
     check(assert_type(s.explode(ignore_index=True), pd.Series), pd.Series)
 
+    s_str = pd.Series(["a,b,c"])
+    check(assert_type(s_str.str.split(",").explode(), "pd.Series[str]"), pd.Series, str)
+
 
 def test_series_index_setter() -> None:
     """Test Series.index setter property GH1366."""

--- a/tests/test_string_accessors.py
+++ b/tests/test_string_accessors.py
@@ -262,6 +262,8 @@ def test_string_accessors_string_series() -> None:
     _check(assert_type(s.str.rstrip(), "pd.Series[str]"))
     _check(assert_type(s.str.slice_replace(0, 2, "XX"), "pd.Series[str]"))
     _check(assert_type(s.str.strip(), "pd.Series[str]"))
+    # pandas-dev/pandas-stubs#1868
+    _check(assert_type(s.str.split("a").explode().str.strip(), "pd.Series[str]"))
     _check(assert_type(s.str.swapcase(), "pd.Series[str]"))
     _check(assert_type(s.str.title(), "pd.Series[str]"))
     _check(
@@ -527,6 +529,8 @@ def test_string_accessors_list_series() -> None:
     _check(assert_type(s.str.split("a", expand=False), "pd.Series[list[str]]"))
     _check(assert_type(s.str.rsplit("a"), "pd.Series[list[str]]"))
     _check(assert_type(s.str.rsplit("a", expand=False), "pd.Series[list[str]]"))
+    # pandas-dev/pandas-stubs#1868
+    _check(assert_type(s.str.split("a").explode().str.split(), "pd.Series[list[str]]"))
 
     s_a = pd.DataFrame({"a": DATA})["a"]
     _check(assert_type(s_a.str.findall("pp"), "pd.Series[list[str]]"))


### PR DESCRIPTION
- [x] Closes #1868. `Series[list[S2]]().explode(...)` should give rise to `Series[S2]`.
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
