### PR TITLE
GH1795 Add pyrefly coverage step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Run pyrefly on 'tests' (using the local stubs) and on the local stubs
         run: poetry run poe pyrefly
 
+      - name: Run pyrefly's type coverage check on 'tests'
+        run: poetry run poe pyrefly_coverage
+
       - name: Run pyright on 'tests' (using the local stubs) and on the local stubs
         run: poetry run poe pyright
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ help = "Run all tests"
 script = "scripts.test:run_tests(src=True, dist=True)"
 
 [tool.poe.tasks.test]
-help = "Run local tests (includes 'mypy', 'pyright', 'pyrefly', 'ty', 'pytest', and 'style')"
+help = "Run local tests (includes 'mypy', 'pyright', 'pyrefly', 'pyrefly_coverage', 'ty', 'pytest', and 'style')"
 script = "scripts.test:run_tests(src=True)"
 
 [tool.poe.tasks.test_dist]
@@ -130,6 +130,10 @@ script = "scripts.test.run:pyrefly_src_strict"
 [tool.poe.tasks.pyrefly_all]
 help = "Run pyrefly on 'tests' (using the local stubs) and on the local stubs with preset 'all'"
 script = "scripts.test.run:pyrefly_src_all"
+
+[tool.poe.tasks.pyrefly_coverage]
+help = "Run pyrefly's type coverage check on 'tests'"
+script = "scripts.test.run:pyrefly_coverage"
 
 [tool.poe.tasks.pyright]
 help = "Run pyright on 'tests' (using the local stubs) and on the local stubs"

