### PR TITLE
TST: add Python versions to type checkers astral-sh/ty#4161 facebook/pyrefly#4416 facebook/pyrefly#4422

### DIFF
--- a/pandas-stubs/_libs/tslibs/timestamps.pyi
+++ b/pandas-stubs/_libs/tslibs/timestamps.pyi
@@ -101,7 +101,7 @@ class Timestamp(datetime, SupportsIndex):
     def fold(self) -> int: ...
     if sys.version_info >= (3, 12):
         @classmethod
-        def fromtimestamp(  # pyright: ignore[reportIncompatibleMethodOverride]
+        def fromtimestamp(  # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override-param-name] # ty: ignore[invalid-method-override]
             cls, t: float, tz: _tzinfo | str | None = None
         ) -> Self: ...
     else:

--- a/pandas-stubs/_libs/tslibs/timestamps.pyi
+++ b/pandas-stubs/_libs/tslibs/timestamps.pyi
@@ -101,7 +101,8 @@ class Timestamp(datetime, SupportsIndex):
     def fold(self) -> int: ...
     if sys.version_info >= (3, 12):
         @classmethod
-        def fromtimestamp(  # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override-param-name] # ty: ignore[invalid-method-override]
+        # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
+        def fromtimestamp(  # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override-param-name] # ty: ignore[invalid-method-override,unused-ignore-comment,unused-ignore-comment]
             cls, t: float, tz: _tzinfo | str | None = None
         ) -> Self: ...
     else:

--- a/scripts/_job.py
+++ b/scripts/_job.py
@@ -10,7 +10,7 @@ from loguru import logger
 @dataclass
 class Step:
     name: str
-    run: Callable[[], None]
+    run: Callable[..., None]
     rollback: Callable[[], None] | None = None
 
 

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -4,6 +4,9 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+from typing import Final
+
+_PYTHON_VERSION: Final = "{}.{}".format(*sys.version_info[:2])
 
 
 def mypy_src() -> None:
@@ -12,7 +15,7 @@ def mypy_src() -> None:
 
 
 def pyright_src() -> None:
-    cmd = ["pyright", "--warnings"]
+    cmd = ["pyright", "--warnings", "--pythonversion", _PYTHON_VERSION]
     subprocess.run(cmd, check=True)
 
 
@@ -49,7 +52,7 @@ def build_dist() -> None:
 
 
 def install_dist() -> None:
-    path = sorted(Path("dist/").glob("pandas_stubs-*.whl"))[-1]
+    path = max(Path("dist/").glob("pandas_stubs-*.whl"))
     cmd = [
         sys.executable,
         "-m",
@@ -72,22 +75,29 @@ def rename_src() -> None:
 
 
 def mypy_dist() -> None:
-    cmd = ["mypy", "tests", "--no-incremental", "--strict"]
+    cmd = [
+        "mypy",
+        "tests",
+        "--no-incremental",
+        "--strict",
+        "--python-version",
+        _PYTHON_VERSION,
+    ]
     subprocess.run(cmd, check=True)
 
 
 def pyright_dist() -> None:
-    cmd = ["pyright", "tests", "--warnings"]
+    cmd = ["pyright", "tests", "--warnings", "--pythonversion", _PYTHON_VERSION]
     subprocess.run(cmd, check=True)
 
 
 def pyrefly_dist() -> None:
-    cmd = ["pyrefly", "check", "tests"]
+    cmd = ["pyrefly", "check", "tests", "--python-version", _PYTHON_VERSION]
     subprocess.run(cmd, check=True)
 
 
 def ty_dist() -> None:
-    cmd = ["ty", "check", "tests"]
+    cmd = ["ty", "check", "tests", "--python-version", _PYTHON_VERSION]
     subprocess.run(cmd, check=True)
 
 
@@ -171,7 +181,7 @@ def released_mypy() -> None:
 
 
 def ty_src() -> None:
-    cmd = ["ty", "check", "pandas-stubs", "tests", "--python", sys.executable]
+    cmd = ["ty", "check", "pandas-stubs", "tests", "--python-version", _PYTHON_VERSION]
     subprocess.run(cmd, check=True)
 
 
@@ -182,7 +192,8 @@ def ty_src_all() -> None:
         "pandas-stubs",
         "tests",
         "--python",
-        sys.executable,
+        "--python-version",
+        _PYTHON_VERSION,
         "--error",
         "all",
     ]
@@ -190,17 +201,42 @@ def ty_src_all() -> None:
 
 
 def pyrefly_src() -> None:
-    cmd = ["pyrefly", "check", "pandas-stubs", "tests"]
+    cmd = [
+        "pyrefly",
+        "check",
+        "pandas-stubs",
+        "tests",
+        "--python-version",
+        _PYTHON_VERSION,
+    ]
     subprocess.run(cmd, check=True)
 
 
 def pyrefly_src_strict() -> None:
-    cmd = ["pyrefly", "check", "pandas-stubs", "tests", "--preset", "strict"]
+    cmd = [
+        "pyrefly",
+        "check",
+        "pandas-stubs",
+        "tests",
+        "--python-version",
+        _PYTHON_VERSION,
+        "--preset",
+        "strict",
+    ]
     subprocess.run(cmd, check=True)
 
 
 def pyrefly_src_all() -> None:
-    cmd = ["pyrefly", "check", "pandas-stubs", "tests", "--preset", "all"]
+    cmd = [
+        "pyrefly",
+        "check",
+        "pandas-stubs",
+        "tests",
+        "--python-version",
+        _PYTHON_VERSION,
+        "--preset",
+        "all",
+    ]
     subprocess.run(cmd, check=True)
 
 

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -904,8 +904,8 @@ def test_timedelta_cmp_array() -> None:
     # TODO: facebook/pyrefly#3977
     if sys.version_info >= (3, 12):
         # TODO: python/mypy#21733 the mypy bugs have manifested in numpy >= 2.5
-        eq_nd1 = check(assert_type(td == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type]
-        ne_nd1 = check(assert_type(td != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type]
+        eq_nd1 = check(assert_type(td == arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
+        ne_nd1 = check(assert_type(td != arr_nd, np_ndarray_bool), np_ndarray_bool, np.bool)  # type: ignore[assert-type] # pyrefly: ignore[assert-type]
         assert (eq_nd1 != ne_nd1).all()
         eq_2d1 = check(assert_type(td == arr_2d, np_2darray[np.bool]), np_2darray[np.bool])  # type: ignore[assert-type]
         ne_2d1 = check(assert_type(td != arr_2d, np_2darray[np.bool]), np_2darray[np.bool])  # type: ignore[assert-type]


### PR DESCRIPTION
It turns out we can indicate python versions to all four type checkers. It has impacts on `ty` and `pyrefly`.

- [x] Closes astral-sh/ty#4161 facebook/pyrefly#4416 facebook/pyrefly#4422
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
