### PR TITLE
BUG: #1890 widen `read_sql`/`read_sql_query` `params`

### DIFF
--- a/pandas-stubs/io/sql.pyi
+++ b/pandas-stubs/io/sql.pyi
@@ -38,6 +38,10 @@ _SQLStatement: TypeAlias = (
     str | Selectable | TextClause | Select[Any] | FromStatement[Any] | UpdateBase
 )
 
+_SQLBindValue: TypeAlias = Scalar | Sequence[Scalar | None] | None
+
+_SQLParams: TypeAlias = Sequence[_SQLBindValue] | Mapping[str, _SQLBindValue]
+
 @overload
 def read_sql_table(
     table_name: str,
@@ -69,14 +73,7 @@ def read_sql_query(
     con: _SQLConnection,
     index_col: str | list[str] | None = None,
     coerce_float: bool = True,
-    params: (
-        list[Scalar]
-        | tuple[Scalar, ...]
-        | tuple[tuple[Scalar, ...], ...]
-        | Mapping[str, Scalar]
-        | Mapping[str, tuple[Scalar, ...]]
-        | None
-    ) = None,
+    params: _SQLParams | None = None,
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = None,
     *,
     chunksize: int,
@@ -89,14 +86,7 @@ def read_sql_query(
     con: _SQLConnection,
     index_col: str | list[str] | None = None,
     coerce_float: bool = True,
-    params: (
-        list[Scalar]
-        | tuple[Scalar, ...]
-        | tuple[tuple[Scalar, ...], ...]
-        | Mapping[str, Scalar]
-        | Mapping[str, tuple[Scalar, ...]]
-        | None
-    ) = None,
+    params: _SQLParams | None = None,
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = None,
     chunksize: None = None,
     dtype: DtypeArg | None = None,
@@ -108,13 +98,7 @@ def read_sql(
     con: _SQLConnection,
     index_col: str | list[str] | None = None,
     coerce_float: bool = True,
-    params: (
-        Sequence[Scalar]
-        | tuple[tuple[Scalar, ...], ...]
-        | Mapping[str, Scalar]
-        | Mapping[str, tuple[Scalar, ...]]
-        | None
-    ) = None,
+    params: _SQLParams | None = None,
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = None,
     columns: list[str] | None = None,
     *,
@@ -128,13 +112,7 @@ def read_sql(
     con: _SQLConnection,
     index_col: str | list[str] | None = None,
     coerce_float: bool = True,
-    params: (
-        Sequence[Scalar]
-        | tuple[tuple[Scalar, ...], ...]
-        | Mapping[str, Scalar]
-        | Mapping[str, tuple[Scalar, ...]]
-        | None
-    ) = None,
+    params: _SQLParams | None = None,
     parse_dates: list[str] | dict[str, str] | dict[str, dict[str, Any]] | None = None,
     columns: list[str] | None = None,
     chunksize: None = None,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1617,32 +1617,125 @@ def test_read_sql_query_via_sqlalchemy_engine_with_params(tmp_path: Path) -> Non
     engine.dispose()
 
 
-@pytest.mark.skip(
-    reason="Only works in Postgres (and MySQL, but with different query syntax)"
-)
-def test_read_sql_query_via_sqlalchemy_engine_with_tuple_valued_params() -> None:
-    db_uri = "postgresql+psycopg2://postgres@localhost:5432/postgres"
+def test_read_sql_query_via_sqlalchemy_engine_with_tuple_valued_params(
+    tmp_path: Path,
+) -> None:
+    path_str = str(tmp_path / str(uuid.uuid4()))
+    db_uri = "sqlite:///" + path_str
     engine = sqlalchemy.create_engine(db_uri)
 
-    check(
-        assert_type(
-            read_sql_query(
-                "select * from test where a in %(a)s", con=engine, params={"a": (1, 2)}
+    check(assert_type(DF.to_sql("test", con=engine), int | None), int)
+    statement = sqlalchemy.text("select * from test where a in :a").bindparams(
+        sqlalchemy.bindparam("a", expanding=True)
+    )
+    with engine.connect() as conn:
+        check(
+            assert_type(
+                read_sql_query(statement, con=conn, params={"a": (1, 2)}), DataFrame
             ),
             DataFrame,
-        ),
-        DataFrame,
-    )
-    check(
+        )
+    if TYPE_CHECKING:
+        # %s paramstyle needs psycopg2 or MySQLdb, so this is checked but not run
         assert_type(
             read_sql_query(
                 "select * from test where a in %s", con=engine, params=((1, 2),)
             ),
             DataFrame,
+        )
+    engine.dispose()
+
+
+def test_read_sql_query_with_mixed_params(tmp_path: Path) -> None:
+    # GH 1890
+    path_str = str(tmp_path / str(uuid.uuid4()))
+    db_uri = "sqlite:///" + path_str
+    engine = sqlalchemy.create_engine(db_uri)
+
+    check(assert_type(DF.to_sql("test", con=engine), int | None), int)
+    statement = sqlalchemy.text(
+        "select * from test where b = :b and a in :a"
+    ).bindparams(sqlalchemy.bindparam("a", expanding=True))
+    with engine.connect() as conn:
+        check(
+            assert_type(
+                read_sql_query(statement, con=conn, params={"b": 0.0, "a": (1, 2)}),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+    if TYPE_CHECKING:
+        # %s paramstyle needs psycopg2 or MySQLdb, so this is checked but not run
+        assert_type(
+            read_sql_query(
+                "select * from test where b = %s and a in %s",
+                con=engine,
+                params=[0.0, (1, 2)],
+            ),
+            DataFrame,
+        )
+    engine.dispose()
+
+
+def test_read_sql_with_mixed_params(tmp_path: Path) -> None:
+    # GH 1890
+    path_str = str(tmp_path / str(uuid.uuid4()))
+    db_uri = "sqlite:///" + path_str
+    engine = sqlalchemy.create_engine(db_uri)
+
+    check(assert_type(DF.to_sql("test", con=engine), int | None), int)
+    statement = sqlalchemy.text(
+        "select * from test where b = :b and a in :a"
+    ).bindparams(sqlalchemy.bindparam("a", expanding=True))
+    with engine.connect() as conn:
+        check(
+            assert_type(
+                read_sql(statement, con=conn, params={"b": 0.0, "a": (1, 2)}),
+                DataFrame,
+            ),
+            DataFrame,
+        )
+    engine.dispose()
+
+
+def test_read_sql_query_with_list_params(tmp_path: Path) -> None:
+    # GH 1890
+    path_str = str(tmp_path / str(uuid.uuid4()))
+    con = sqlite3.connect(path_str)
+    frame = DataFrame({"a": ["x", "y"], "b": [1, 2]})
+    check(assert_type(frame.to_sql("test", con=con), int | None), int)
+    names: list[str] = ["x"]
+    check(
+        assert_type(
+            read_sql_query("select * from test where a = ?", con=con, params=names),
+            DataFrame,
         ),
         DataFrame,
     )
-    engine.dispose()
+    check(
+        assert_type(
+            read_sql_query("select * from test where a is ?", con=con, params=[None]),
+            DataFrame,
+        ),
+        DataFrame,
+    )
+    con.close()
+
+
+def test_read_sql_params_invalid_usage(tmp_path: Path) -> None:
+    # GH 1890
+    path_str = str(tmp_path / str(uuid.uuid4()))
+    con = sqlite3.connect(path_str)
+    check(assert_type(DF.to_sql("test", con=con), int | None), int)
+    if TYPE_CHECKING_INVALID_USAGE:
+        values = {1, 2}
+        set_valued = {"a": {1, 2}}
+        nested = {"a": [[1, 2]]}
+        read_sql_query("select * from test where a in ?", con=con, params=values)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
+        read_sql_query("select * from test where a in :a", con=con, params=set_valued)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
+        read_sql_query("select * from test where a in :a", con=con, params=nested)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
+        read_sql_query("select * from test where a = ?", con=con, params=[{1, 2}])  # type: ignore[list-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
+    con.close()
 
 
 def test_read_html(tmp_path: Path) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1704,7 +1704,7 @@ def test_read_sql_query_with_list_params(tmp_path: Path) -> None:
     con = sqlite3.connect(path_str)
     frame = DataFrame({"a": ["x", "y"], "b": [1, 2]})
     check(assert_type(frame.to_sql("test", con=con), int | None), int)
-    names: list[str] = ["x"]
+    names = ["x"]
     check(
         assert_type(
             read_sql_query("select * from test where a = ?", con=con, params=names),


### PR DESCRIPTION
- [x] Closes #1890
- [x] Tests added
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

This fixes `params` in `read_sql` and `read_sql_query` being able to take a mixed type mapping.

This introduces one regression in `read_sql_query` that already exists on main for `read_sql`, `params` will now accept a `str` (and `bytes` / `bytearray` / `memoryview`), which is incorrect as it mismatches documentation and functionality. I tried to fix this for both  `read_sql_query` and `read_sql` but I found both short comings in `SequenceNotStr` and using a protocol (same issue as #1609) in mypy, happy to take guidance on this.