### PR TITLE
BUG: #1905 allow pyarrow read_parquet without to_pandas_kwargs

### DIFF
--- a/pandas-stubs/io/parquet.pyi
+++ b/pandas-stubs/io/parquet.pyi
@@ -39,6 +39,6 @@ def read_parquet(
     filesystem: Any = None,
     filters: Sequence[_Filter] | Sequence[Sequence[_Filter]] | None = None,
     *,
-    to_pandas_kwargs: dict[str, Any],
+    to_pandas_kwargs: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> DataFrame: ...

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -614,6 +614,7 @@ def test_parquet(tmp_path: Path) -> None:
     check(assert_type(DF.to_parquet(path_str), None), type(None))
     check(assert_type(DF.to_parquet(), bytes), bytes)
     check(assert_type(read_parquet(path_str), DataFrame), DataFrame)
+    check(assert_type(read_parquet(path_str, "pyarrow"), DataFrame), DataFrame)
     check(
         assert_type(
             read_parquet(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -614,13 +614,25 @@ def test_parquet(tmp_path: Path) -> None:
     check(assert_type(DF.to_parquet(path_str), None), type(None))
     check(assert_type(DF.to_parquet(), bytes), bytes)
     check(assert_type(read_parquet(path_str), DataFrame), DataFrame)
+    check(
+        assert_type(
+            read_parquet(
+                path_str,
+                engine="pyarrow",
+                columns=["a"],
+                filesystem=None,
+            ),
+            DataFrame,
+        ),
+        DataFrame,
+    )
 
 
 def test_parquet_to_pandas() -> None:
     """Test passing `to_pandas_kwargs` in read_parquet."""
 
     if TYPE_CHECKING_INVALID_USAGE:
-        read_parquet(Path(), to_pandas_kwargs={"categories": ["a", "b"]})  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        read_parquet(Path(), to_pandas_kwargs={"categories": ["a", "b"]})  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
 
 
 def test_parquet_options(tmp_path: Path) -> None:


### PR DESCRIPTION
- [x] Closes #1905
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

## Summary

- make `to_pandas_kwargs` optional for the `pyarrow` `read_parquet` overload, matching the pandas runtime default
- add a regression test for calling `read_parquet` with `engine=pyarrow`, `columns`, and `filesystem` without `to_pandas_kwargs`
- keep the non-pyarrow overload restriction covered by the existing invalid-usage test

## Tests

- `poetry run poe test_all`