--- a/scripts/test/__init__.py
+++ b/scripts/test/__init__.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 _SRC_STEPS = [
     _step.ty_src,
     _step.pyrefly_src,
+    _step.pyrefly_coverage,
     _step.mypy_src,
     _step.pyright_src,
     _step.pytest,

--- a/scripts/test/_step.py
+++ b/scripts/test/_step.py
@@ -21,6 +21,10 @@ pyrefly_src_all = Step(
     name="Run pyrefly on 'tests' (using the local stubs) and on the local stubs with preset 'all'",
     run=run.pyrefly_src_all,
 )
+pyrefly_coverage = Step(
+    name="Run pyrefly coverage check on 'tests'",
+    run=run.pyrefly_coverage,
+)
 pyright_src = Step(
     name="Run pyright on 'tests' (using the local stubs) and on the local stubs",
     run=run.pyright_src,

--- a/scripts/test/run.py
+++ b/scripts/test/run.py
@@ -239,6 +239,18 @@ def pyrefly_src_all() -> None:
     subprocess.run(cmd, check=True)
 
 
+def pyrefly_coverage() -> None:
+    cmd = [
+        "pyrefly",
+        "coverage",
+        "check",
+        "tests",
+        "--python-version",
+        _PYTHON_VERSION,
+    ]
+    subprocess.run(cmd, check=True)
+
+
 def type_completeness() -> None:
     cmd = ["python", "-m", "scripts.type_completeness"]
     subprocess.run(cmd, check=True)

--- a/tests/dtypes.py
+++ b/tests/dtypes.py
@@ -3,6 +3,10 @@ from datetime import (
     datetime,
     timedelta,
 )
+from typing import (
+    Any,
+    Literal,
+)
 
 import numpy as np
 import pandas as pd
@@ -62,15 +66,23 @@ from tests._typing import (
     VoidDtypeArg,
 )
 
-PYTHON_BOOL_ARGS = dict.fromkeys((bool, "bool"), np.bool_)
-PANDAS_BOOL_ARGS = dict.fromkeys((pd.BooleanDtype(), "boolean"), np.bool_)
-NUMPY_BOOL_ARGS = dict.fromkeys((np.bool_, "?", "b1", "bool_"), np.bool_)
-PYARROW_BOOL_ARGS = dict.fromkeys(("bool[pyarrow]", "boolean[pyarrow]"), bool)
+PYTHON_BOOL_ARGS: dict[str | type[bool], type[np.bool_]] = dict.fromkeys(
+    (bool, "bool"), np.bool_
+)
+PANDAS_BOOL_ARGS: dict[str | pd.BooleanDtype, type[np.bool_]] = dict.fromkeys(
+    (pd.BooleanDtype(), "boolean"), np.bool_
+)
+NUMPY_BOOL_ARGS: dict[str | type[np.bool_], type[np.bool_]] = dict.fromkeys(
+    (np.bool_, "?", "b1", "bool_"), np.bool_
+)
+PYARROW_BOOL_ARGS: dict[str, type[bool]] = dict.fromkeys(
+    ("bool[pyarrow]", "boolean[pyarrow]"), bool
+)
 ASTYPE_BOOL_ARGS = (
     PYTHON_BOOL_ARGS | PANDAS_BOOL_ARGS | NUMPY_BOOL_ARGS | PYARROW_BOOL_ARGS
 )
 
-PYTHON_INT_ARGS = dict.fromkeys((int, "int"), np.integer)
+PYTHON_INT_ARGS: dict[str | type[int], Any] = dict.fromkeys((int, "int"), np.integer)
 PANDAS_INT_ARGS = {
     **dict.fromkeys((pd.Int8Dtype(), "Int8"), np.int8),  # pandas Int8
     **dict.fromkeys((pd.Int16Dtype(), "Int16"), np.int16),  # pandas Int16
@@ -97,7 +109,9 @@ NUMPY_INT_ARGS: dict[str | type[np.signedinteger], type[np.signedinteger]] = {
     # numpy signed pointer  (platform dependent one of int[8,16,32,64])
     **dict.fromkeys((np.intp, "intp", "p"), np.intp),
 }
-PYARROW_INT_ARGS = dict.fromkeys([f"int{b}[pyarrow]" for b in (8, 16, 32, 64)], int)
+PYARROW_INT_ARGS: dict[str, type[int]] = dict.fromkeys(
+    [f"int{b}[pyarrow]" for b in (8, 16, 32, 64)], int
+)
 ASTYPE_INT_ARGS = PYTHON_INT_ARGS | PANDAS_INT_ARGS | NUMPY_INT_ARGS | PYARROW_INT_ARGS
 
 PANDAS_UINT_ARGS = {
@@ -126,10 +140,14 @@ NUMPY_UINT_ARGS: dict[str | type[np.unsignedinteger], type[np.unsignedinteger]] 
     # numpy unsigned pointer  (platform dependent one of uint[8,16,32,64])
     **dict.fromkeys((np.uintp, "uintp", "P"), np.uintp),
 }
-PYARROW_UINT_ARGS = dict.fromkeys([f"uint{b}[pyarrow]" for b in (8, 16, 32, 64)], int)
+PYARROW_UINT_ARGS: dict[str, type[int]] = dict.fromkeys(
+    [f"uint{b}[pyarrow]" for b in (8, 16, 32, 64)], int
+)
 ASTYPE_UINT_ARGS = PANDAS_UINT_ARGS | NUMPY_UINT_ARGS | PYARROW_UINT_ARGS
 
-PYTHON_FLOAT_ARGS = dict.fromkeys((float, "float"), np.floating)
+PYTHON_FLOAT_ARGS: dict[str | type[float], type[np.floating]] = dict.fromkeys(
+    (float, "float"), np.floating
+)
 PANDAS_FLOAT_ARGS = {
     **dict.fromkeys((pd.Float32Dtype(), "Float32"), np.float32),  # pandas Float32
     **dict.fromkeys((pd.Float64Dtype(), "Float64"), np.float64),  # pandas Float64
@@ -164,7 +182,9 @@ ASTYPE_FLOAT_ARGS = (
     | PYARROW_FLOAT_ARGS
 )
 
-PYTHON_COMPLEX_ARGS = dict.fromkeys((complex, "complex"), np.complexfloating)
+PYTHON_COMPLEX_ARGS: dict[str | type[complex], type[np.complexfloating]] = (
+    dict.fromkeys((complex, "complex"), np.complexfloating)
+)
 NUMPY_COMPLEX_ARGS: dict[str | type[np.complexfloating], type[np.complexfloating]] = {
     # numpy complex64
     **dict.fromkeys((np.csingle, "csingle", "F"), np.csingle),
@@ -191,7 +211,7 @@ NUMPY_TIMESTAMP_ARGS = {  # type: ignore[misc]
     **dict.fromkeys([f"<M8[{u}]" for u in NUMPY_UNITS], datetime),
     np.dtype("datetime64[ms]"): datetime,
 }
-PANDAS_TIMESTAMP_ARGS = dict.fromkeys(
+PANDAS_TIMESTAMP_ARGS: dict[str, type[datetime]] = dict.fromkeys(
     [f"datetime64[{u}, UTC]" for u in NUMPY_UNITS], datetime
 )
 PANDAS_ASTYPE_TIMESTAMP_ARGS = {
@@ -231,17 +251,25 @@ PANDAS_ASTYPE_TIMEDELTA_ARGS = {
     **dict.fromkeys([f"<m8[{u}]" for u in PANDAS_UNITS], timedelta),
 }
 # pyarrow duration
-PYARROW_TIMEDELTA_ARGS = dict.fromkeys(
+PYARROW_TIMEDELTA_ARGS: dict[str, type[timedelta]] = dict.fromkeys(
     [f"duration[{u}][pyarrow]" for u in NUMPY_UNITS], timedelta
 )
 TYPE_TIMEDELTA_ARGS = NUMPY_TIMEDELTA_ARGS | PYARROW_TIMEDELTA_ARGS
 ASTYPE_TIMEDELTA_ARGS = TYPE_TIMEDELTA_ARGS | PANDAS_ASTYPE_TIMEDELTA_ARGS
 
-PYTHON_STRING_ARGS = dict.fromkeys((str, "str"), str)
-PANDAS_BASE_STRING_ARGS = dict.fromkeys((pd.StringDtype(), "string"), str)
-PANDAS_STRING_ARGS = dict.fromkeys((pd.StringDtype("python"), "string[python]"), str)
-NUMPY_STRING_ARGS = dict.fromkeys((np.str_, "str_", "unicode", "U"), str)
-PYARROW_STRING_ARGS = dict.fromkeys((pd.StringDtype("pyarrow"), "string[pyarrow]"), str)
+PYTHON_STRING_ARGS: dict[str | type[str], type[str]] = dict.fromkeys((str, "str"), str)
+PANDAS_BASE_STRING_ARGS: dict[str | pd.StringDtype, type[str]] = dict.fromkeys(
+    (pd.StringDtype(), "string"), str
+)
+PANDAS_STRING_ARGS: 'dict[str | pd.StringDtype[Literal["python"]], type[str]]' = (
+    dict.fromkeys((pd.StringDtype("python"), "string[python]"), str)
+)
+NUMPY_STRING_ARGS: dict[str | type[np.str_], type[str]] = dict.fromkeys(
+    (np.str_, "str_", "unicode", "U"), str
+)
+PYARROW_STRING_ARGS: 'dict[str | pd.StringDtype[Literal["pyarrow"]], type[str]]' = (
+    dict.fromkeys((pd.StringDtype("pyarrow"), "string[pyarrow]"), str)
+)
 ASTYPE_STRING_ARGS = (
     PYTHON_STRING_ARGS
     | PANDAS_BASE_STRING_ARGS
@@ -251,8 +279,12 @@ ASTYPE_STRING_ARGS = (
     | PYARROW_STRING_ARGS
 )
 
-PYTHON_BYTES_ARGS = dict.fromkeys((bytes, "bytes"), bytes)
-NUMPY_BYTES_ARGS = dict.fromkeys((np.bytes_, "S", "bytes_"), np.bytes_)
+PYTHON_BYTES_ARGS: dict[str | type[bytes], type[bytes]] = dict.fromkeys(
+    (bytes, "bytes"), bytes
+)
+NUMPY_BYTES_ARGS: dict[str | type[np.bytes_], type[np.bytes_]] = dict.fromkeys(
+    (np.bytes_, "S", "bytes_"), np.bytes_
+)
 PYARROW_BYTES_ARGS = {"binary[pyarrow]": bytes}
 ASTYPE_BYTES_ARGS = PYTHON_BYTES_ARGS | NUMPY_BYTES_ARGS | PYARROW_BYTES_ARGS
 
@@ -263,11 +295,17 @@ ASTYPE_CATEGORICAL_ARGS = {
     # ("dictionary[pyarrow]", "pd.Series[category]", Categorical),
 }
 
-PYTHON_OBJECT_ARGS = dict.fromkeys((object, "object"), object)
-NUMPY_OBJECT_ARGS = dict.fromkeys((np.object_, "object_", "O"), object)
+PYTHON_OBJECT_ARGS: dict[str | type[object], type[object]] = dict.fromkeys(
+    (object, "object"), object
+)
+NUMPY_OBJECT_ARGS: dict[str | type[np.object_], type[object]] = dict.fromkeys(
+    (np.object_, "object_", "O"), object
+)
 ASTYPE_OBJECT_ARGS = PYTHON_OBJECT_ARGS | NUMPY_OBJECT_ARGS
 
-NUMPY_VOID_ARGS = dict.fromkeys((np.void, "void", "V"), np.void)
+NUMPY_VOID_ARGS: dict[str | type[np.void], type[np.void]] = dict.fromkeys(
+    (np.void, "void", "V"), np.void
+)
 ASTYPE_VOID_ARGS = NUMPY_VOID_ARGS
 
 PYTHON_NOT_STR_OBJ_DTYPE_ARGS = (

--- a/tests/extension/decimal/array.py
+++ b/tests/extension/decimal/array.py
@@ -77,7 +77,7 @@ class DecimalDtype(ExtensionDtype):
 
     def __init__(self, context: decimal.Context | None = None) -> None:
         super().__init__()
-        self.context = context or decimal.getcontext()
+        self.context: decimal.Context = context or decimal.getcontext()
 
     def __repr__(self) -> str:
         return f"DecimalDtype(context={self.context})"
@@ -122,7 +122,8 @@ class DecimalArray(OpsMixin, ExtensionArray):
         self._data = values_np
         # Some aliases for common attribute names to ensure pandas supports
         # these
-        self._items = self.data = self._data
+        self._items = self._data
+        self.data: np_ndarray = self._data
         # those aliases are currently not working due to assumptions
         # in internal code (GH-20735)
         # self._values = self.values = self.data

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -3556,7 +3556,9 @@ def where_cond2(x: pd.DataFrame) -> pd.DataFrame:
     return x > 1
 
 
-where_cond3 = pd.DataFrame({"a": [True, True, False], "b": [False, False, False]})
+where_cond3: pd.DataFrame = pd.DataFrame(
+    {"a": [True, True, False], "b": [False, False, False]}
+)
 
 
 @pytest.mark.parametrize("cond", [where_cond1, where_cond2, where_cond3])

--- a/tests/indexes/bool/test_add.py
+++ b/tests/indexes/bool/test_add.py
@@ -11,7 +11,7 @@ from tests._typing import (
 )
 
 # left operand
-left = pd.Index([True, True, False])
+left: "pd.Index[bool]" = pd.Index([True, True, False])
 
 
 def test_add_py_scalar() -> None:

--- a/tests/indexes/bool/test_sub.py
+++ b/tests/indexes/bool/test_sub.py
@@ -13,7 +13,7 @@ from tests import (
 )
 from tests._typing import np_ndarray_int64
 
-left = pd.Index([True, True, False])  # left operand
+left: "pd.Index[bool]" = pd.Index([True, True, False])  # left operand
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/indexes/complex/test_add.py
+++ b/tests/indexes/complex/test_add.py
@@ -11,7 +11,7 @@ from tests._typing import (
 )
 
 # left operand
-left = pd.Index([1j, 2j, 3j])
+left: "pd.Index[complex]" = pd.Index([1j, 2j, 3j])
 
 
 def test_add_py_scalar() -> None:

--- a/tests/indexes/complex/test_sub.py
+++ b/tests/indexes/complex/test_sub.py
@@ -11,7 +11,7 @@ from tests import check
 from tests._typing import np_ndarray_int64
 
 # left operand
-left = pd.Index([1j, 2j, 3j])
+left: "pd.Index[complex]" = pd.Index([1j, 2j, 3j])
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/indexes/float/test_add.py
+++ b/tests/indexes/float/test_add.py
@@ -11,7 +11,7 @@ from tests._typing import (
 )
 
 # left operand
-left = pd.Index([1.0, 2.0, 3.0])
+left: "pd.Index[float]" = pd.Index([1.0, 2.0, 3.0])
 
 
 def test_add_py_scalar() -> None:

--- a/tests/indexes/float/test_sub.py
+++ b/tests/indexes/float/test_sub.py
@@ -11,7 +11,7 @@ from tests import check
 from tests._typing import np_ndarray_int64
 
 # left operand
-left = pd.Index([1.0, 2.0, 3.0])
+left: "pd.Index[float]" = pd.Index([1.0, 2.0, 3.0])
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/indexes/int/test_add.py
+++ b/tests/indexes/int/test_add.py
@@ -11,7 +11,7 @@ from tests._typing import (
 )
 
 # left operand
-left = pd.Index([1, 2, 3])
+left: "pd.Index[int]" = pd.Index([1, 2, 3])
 
 
 def test_add_py_scalar() -> None:

--- a/tests/indexes/int/test_sub.py
+++ b/tests/indexes/int/test_sub.py
@@ -11,7 +11,7 @@ from tests import check
 from tests._typing import np_ndarray_int64
 
 # left operand
-left = pd.Index([1, 2, 3])
+left: "pd.Index[int]" = pd.Index([1, 2, 3])
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/indexes/str/test_add.py
+++ b/tests/indexes/str/test_add.py
@@ -18,7 +18,7 @@ from tests._typing import (
     np_ndarray_str,
 )
 
-left = pd.Index(["1", "23", "456"])  # left operand
+left: "pd.Index[str]" = pd.Index(["1", "23", "456"])  # left operand
 
 
 def test_add_py_scalar() -> None:

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -887,8 +887,10 @@ def test_interval_index_tuples() -> None:
     )
 
 
-dt_l, dt_r = dt.datetime(2025, 12, 14), dt.datetime(2025, 12, 15)
-td_l, td_r = dt.timedelta(seconds=1), dt.timedelta(seconds=2)
+dt_l: dt.datetime = dt.datetime(2025, 12, 14)
+dt_r: dt.datetime = dt.datetime(2025, 12, 15)
+td_l: dt.timedelta = dt.timedelta(seconds=1)
+td_r: dt.timedelta = dt.timedelta(seconds=2)
 
 
 @pytest.mark.parametrize(

--- a/tests/series/bool/test_add.py
+++ b/tests/series/bool/test_add.py
@@ -10,7 +10,7 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-left = pd.Series([True, True, False])  # left operand
+left: "pd.Series[bool]" = pd.Series([True, True, False])  # left operand
 
 
 def test_add_py_scalar() -> None:

--- a/tests/series/bool/test_sub.py
+++ b/tests/series/bool/test_sub.py
@@ -13,7 +13,7 @@ from tests import (
 )
 from tests._typing import np_ndarray_int64
 
-left = pd.Series([True, True, False])  # left operand
+left: "pd.Series[bool]" = pd.Series([True, True, False])  # left operand
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/series/complex/test_add.py
+++ b/tests/series/complex/test_add.py
@@ -10,7 +10,7 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-left = pd.Series([1j, 2j, 3j])  # left operand
+left: "pd.Series[complex]" = pd.Series([1j, 2j, 3j])  # left operand
 
 
 def test_add_py_scalar() -> None:

--- a/tests/series/complex/test_sub.py
+++ b/tests/series/complex/test_sub.py
@@ -10,7 +10,7 @@ import pandas as pd
 from tests import check
 from tests._typing import np_ndarray_int64
 
-left = pd.Series([1j, 2j, 3j])  # left operand
+left: "pd.Series[complex]" = pd.Series([1j, 2j, 3j])  # left operand
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/series/float/test_add.py
+++ b/tests/series/float/test_add.py
@@ -10,7 +10,7 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-left = pd.Series([1.0, 2.0, 3.0])  # left operand
+left: "pd.Series[float]" = pd.Series([1.0, 2.0, 3.0])  # left operand
 
 
 def test_add_py_scalar() -> None:

--- a/tests/series/float/test_sub.py
+++ b/tests/series/float/test_sub.py
@@ -10,7 +10,7 @@ import pandas as pd
 from tests import check
 from tests._typing import np_ndarray_int64
 
-left = pd.Series([1.0, 2.0, 3.0])  # left operand
+left: "pd.Series[float]" = pd.Series([1.0, 2.0, 3.0])  # left operand
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/series/int/test_add.py
+++ b/tests/series/int/test_add.py
@@ -10,7 +10,7 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-left = pd.Series([1, 2, 3])  # left operand
+left: "pd.Series[int]" = pd.Series([1, 2, 3])  # left operand
 
 
 def test_add_py_scalar() -> None:

--- a/tests/series/int/test_sub.py
+++ b/tests/series/int/test_sub.py
@@ -10,7 +10,7 @@ import pandas as pd
 from tests import check
 from tests._typing import np_ndarray_int64
 
-left = pd.Series([1, 2, 3])  # left operand
+left: "pd.Series[int]" = pd.Series([1, 2, 3])  # left operand
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/series/str/test_add.py
+++ b/tests/series/str/test_add.py
@@ -18,7 +18,7 @@ from tests._typing import (
     np_ndarray_str,
 )
 
-left = pd.Series(["1", "23", "456"])  # left operand
+left: "pd.Series[str]" = pd.Series(["1", "23", "456"])  # left operand
 
 
 def test_add_py_scalar() -> None:

--- a/tests/series/test_sub.py
+++ b/tests/series/test_sub.py
@@ -15,7 +15,7 @@ from tests import (
     check,
 )
 
-anchor = datetime(2025, 8, 18)
+anchor: datetime = datetime(2025, 8, 18)
 
 # left operands
 left_i = pd.DataFrame({"a": [1, 2, 3]})["a"]

--- a/tests/series/timedelta/test_add.py
+++ b/tests/series/timedelta/test_add.py
@@ -16,7 +16,7 @@ from tests._typing import (
     np_ndarray_td,
 )
 
-left = pd.Series([pd.Timedelta(1, "s")])  # left operand
+left: "pd.Series[pd.Timedelta]" = pd.Series([pd.Timedelta(1, "s")])  # left operand
 
 
 def test_add_py_scalar() -> None:

--- a/tests/series/timedelta/test_sub.py
+++ b/tests/series/timedelta/test_sub.py
@@ -19,7 +19,7 @@ from tests._typing import (
     np_ndarray_td,
 )
 
-left = pd.Series([pd.Timedelta(1, "s")])  # left operand
+left: "pd.Series[pd.Timedelta]" = pd.Series([pd.Timedelta(1, "s")])  # left operand
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/series/timestamp/test_add.py
+++ b/tests/series/timestamp/test_add.py
@@ -19,7 +19,7 @@ from tests._typing import (
     np_ndarray_td,
 )
 
-left = pd.Series([pd.Timestamp(2025, 8, 20)])  # left operand
+left: "pd.Series[pd.Timestamp]" = pd.Series([pd.Timestamp(2025, 8, 20)])  # left operand
 
 
 def test_add_py_scalar() -> None:

--- a/tests/series/timestamp/test_sub.py
+++ b/tests/series/timestamp/test_sub.py
@@ -16,7 +16,7 @@ from tests._typing import (
     np_ndarray_td,
 )
 
-left = pd.Series([pd.Timestamp(2025, 8, 20)])  # left operand
+left: "pd.Series[pd.Timestamp]" = pd.Series([pd.Timestamp(2025, 8, 20)])  # left operand
 
 
 def test_sub_py_scalar() -> None:

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -11,13 +11,13 @@ from pandas.api.typing.aliases import DtypeObj
 
 from tests import check
 
-nparr = np.array([1, 2, 3])
-arr = pd.Series([1, 2, 3])
+nparr: np.ndarray = np.array([1, 2, 3])
+arr: "pd.Series[int]" = pd.Series([1, 2, 3])
 obj = "True"
 mapping = {"a": "a"}
-dframe = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-dtylike = np.dtype(np.int32)
-ind = pd.Index([1, 2.0])
+dframe: pd.DataFrame = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+dtylike: "np.dtype[np.int32]" = np.dtype(np.int32)
+ind: "pd.Index[float]" = pd.Index([1, 2.0])
 
 
 def test_is_bool() -> None:

--- a/tests/test_groupby.py
+++ b/tests/test_groupby.py
@@ -16,6 +16,7 @@ from typing import (
 import numpy as np
 from pandas import (
     DataFrame,
+    DatetimeIndex,
     Index,
     Series,
     Timedelta,
@@ -35,6 +36,7 @@ from pandas.core.window import (
     RollingGroupby,
 )
 
+from pandas._typing import Scalar
 from pandas.errors import Pandas4Warning
 
 from tests import (
@@ -46,13 +48,13 @@ from tests import (
 if TYPE_CHECKING:
     from pandas.core.groupby.groupby import ResamplerGroupBy  # noqa: F401
 
-DR = date_range("1999-1-1", periods=365, freq="D")
-DF_ = DataFrame(np.random.standard_normal((365, 1)), index=DR)
-BY = Series(np.random.choice([1, 2], 365), index=DR)
+DR: DatetimeIndex = date_range("1999-1-1", periods=365, freq="D")
+DF_: DataFrame = DataFrame(np.random.standard_normal((365, 1)), index=DR)
+BY: Series[float] = Series(np.random.choice([1, 2], 365), index=DR)
 S = DF_.iloc[:, 0]
-DF = DataFrame({"col1": S, "col2": S, "col3": BY})
-GB_DF = DF.groupby("col3")
-GB_S = cast("SeriesGroupBy[float, int]", GB_DF.col1)
+DF: DataFrame = DataFrame({"col1": S, "col2": S, "col3": BY})
+GB_DF: DataFrameGroupBy[Scalar, Literal[True]] = DF.groupby("col3")
+GB_S: SeriesGroupBy[float, int] = cast("SeriesGroupBy[float, int]", GB_DF.col1)
 
 
 def test_frame_groupby_resample() -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -81,8 +81,8 @@ from pandas.io.sas.sas7bdat import SAS7BDATReader
 from pandas.io.sas.sas_xport import XportReader
 from pandas.io.stata import StataReader
 
-DF = DataFrame({"a": [1, 2, 3], "b": [0.0, 0.0, 0.0]})
-CWD = Path(__file__).parent.resolve()
+DF: DataFrame = DataFrame({"a": [1, 2, 3], "b": [0.0, 0.0, 0.0]})
+CWD: Path = Path(__file__).parent.resolve()
 
 
 def test_orc(tmp_path: Path) -> None:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -192,7 +192,7 @@ IRIS = """SepalLength,SepalWidth,PetalLength,PetalWidth,Name
 6.2,3.4,5.4,2.3,Iris-virginica
 5.9,3.0,5.1,1.8,Iris-virginica"""
 
-IRIS_DF = pd.read_csv(io.StringIO(IRIS))
+IRIS_DF: pd.DataFrame = pd.read_csv(io.StringIO(IRIS))
 
 
 def test_andrews_curves(close_figures: None) -> None:

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -16,7 +16,10 @@ from pandas.core.groupby.generic import (
     DataFrameGroupBy,
     SeriesGroupBy,
 )
-from pandas.core.indexes.datetimes import date_range
+from pandas.core.indexes.datetimes import (
+    DatetimeIndex,
+    date_range,
+)
 from pandas.core.resample import DatetimeIndexResampler
 from pandas.core.series import Series
 
@@ -25,10 +28,10 @@ from tests import (
     check,
 )
 
-DR = date_range("1999-1-1", periods=365, freq="D")
-DF_ = DataFrame(np.random.standard_normal((365, 1)), index=DR)
+DR: DatetimeIndex = date_range("1999-1-1", periods=365, freq="D")
+DF_: DataFrame = DataFrame(np.random.standard_normal((365, 1)), index=DR)
 S = DF_.iloc[:, 0]
-DF = DataFrame({"col1": S, "col2": S})
+DF: DataFrame = DataFrame({"col1": S, "col2": S})
 
 
 def test_iter() -> None:

--- a/tests/test_styler.py
+++ b/tests/test_styler.py
@@ -34,9 +34,9 @@ else:
     StyleExportDict = object
 
 
-DF = DataFrame({"a": [1, 2, 3], "b": [3.14, 2.72, 1.61]})
+DF: DataFrame = DataFrame({"a": [1, 2, 3], "b": [3.14, 2.72, 1.61]})
 
-PWD = Path(__file__).parent.resolve()
+PWD: Path = Path(__file__).parent.resolve()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -16,6 +16,7 @@ from pandas.core.indexers.objects import (
     FixedForwardWindowIndexer,
     VariableOffsetWindowIndexer,
 )
+from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.window import (
     ExponentialMovingWindow,
     Rolling,
@@ -35,11 +36,11 @@ from tests._typing import (
 
 from pandas.tseries.frequencies import to_offset
 
-IDX = date_range("1/1/2000", periods=700, freq="D")
-S = Series(np.random.standard_normal(700))
-DF = DataFrame({"col1": S, "col2": S})
-S_DTI = Series(data=np.random.standard_normal(700), index=IDX)
-DF_DTI = DataFrame(data=np.random.standard_normal(700), index=IDX)
+IDX: DatetimeIndex = date_range("1/1/2000", periods=700, freq="D")
+S: "Series[float]" = Series(np.random.standard_normal(700))
+DF: DataFrame = DataFrame({"col1": S, "col2": S})
+S_DTI: "Series[float]" = Series(data=np.random.standard_normal(700), index=IDX)
+DF_DTI: DataFrame = DataFrame(data=np.random.standard_normal(700), index=IDX)
 
 
 def test_rolling_basic() -> None:


### PR DESCRIPTION
- [x] Closes #1795
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Adding pyrefly coverage, needed a few tweaks for the data at the top of test files but this is now looking quite good.