### PR TITLE
bump: `ty` and `numpy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ Documentation = "https://pandas.pydata.org/pandas-docs/stable"
 dev = [
   "mypy>=2.2.0",
   "pandas==3.0.5",
-  "numpy>=2.5.1;python_version>='3.12'",
+  "numpy>=2.5.2;python_version>='3.12'",
   "pyarrow>=10.0.1",
   "pytest>=8.4.2",
   "pyright>=1.1.410",

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -566,12 +566,7 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    if sys.version_info >= (3, 12):
-        # numpy >= 2.5 has eliminated the type checking errors
-        check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)
-    else:
-        # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
-        check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type] # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
+    check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type] # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
     check(assert_type(as_timedelta_index + td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(as_period_index + td, pd.PeriodIndex), pd.PeriodIndex)
     check(assert_type(as_datetime_index + td, pd.DatetimeIndex), pd.DatetimeIndex)
@@ -613,12 +608,7 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    if sys.version_info >= (3, 12):
-        # numpy >= 2.5 has eliminated the type checking errors
-        check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)
-    else:
-        # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
-        check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type] # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
+    check(assert_type(as_timedelta64 - td, dt.datetime), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type] # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
     check(assert_type(as_timedelta_index - td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(as_period_index - td, pd.PeriodIndex), pd.PeriodIndex)
     check(assert_type(as_datetime_index - td, pd.DatetimeIndex), pd.DatetimeIndex)

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -566,6 +566,7 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
+    # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
     check(assert_type(as_timedelta64 + td, pd.Timedelta), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type] # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
     check(assert_type(as_timedelta_index + td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(as_period_index + td, pd.PeriodIndex), pd.PeriodIndex)
@@ -608,7 +609,8 @@ def test_timedelta_add_sub() -> None:
         ),
         pd.Timedelta,
     )
-    check(assert_type(as_timedelta64 - td, dt.datetime), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type] # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
+    # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
+    check(assert_type(as_timedelta64 - td, pd.Timedelta), pd.Timedelta)  # type: ignore[assert-type] # pyright: ignore[reportAssertTypeFailure] # pyrefly: ignore[assert-type] # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
     check(assert_type(as_timedelta_index - td, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(as_period_index - td, pd.PeriodIndex), pd.PeriodIndex)
     check(assert_type(as_datetime_index - td, pd.DatetimeIndex), pd.DatetimeIndex)


### PR DESCRIPTION
fix the CI pipeline https://github.com/pandas-dev/pandas-stubs/actions/runs/31352537680/

- [ ] Closes #xxxx (Replace xxxx with the Github issue number)
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
