### PR TITLE
BUG: relocate `to_offset` and other `pyrefly`-inspired changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: ruff-check
         args: [--exit-non-zero-on-fix]
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
     - id: codespell
       args: [-L, "THIRDPARTY"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
     autofix_prs: false
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
     -   id: ruff-check
         args: [--exit-non-zero-on-fix]

--- a/pandas-stubs/_libs/tslibs/offsets.pyi
+++ b/pandas-stubs/_libs/tslibs/offsets.pyi
@@ -18,6 +18,7 @@ import numpy as np
 from pandas import Timestamp
 
 from pandas._typing import (
+    Frequency,
     ShapeT,
     np_ndarray_object,
 )
@@ -103,6 +104,11 @@ class BaseOffset:
     def nanos(self) -> int: ...
 
 class SingleConstructorOffset(BaseOffset): ...
+
+@overload
+def to_offset(freq: None, is_period: bool = False) -> None: ...
+@overload
+def to_offset(freq: Frequency | timedelta, is_period: bool = False) -> BaseOffset: ...
 
 class Tick(SingleConstructorOffset):
     def __init__(self, n: int = ..., normalize: bool = ...) -> None: ...

--- a/pandas-stubs/_libs/tslibs/timestamps.pyi
+++ b/pandas-stubs/_libs/tslibs/timestamps.pyi
@@ -48,7 +48,7 @@ _Ambiguous: TypeAlias = bool | Literal["raise", "NaT"]
 
 # Repeated from `_typing.pyi` so as to satisfy mixed strict / non-strict paths.
 # https://github.com/pandas-dev/pandas-stubs/pull/1151#issuecomment-2715130190
-TimeZones: TypeAlias = str | _tzinfo | None | int
+TimeZones: TypeAlias = str | _tzinfo | int | None
 
 class Timestamp(datetime, SupportsIndex):
     min: ClassVar[Timestamp]  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/pandas-stubs/_typing.pyi
+++ b/pandas-stubs/_typing.pyi
@@ -703,7 +703,7 @@ StorageOptions: TypeAlias = dict[str, Any] | None
 # compression keywords and compression
 CompressionDict: TypeAlias = dict[str, Any]
 CompressionOptions: TypeAlias = (
-    None | Literal["infer", "gzip", "bz2", "zip", "xz", "zstd", "tar"] | CompressionDict
+    Literal["infer", "gzip", "bz2", "zip", "xz", "zstd", "tar"] | CompressionDict | None
 )
 ParquetCompressionOptions: TypeAlias = (
     Literal["snappy", "gzip", "brotli", "lz4", "zstd"] | None
@@ -1203,7 +1203,7 @@ ExcelWriteEngine: TypeAlias = Literal["openpyxl", "odf", "xlsxwriter"]
 
 # Repeated in `timestamps.pyi` so as to satisfy mixed strict / non-strict paths.
 # https://github.com/pandas-dev/pandas-stubs/pull/1151#issuecomment-2715130190
-TimeZones: TypeAlias = str | tzinfo | None | int
+TimeZones: TypeAlias = str | tzinfo | int | None
 
 ColumnValue: TypeAlias = AnyArrayLike | Scalar | Sequence[Scalar] | range | None
 # Evaluates to a DataFrame column in DataFrame.assign context.

--- a/pandas-stubs/core/construction.pyi
+++ b/pandas-stubs/core/construction.pyi
@@ -136,7 +136,7 @@ def array(  # type: ignore[overload-overlap]
 @overload
 def array(
     data: (
-        Sequence[IntervalT | None | float]
+        Sequence[IntervalT | float | None]
         | IntervalArray
         | IntervalIndex
         | Series[Interval]

--- a/pandas-stubs/core/indexes/timedeltas.pyi
+++ b/pandas-stubs/core/indexes/timedeltas.pyi
@@ -160,7 +160,7 @@ def timedelta_range(
     freq: Frequency | Timedelta | timedelta | None = None,
     name: Hashable | None = None,
     closed: Literal["left", "right"] | None = None,
-    unit: None | str = None,
+    unit: str | None = None,
 ) -> TimedeltaIndex: ...
 @overload
 def timedelta_range(
@@ -170,7 +170,7 @@ def timedelta_range(
     freq: Frequency | Timedelta | timedelta | None = None,
     name: Hashable | None = None,
     closed: Literal["left", "right"] | None = None,
-    unit: None | str = None,
+    unit: str | None = None,
 ) -> TimedeltaIndex: ...
 @overload
 def timedelta_range(
@@ -180,7 +180,7 @@ def timedelta_range(
     freq: Frequency | Timedelta | timedelta | None = None,
     name: Hashable | None = None,
     closed: Literal["left", "right"] | None = None,
-    unit: None | str = None,
+    unit: str | None = None,
 ) -> TimedeltaIndex: ...
 @overload
 def timedelta_range(
@@ -190,5 +190,5 @@ def timedelta_range(
     *,
     name: Hashable | None = None,
     closed: Literal["left", "right"] | None = None,
-    unit: None | str = None,
+    unit: str | None = None,
 ) -> TimedeltaIndex: ...

--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -128,6 +128,7 @@ from pandas.core.window.rolling import (
     Rolling,
     Window,
 )
+from typing_extensions import override
 import xarray as xr
 
 from pandas._libs.interval import Interval
@@ -1874,7 +1875,8 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     @final
     def last_valid_index(self) -> Scalar: ...
     @overload
-    def value_counts(  # pyrefly: ignore
+    @override
+    def value_counts(
         self,
         normalize: Literal[False] = False,
         sort: _bool = ...,

--- a/pandas-stubs/tseries/frequencies.pyi
+++ b/pandas-stubs/tseries/frequencies.pyi
@@ -1,18 +1,7 @@
-from datetime import timedelta
-from typing import overload
+from pandas.core.indexes.datetimes import DatetimeIndex
+from pandas.core.indexes.timedeltas import TimedeltaIndex
+from pandas.core.series import Series
 
-from pandas import (
-    DatetimeIndex,
-    Series,
-    TimedeltaIndex,
-)
+from pandas._libs.tslibs.offsets import to_offset as to_offset
 
-from pandas._typing import Frequency
-
-from pandas.tseries.offsets import BaseOffset
-
-@overload
-def to_offset(freq: None, is_period: bool = False) -> None: ...
-@overload
-def to_offset(freq: Frequency | timedelta, is_period: bool = False) -> BaseOffset: ...
 def infer_freq(index: Series | DatetimeIndex | TimedeltaIndex) -> str | None: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,10 +347,12 @@ filterwarnings = [
 project-includes = ["pandas-stubs", "tests"]
 enabled-ignores = ["pyrefly"]
 python-version = "3.11"
+min-severity = "warn"
 
 [tool.pyrefly.errors]
 explicit-any = false  # We do use implicit Any
 implicit-any-type-argument = false  # We do use implicit Any
+implicit-bool = false  # We do use implicit bool
 untyped-import = false  # Import discovery
 
 [tool.ty.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ extend-select = ["ALL"]
 ignore = [
   # The following rules are ignored permanently for good reasons
   "COM",    # https://docs.astral.sh/ruff/rules/#flake8-commas-com
+  "CPY001", # https://docs.astral.sh/ruff/rules/missing-copyright-notice/
   "D",      # https://docs.astral.sh/ruff/rules/#pydocstyle-d
   "E501",   # handled by black https://docs.astral.sh/ruff/rules/line-too-long/
   "FBT",    # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -91,8 +91,10 @@ def check(
     value: Any
     if isinstance(actual, pd.Series):
         # cast is by design microsoft/pyright#11191
+        # pyrefly: ignore[redundant-cast]
         value = cast(pd.Series, actual).iloc[index_to_check_for_type]
     elif isinstance(actual, pd.Index):
+        # pyrefly: ignore[redundant-cast]
         # cast is by design microsoft/pyright#11191
         value = cast(pd.Index, actual)[index_to_check_for_type]
     elif isinstance(actual, BaseGroupBy):

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -297,7 +297,10 @@ def test_assign() -> None:
     df = pd.DataFrame({"a": [1, 2, 3], 1: [4, 5, 6]})
 
     my_unnamed_func = (  # pyright: ignore[reportUnknownVariableType]
-        lambda df: df["a"] * 2  # pyright: ignore[reportUnknownLambdaType]
+        lambda df: df[  # pyright: ignore[reportUnknownLambdaType] # pyrefly: ignore[implicit-any-lambda]
+            "a"
+        ]
+        * 2
     )
 
     def my_named_func_1(df: pd.DataFrame) -> pd.Series[str]:
@@ -4572,12 +4575,14 @@ def test_frame_pipe() -> None:
         return x.max() - k * x.min()
 
     check(
+        # pyrefly: ignore[implicity-any-lambda]
         assert_type(df.rolling(2).pipe(lambda x: x.min() - x.max()), pd.DataFrame),
         pd.DataFrame,
     )
     check(assert_type(df.rolling(2).pipe(func_r, k=2), pd.DataFrame), pd.DataFrame)
 
     check(
+        # pyrefly: ignore[implicity-any-lambda]
         assert_type(df.expanding().pipe(lambda x: x.min() - x.max()), pd.DataFrame),
         pd.DataFrame,
     )

--- a/tests/test_groupby.py
+++ b/tests/test_groupby.py
@@ -156,6 +156,7 @@ def test_frame_groupby_resample() -> None:
         return val.mean()
 
     def df2scalar(val: DataFrame) -> float:
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean().mean())
 
     check(assert_type(GB_DF.resample("ME").aggregate(np.sum), DataFrame), DataFrame)
@@ -245,6 +246,7 @@ def test_frame_groupby_resample() -> None:
 
     def i(val: Resampler[DataFrame]) -> float:
         assert isinstance(val, Resampler)
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean().mean().mean())
 
     check(assert_type(GB_DF.resample("ME").pipe(i), float), float)
@@ -367,6 +369,7 @@ def test_series_groupby_resample() -> None:
     # pipe
     def g(val: Resampler[Series]) -> float:
         assert isinstance(val, Resampler)
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean().mean())
 
     check(assert_type(GB_S.resample("ME").pipe(g), float), float)
@@ -382,6 +385,7 @@ def test_series_groupby_resample() -> None:
         return Series(val)
 
     def s2scalar(val: Series) -> float:
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean())
 
     check(assert_type(GB_S.resample("ME").aggregate(np.sum), Series), Series)
@@ -477,6 +481,7 @@ def test_frame_groupby_rolling() -> None:
         return val.mean()
 
     def df2scalar(val: DataFrame) -> float:
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean().mean())
 
     check(assert_type(GB_DF.rolling(1).aggregate(np.sum), DataFrame), DataFrame)
@@ -578,6 +583,7 @@ def test_series_groupby_rolling() -> None:
     check(assert_type(GB_S.rolling(1).aggregate(f), Series), Series)
 
     def s2scalar(val: Series) -> float:
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean())
 
     check(assert_type(GB_S.rolling(1).aggregate(s2scalar), Series), Series)
@@ -652,6 +658,7 @@ def test_frame_groupby_expanding() -> None:
         return val.mean()
 
     def df2scalar(val: DataFrame) -> float:
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean().mean())
 
     check(assert_type(GB_DF.expanding(1).aggregate(np.sum), DataFrame), DataFrame)
@@ -757,6 +764,7 @@ def test_series_groupby_expanding() -> None:
     check(assert_type(GB_S.expanding(1).aggregate(f), Series), Series)
 
     def s2scalar(val: Series) -> float:
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean())
 
     check(assert_type(GB_S.expanding(1).aggregate(s2scalar), Series), Series)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -562,7 +562,7 @@ def test_isna() -> None:
     assert not check(assert_type(pd.notna(np_nat), bool), bool)
 
     # Check TypeIs type narrowing functionality
-    nullable1: str | None | NAType | NaTType = random.choice(
+    nullable1: str | NAType | NaTType | None = random.choice(
         ["value", None, pd.NA, pd.NaT]
     )
     if pd.notna(nullable1):
@@ -584,7 +584,7 @@ def test_isna() -> None:
     if not pd.notna(nullable2):
         check(assert_type(nullable2, None), type(None))
 
-    nullable3: bool | None | NAType = random.choice([True, None, pd.NA])
+    nullable3: bool | NAType | None = random.choice([True, None, pd.NA])
     if pd.notna(nullable3):
         check(assert_type(nullable3, bool), bool)
     if not pd.isna(nullable3):

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -160,6 +160,7 @@ def test_pipe() -> None:
 
     def i(val: "DatetimeIndexResampler[DataFrame]") -> float:
         assert isinstance(val, DatetimeIndexResampler)
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean().mean().mean())
 
     check(assert_type(DF.resample("ME").pipe(i), float), float)
@@ -304,6 +305,7 @@ def test_pipe_series() -> None:
 
     def g(val: "DatetimeIndexResampler[Series]") -> float:
         assert isinstance(val, DatetimeIndexResampler)
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean().mean())
 
     check(assert_type(S.resample("ME").pipe(g), float), float)
@@ -327,6 +329,7 @@ def test_aggregate_series_combinations() -> None:
         return Series(val)
 
     def s2scalar(val: Series) -> float:
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean())
 
     check(assert_type(S.resample("ME").aggregate(np.sum), Series), Series)
@@ -361,6 +364,7 @@ def test_aggregate_frame_combinations() -> None:
         return val.mean()
 
     def df2scalar(val: DataFrame) -> float:
+        # pyrefly: ignore[unnecessary-type-conversion]
         return float(val.mean().mean())
 
     check(assert_type(DF.resample("ME").aggregate(np.sum), DataFrame), DataFrame)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -42,8 +42,8 @@ def _to_type(t: Any) -> type:
     if isinstance(t, ExtensionDtype):
         return type(t)
     if issubclass(type(t), np.dtype):
-        return t.type  # type: ignore[no-any-return]
-    return t  # type: ignore[no-any-return]
+        return t.type  # type: ignore[no-any-return] # pyrefly: ignore[no-any-return-explicit]
+    return t  # type: ignore[no-any-return] # pyrefly: ignore[no-any-return-explicit]
 
 
 @pytest.mark.parametrize(("dtype_arg", "alias_map"), DTYPE_ARG_ALIAS_MAPS.items())


### PR DESCRIPTION
`to_offset` has been moved from `pandas-stubs/tseries/frequencies.pyi` to `pandas-stubs/_libs/tslibs/offsets.pyi`.

- [x] Towards #1867 which is gigantic
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
