### PR TITLE
BUG: #1896 `DataFrame.apply`

### DIFF
--- a/pandas-stubs/core/frame.pyi
+++ b/pandas-stubs/core/frame.pyi
@@ -1449,7 +1449,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Series],
+        func: Callable[..., ListLikeExceptSeriesAndStr | Series],
         axis: AxisIndex = ...,
         raw: _bool = ...,
         result_type: None = None,
@@ -1460,7 +1460,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     def apply(
         self,
         # Use S2 (TypeVar without `default=Any`) instead of S1 due to https://github.com/python/mypy/issues/19182.
-        f: Callable[..., S2 | NAType],
+        func: Callable[..., S2 | NAType],
         axis: AxisIndex = ...,
         raw: _bool = ...,
         result_type: None = None,
@@ -1472,7 +1472,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[..., Mapping[Any, Any]],
+        func: Callable[..., Mapping[Any, Any]],
         axis: AxisIndex = ...,
         raw: _bool = ...,
         result_type: None = None,
@@ -1485,7 +1485,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     def apply(
         self,
         # Use S2 (TypeVar without `default=Any`) instead of S1 due to https://github.com/python/mypy/issues/19182.
-        f: Callable[..., S2 | NAType],
+        func: Callable[..., S2 | NAType],
         axis: Axis = 0,
         raw: _bool = ...,
         args: Any = ...,
@@ -1496,7 +1496,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Series | Mapping[Any, Any]],
+        func: Callable[..., ListLikeExceptSeriesAndStr | Series | Mapping[Any, Any]],
         axis: Axis = 0,
         raw: _bool = ...,
         args: Any = ...,
@@ -1507,7 +1507,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Mapping[Any, Any]],
+        func: Callable[..., ListLikeExceptSeriesAndStr | Mapping[Any, Any]],
         axis: Axis = 0,
         raw: _bool = ...,
         args: Any = ...,
@@ -1518,7 +1518,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[
+        func: Callable[
             ..., ListLikeExceptSeriesAndStr | Series | Scalar | Mapping[Any, Any]
         ],
         axis: Axis = 0,
@@ -1533,7 +1533,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[..., Series],
+        func: Callable[..., Series],
         axis: AxisIndex = 0,
         raw: _bool = ...,
         args: Any = ...,
@@ -1547,7 +1547,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     def apply(
         self,
         # Use S2 (TypeVar without `default=Any`) instead of S1 due to https://github.com/python/mypy/issues/19182.
-        f: Callable[..., S2 | NAType],
+        func: Callable[..., S2 | NAType],
         raw: _bool = ...,
         result_type: None = None,
         args: Any = ...,
@@ -1558,7 +1558,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[..., ListLikeExceptSeriesAndStr | Mapping[Any, Any]],
+        func: Callable[..., ListLikeExceptSeriesAndStr | Mapping[Any, Any]],
         raw: _bool = ...,
         result_type: None = None,
         args: Any = ...,
@@ -1569,7 +1569,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[..., Series],
+        func: Callable[..., Series],
         raw: _bool = ...,
         result_type: None = None,
         args: Any = ...,
@@ -1582,7 +1582,7 @@ class DataFrame(NDFrame, OpsMixin, _GetItemHack):
     @overload
     def apply(
         self,
-        f: Callable[..., Series],
+        func: Callable[..., Series],
         raw: _bool = ...,
         args: Any = ...,
         *,

--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -1116,6 +1116,14 @@ def test_types_apply() -> None:
 
     check(assert_type(df.apply(gethead, args=(4,)), pd.DataFrame), pd.DataFrame)
 
+    # GH 1896: first parameter is named func at runtime
+    check(assert_type(df.apply(func=np.exp), pd.DataFrame), pd.DataFrame)
+    check(
+        assert_type(df.apply(func=returns_scalar), "pd.Series[int]"),
+        pd.Series,
+        np.integer,
+    )
+
     # Check various return types for default result_type (None) with default axis (0)
     check(
         assert_type(df.apply(returns_scalar), "pd.Series[int]"), pd.Series, np.integer


### PR DESCRIPTION
- [x] Closes #1896
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

`DataFrame.apply` overloads named the first parameter `f`, but pandas names it `func`. `df.apply(func=...)` is valid at runtime and was rejected by the stubs; `df.apply(f=...)` type-checked and then raised `TypeError`.

Rename the parameter to `func` on every overload. `DataFrameGroupBy.apply` / `Series.apply` already used `func`.