### PR TITLE
TYP: complete CustomBusinessDay annotations

### DIFF
--- a/pandas-stubs/_libs/tslibs/offsets.pyi
+++ b/pandas-stubs/_libs/tslibs/offsets.pyi
@@ -239,9 +239,17 @@ class CustomBusinessDay(BusinessDay):
         self,
         n: int = ...,
         normalize: bool = ...,
-        holidays: list[Any] = ...,
-        calendar: AbstractHolidayCalendar | np.busdaycalendar = ...,
+        weekmask: str = ...,
+        holidays: list[Any] | None = ...,
+        calendar: AbstractHolidayCalendar | np.busdaycalendar | None = ...,
+        offset: timedelta = ...,
     ) -> None: ...
+    @property
+    def weekmask(self) -> str: ...
+    @property
+    def holidays(self) -> tuple[np.datetime64, ...]: ...
+    @property
+    def calendar(self) -> np.busdaycalendar: ...
 
 class CustomBusinessHour(BusinessHour):
     def __init__(

--- a/tests/test_holidays.py
+++ b/tests/test_holidays.py
@@ -189,6 +189,36 @@ def test_custom_business_month() -> None:
     )
 
 
+def test_custom_business_day() -> None:
+    custom_business_day = pd.offsets.CustomBusinessDay(
+        weekmask="Mon Tue Wed Thu Fri",
+        holidays=["2026-01-01"],
+        offset=timedelta(hours=1),
+    )
+
+    check(
+        assert_type(custom_business_day, pd.offsets.CustomBusinessDay),
+        pd.offsets.CustomBusinessDay,
+    )
+    check(assert_type(custom_business_day.weekmask, str), str)
+    check(
+        assert_type(custom_business_day.holidays, tuple[np.datetime64, ...]),
+        tuple,
+        np.datetime64,
+    )
+    check(
+        assert_type(custom_business_day.calendar, np.busdaycalendar),
+        np.busdaycalendar,
+    )
+    check(
+        assert_type(
+            pd.offsets.CustomBusinessDay(holidays=None, calendar=None),
+            pd.offsets.CustomBusinessDay,
+        ),
+        pd.offsets.CustomBusinessDay,
+    )
+
+
 def test_rollforward_rollback_return_type() -> None:
 
     bmb = pd.offsets.CustomBusinessMonthBegin()


### PR DESCRIPTION
The `CustomBusinessDay` stub omits the documented `weekmask` and `offset` constructor parameters. It also does not expose the public `weekmask`, `holidays`, and `calendar` attributes.

This PR:

- adds the missing constructor parameters;
- permits the documented `None` values for `holidays` and `calendar`;
- adds read-only types for the three public attributes;
- adds static and runtime tests for the annotations.

The constructor parameters are defined in the [`CustomBusinessDay` API documentation](https://pandas.pydata.org/docs/reference/api/pandas.tseries.offsets.CustomBusinessDay.html). Pandas also documents each attribute separately:

- [`CustomBusinessDay.weekmask`](https://pandas.pydata.org/docs/reference/api/pandas.tseries.offsets.CustomBusinessDay.weekmask.html)
- [`CustomBusinessDay.holidays`](https://pandas.pydata.org/docs/reference/api/pandas.tseries.offsets.CustomBusinessDay.holidays.html)
- [`CustomBusinessDay.calendar`](https://pandas.pydata.org/docs/reference/api/pandas.tseries.offsets.CustomBusinessDay.calendar.html)

The tests verify the pandas 3.0.5 runtime types: `str`, `tuple[np.datetime64, ...]`, and `np.busdaycalendar`.

## Tests

- `poetry run poe test_all`

- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
