### PR TITLE
GH1908 Add overloads to pd.array for pyarrow types

### DIFF
--- a/pandas-stubs/core/construction.pyi
+++ b/pandas-stubs/core/construction.pyi
@@ -61,11 +61,8 @@ from pandas._typing import (
     PandasStrDtypeArg,
     PandasTimestampDtypeArg,
     PandasUIntDtypeArg,
-    PyArrowBooleanDtypeArg,
-    PyArrowFloatDtypeArg,
-    PyArrowIntDtypeArg,
+    PyArrowNotStrDtypeArg,
     PyArrowStrDtypeArg,
-    PyArrowUIntDtypeArg,
     TimedeltaDtypeArg,
     np_1darray_td,
     np_ndarray,
@@ -195,22 +192,10 @@ def array(
 ) -> BooleanArray: ...
 @overload
 def array(
-    data: Sequence[bool | np.bool | Just[float] | NAType | None],
-    dtype: PyArrowBooleanDtypeArg,
-    copy: bool = True,
-) -> ArrowExtensionArray: ...
-@overload
-def array(
     data: Sequence[float | np.integer | NAType | None],
     dtype: PandasIntDtypeArg | PandasUIntDtypeArg,
     copy: bool = True,
 ) -> IntegerArray: ...
-@overload
-def array(
-    data: Sequence[float | np.integer | NAType | None],
-    dtype: PyArrowIntDtypeArg | PyArrowUIntDtypeArg,
-    copy: bool = True,
-) -> ArrowExtensionArray: ...
 @overload
 def array(  # type: ignore[overload-overlap]
     data: Sequence[int | np.integer | NAType | None],
@@ -231,12 +216,6 @@ def array(  # type: ignore[overload-overlap]
     dtype: PandasFloatDtypeArg | None = None,
     copy: bool = True,
 ) -> FloatingArray: ...
-@overload
-def array(
-    data: Sequence[float | np.floating | NAType | None] | np_ndarray_float,
-    dtype: PyArrowFloatDtypeArg,
-    copy: bool = True,
-) -> ArrowExtensionArray: ...
 @overload
 def array(
     data: Sequence[_NaTDatetimeElement] | np_ndarray | DatetimeArray,
@@ -306,6 +285,12 @@ def array(
     dtype: None = None,
     copy: bool = True,
 ) -> BaseStringArray: ...
+@overload
+def array(
+    data: Sequence[Any],
+    dtype: PyArrowNotStrDtypeArg | PyArrowStrDtypeArg,
+    copy: bool = True,
+) -> ArrowExtensionArray: ...
 @overload
 def array(
     data: Sequence[Any], dtype: BuiltinObjectDtypeArg | None = None, copy: bool = True

--- a/pandas-stubs/core/construction.pyi
+++ b/pandas-stubs/core/construction.pyi
@@ -11,6 +11,7 @@ from typing import (
 )
 
 import numpy as np
+from pandas.core.arrays.arrow import ArrowExtensionArray
 from pandas.core.arrays.base import ExtensionArray
 from pandas.core.arrays.boolean import BooleanArray
 from pandas.core.arrays.categorical import Categorical
@@ -60,7 +61,11 @@ from pandas._typing import (
     PandasStrDtypeArg,
     PandasTimestampDtypeArg,
     PandasUIntDtypeArg,
+    PyArrowBooleanDtypeArg,
+    PyArrowFloatDtypeArg,
+    PyArrowIntDtypeArg,
     PyArrowStrDtypeArg,
+    PyArrowUIntDtypeArg,
     TimedeltaDtypeArg,
     np_1darray_td,
     np_ndarray,
@@ -190,10 +195,22 @@ def array(
 ) -> BooleanArray: ...
 @overload
 def array(
+    data: Sequence[bool | np.bool | Just[float] | NAType | None],
+    dtype: PyArrowBooleanDtypeArg,
+    copy: bool = True,
+) -> ArrowExtensionArray: ...
+@overload
+def array(
     data: Sequence[float | np.integer | NAType | None],
     dtype: PandasIntDtypeArg | PandasUIntDtypeArg,
     copy: bool = True,
 ) -> IntegerArray: ...
+@overload
+def array(
+    data: Sequence[float | np.integer | NAType | None],
+    dtype: PyArrowIntDtypeArg | PyArrowUIntDtypeArg,
+    copy: bool = True,
+) -> ArrowExtensionArray: ...
 @overload
 def array(  # type: ignore[overload-overlap]
     data: Sequence[int | np.integer | NAType | None],
@@ -214,6 +231,12 @@ def array(  # type: ignore[overload-overlap]
     dtype: PandasFloatDtypeArg | None = None,
     copy: bool = True,
 ) -> FloatingArray: ...
+@overload
+def array(
+    data: Sequence[float | np.floating | NAType | None] | np_ndarray_float,
+    dtype: PyArrowFloatDtypeArg,
+    copy: bool = True,
+) -> ArrowExtensionArray: ...
 @overload
 def array(
     data: Sequence[_NaTDatetimeElement] | np_ndarray | DatetimeArray,

--- a/tests/arrays/test_arrow.py
+++ b/tests/arrays/test_arrow.py
@@ -115,7 +115,9 @@ def test_pd_array_uint(dtype: PyArrowUIntDtypeArg, target_dtype: type) -> None:
     )
 
 
-@pytest.mark.parametrize(("dtype", "target_dtype"), PYARROW_FLOAT_ARGS.items(), ids=repr)
+@pytest.mark.parametrize(
+    ("dtype", "target_dtype"), PYARROW_FLOAT_ARGS.items(), ids=repr
+)
 def test_pd_array_float(dtype: PyArrowFloatDtypeArg, target_dtype: type) -> None:
     check(
         assert_type(pd.array([1.0, 2.0, 3.0], dtype), ArrowExtensionArray),

--- a/tests/arrays/test_arrow.py
+++ b/tests/arrays/test_arrow.py
@@ -11,8 +11,10 @@ from typing import (
 )
 
 import pandas as pd
-from pandas.arrays import ArrowExtensionArray
-from pandas.arrays import ArrowStringArray
+from pandas.arrays import (
+    ArrowExtensionArray,
+    ArrowStringArray,
+)
 import pyarrow as pa
 import pytest
 
@@ -77,7 +79,7 @@ def test_constructor(data: Sequence[Any]) -> None:
         )
 
 
-def test_pd_array_bool_bool_pyarrow() -> None:
+def test_constructor_bool_bool_pyarrow() -> None:
     check(
         assert_type(pd.array([True, False], "bool[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -85,7 +87,7 @@ def test_pd_array_bool_bool_pyarrow() -> None:
     )
 
 
-def test_pd_array_bool_boolean_pyarrow() -> None:
+def test_constructor_bool_boolean_pyarrow() -> None:
     check(
         assert_type(pd.array([True, False], "boolean[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -93,7 +95,7 @@ def test_pd_array_bool_boolean_pyarrow() -> None:
     )
 
 
-def test_pd_array_int_int8_pyarrow() -> None:
+def test_constructor_int_int8_pyarrow() -> None:
     check(
         assert_type(pd.array([1, 2, 3], "int8[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -101,7 +103,7 @@ def test_pd_array_int_int8_pyarrow() -> None:
     )
 
 
-def test_pd_array_int_int16_pyarrow() -> None:
+def test_constructor_int_int16_pyarrow() -> None:
     check(
         assert_type(pd.array([1, 2, 3], "int16[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -109,7 +111,7 @@ def test_pd_array_int_int16_pyarrow() -> None:
     )
 
 
-def test_pd_array_int_int32_pyarrow() -> None:
+def test_constructor_int_int32_pyarrow() -> None:
     check(
         assert_type(pd.array([1, 2, 3], "int32[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -117,7 +119,7 @@ def test_pd_array_int_int32_pyarrow() -> None:
     )
 
 
-def test_pd_array_int_int64_pyarrow() -> None:
+def test_constructor_int_int64_pyarrow() -> None:
     check(
         assert_type(pd.array([1, 2, 3], "int64[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -125,7 +127,7 @@ def test_pd_array_int_int64_pyarrow() -> None:
     )
 
 
-def test_pd_array_uint_uint8_pyarrow() -> None:
+def test_constructor_uint_uint8_pyarrow() -> None:
     check(
         assert_type(pd.array([1, 2, 3], "uint8[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -133,7 +135,7 @@ def test_pd_array_uint_uint8_pyarrow() -> None:
     )
 
 
-def test_pd_array_uint_uint16_pyarrow() -> None:
+def test_constructor_uint_uint16_pyarrow() -> None:
     check(
         assert_type(pd.array([1, 2, 3], "uint16[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -141,7 +143,7 @@ def test_pd_array_uint_uint16_pyarrow() -> None:
     )
 
 
-def test_pd_array_uint_uint32_pyarrow() -> None:
+def test_constructor_uint_uint32_pyarrow() -> None:
     check(
         assert_type(pd.array([1, 2, 3], "uint32[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -149,7 +151,7 @@ def test_pd_array_uint_uint32_pyarrow() -> None:
     )
 
 
-def test_pd_array_uint_uint64_pyarrow() -> None:
+def test_constructor_uint_uint64_pyarrow() -> None:
     check(
         assert_type(pd.array([1, 2, 3], "uint64[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -157,7 +159,7 @@ def test_pd_array_uint_uint64_pyarrow() -> None:
     )
 
 
-def test_pd_array_float_float16_pyarrow() -> None:
+def test_constructor_float_float16_pyarrow() -> None:
     check(
         assert_type(pd.array([1.0, 2.0, 3.0], "float16[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -165,7 +167,7 @@ def test_pd_array_float_float16_pyarrow() -> None:
     )
 
 
-def test_pd_array_float_float32_pyarrow() -> None:
+def test_constructor_float_float32_pyarrow() -> None:
     check(
         assert_type(pd.array([1.0, 2.0, 3.0], "float32[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -173,7 +175,7 @@ def test_pd_array_float_float32_pyarrow() -> None:
     )
 
 
-def test_pd_array_float_float_pyarrow() -> None:
+def test_constructor_float_float_pyarrow() -> None:
     check(
         assert_type(pd.array([1.0, 2.0, 3.0], "float[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -181,7 +183,7 @@ def test_pd_array_float_float_pyarrow() -> None:
     )
 
 
-def test_pd_array_float_float64_pyarrow() -> None:
+def test_constructor_float_float64_pyarrow() -> None:
     check(
         assert_type(pd.array([1.0, 2.0, 3.0], "float64[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -189,7 +191,7 @@ def test_pd_array_float_float64_pyarrow() -> None:
     )
 
 
-def test_pd_array_float_double_pyarrow() -> None:
+def test_constructor_float_double_pyarrow() -> None:
     check(
         assert_type(pd.array([1.0, 2.0, 3.0], "double[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -197,7 +199,7 @@ def test_pd_array_float_double_pyarrow() -> None:
     )
 
 
-def test_pd_array_mixed_int_bool_data_float_pyarrow() -> None:
+def test_constructor_mixed_int_bool_data_float_pyarrow() -> None:
     # data is a mix of int and bool elements, coerced by pyarrow to float64
     check(
         assert_type(pd.array([1, True], "float64[pyarrow]"), ArrowExtensionArray),
@@ -206,7 +208,7 @@ def test_pd_array_mixed_int_bool_data_float_pyarrow() -> None:
     )
 
 
-def test_pd_array_str_data_float_pyarrow() -> None:
+def test_constructor_str_data_float_pyarrow() -> None:
     # pyarrow parses the numeric strings into a float64 array
     check(
         assert_type(pd.array(["1", "1"], "float64[pyarrow]"), ArrowExtensionArray),
@@ -215,7 +217,7 @@ def test_pd_array_str_data_float_pyarrow() -> None:
     )
 
 
-def test_pd_array_float_data_string_pyarrow() -> None:
+def test_constructor_float_data_string_pyarrow() -> None:
     # dtype-specific string overload takes precedence, giving ArrowStringArray
     check(
         assert_type(pd.array([0.1, 0.2], "string[pyarrow]"), ArrowStringArray),
@@ -224,7 +226,7 @@ def test_pd_array_float_data_string_pyarrow() -> None:
     )
 
 
-def test_pd_array_float_data_duration_pyarrow() -> None:
+def test_constructor_float_data_duration_pyarrow() -> None:
     check(
         assert_type(pd.array([0.1, 0.2], "duration[s][pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
@@ -232,7 +234,7 @@ def test_pd_array_float_data_duration_pyarrow() -> None:
     )
 
 
-def test_pd_array_mixed_int_str_data_float_pyarrow_runtime_failure() -> None:
+def test_constructor_mixed_int_str_data_float_pyarrow_runtime_failure() -> None:
     # type checkers cannot statically detect this is invalid since pyarrow's
     # casting behavior depends on runtime values, not just element types;
     # it still raises at runtime because pyarrow cannot cast "1" once it has

--- a/tests/arrays/test_arrow.py
+++ b/tests/arrays/test_arrow.py
@@ -11,8 +11,8 @@ from typing import (
 )
 
 import pandas as pd
-from pandas.core.arrays.arrow.array import ArrowExtensionArray
-from pandas.core.arrays.string_arrow import ArrowStringArray
+from pandas.arrays import ArrowExtensionArray
+from pandas.arrays import ArrowStringArray
 import pyarrow as pa
 import pytest
 

--- a/tests/arrays/test_arrow.py
+++ b/tests/arrays/test_arrow.py
@@ -12,22 +12,11 @@ from typing import (
 
 import pandas as pd
 from pandas.core.arrays.arrow.array import ArrowExtensionArray
+from pandas.core.arrays.string_arrow import ArrowStringArray
 import pyarrow as pa
 import pytest
 
 from tests import check
-from tests._typing import (
-    PyArrowBooleanDtypeArg,
-    PyArrowFloatDtypeArg,
-    PyArrowIntDtypeArg,
-    PyArrowUIntDtypeArg,
-)
-from tests.dtypes import (
-    PYARROW_BOOL_ARGS,
-    PYARROW_FLOAT_ARGS,
-    PYARROW_INT_ARGS,
-    PYARROW_UINT_ARGS,
-)
 
 
 @pytest.mark.parametrize(
@@ -88,39 +77,165 @@ def test_constructor(data: Sequence[Any]) -> None:
         )
 
 
-@pytest.mark.parametrize(("dtype", "target_dtype"), PYARROW_BOOL_ARGS.items(), ids=repr)
-def test_pd_array_boolean(dtype: PyArrowBooleanDtypeArg, target_dtype: type) -> None:
+def test_pd_array_bool_bool_pyarrow() -> None:
     check(
-        assert_type(pd.array([True, False], dtype), ArrowExtensionArray),
+        assert_type(pd.array([True, False], "bool[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
-        target_dtype,
+        bool,
     )
 
 
-@pytest.mark.parametrize(("dtype", "target_dtype"), PYARROW_INT_ARGS.items(), ids=repr)
-def test_pd_array_int(dtype: PyArrowIntDtypeArg, target_dtype: type) -> None:
+def test_pd_array_bool_boolean_pyarrow() -> None:
     check(
-        assert_type(pd.array([1, 2, 3], dtype), ArrowExtensionArray),
+        assert_type(pd.array([True, False], "boolean[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
-        target_dtype,
+        bool,
     )
 
 
-@pytest.mark.parametrize(("dtype", "target_dtype"), PYARROW_UINT_ARGS.items(), ids=repr)
-def test_pd_array_uint(dtype: PyArrowUIntDtypeArg, target_dtype: type) -> None:
+def test_pd_array_int_int8_pyarrow() -> None:
     check(
-        assert_type(pd.array([1, 2, 3], dtype), ArrowExtensionArray),
+        assert_type(pd.array([1, 2, 3], "int8[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
-        target_dtype,
+        int,
     )
 
 
-@pytest.mark.parametrize(
-    ("dtype", "target_dtype"), PYARROW_FLOAT_ARGS.items(), ids=repr
-)
-def test_pd_array_float(dtype: PyArrowFloatDtypeArg, target_dtype: type) -> None:
+def test_pd_array_int_int16_pyarrow() -> None:
     check(
-        assert_type(pd.array([1.0, 2.0, 3.0], dtype), ArrowExtensionArray),
+        assert_type(pd.array([1, 2, 3], "int16[pyarrow]"), ArrowExtensionArray),
         ArrowExtensionArray,
-        target_dtype,
+        int,
     )
+
+
+def test_pd_array_int_int32_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1, 2, 3], "int32[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        int,
+    )
+
+
+def test_pd_array_int_int64_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1, 2, 3], "int64[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        int,
+    )
+
+
+def test_pd_array_uint_uint8_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1, 2, 3], "uint8[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        int,
+    )
+
+
+def test_pd_array_uint_uint16_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1, 2, 3], "uint16[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        int,
+    )
+
+
+def test_pd_array_uint_uint32_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1, 2, 3], "uint32[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        int,
+    )
+
+
+def test_pd_array_uint_uint64_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1, 2, 3], "uint64[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        int,
+    )
+
+
+def test_pd_array_float_float16_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1.0, 2.0, 3.0], "float16[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        float,
+    )
+
+
+def test_pd_array_float_float32_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1.0, 2.0, 3.0], "float32[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        float,
+    )
+
+
+def test_pd_array_float_float_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1.0, 2.0, 3.0], "float[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        float,
+    )
+
+
+def test_pd_array_float_float64_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1.0, 2.0, 3.0], "float64[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        float,
+    )
+
+
+def test_pd_array_float_double_pyarrow() -> None:
+    check(
+        assert_type(pd.array([1.0, 2.0, 3.0], "double[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        float,
+    )
+
+
+def test_pd_array_mixed_int_bool_data_float_pyarrow() -> None:
+    # data is a mix of int and bool elements, coerced by pyarrow to float64
+    check(
+        assert_type(pd.array([1, True], "float64[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        float,
+    )
+
+
+def test_pd_array_str_data_float_pyarrow() -> None:
+    # pyarrow parses the numeric strings into a float64 array
+    check(
+        assert_type(pd.array(["1", "1"], "float64[pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        float,
+    )
+
+
+def test_pd_array_float_data_string_pyarrow() -> None:
+    # dtype-specific string overload takes precedence, giving ArrowStringArray
+    check(
+        assert_type(pd.array([0.1, 0.2], "string[pyarrow]"), ArrowStringArray),
+        ArrowStringArray,
+        str,
+    )
+
+
+def test_pd_array_float_data_duration_pyarrow() -> None:
+    check(
+        assert_type(pd.array([0.1, 0.2], "duration[s][pyarrow]"), ArrowExtensionArray),
+        ArrowExtensionArray,
+        pd.Timedelta,
+    )
+
+
+def test_pd_array_mixed_int_str_data_float_pyarrow_runtime_failure() -> None:
+    # type checkers cannot statically detect this is invalid since pyarrow's
+    # casting behavior depends on runtime values, not just element types;
+    # it still raises at runtime because pyarrow cannot cast "1" once it has
+    # inferred an int64 array from the first element.
+    with pytest.raises(pa.ArrowInvalid):
+        pd.array([1, "1"], "float64[pyarrow]")

--- a/tests/arrays/test_arrow.py
+++ b/tests/arrays/test_arrow.py
@@ -10,11 +10,24 @@ from typing import (
     assert_type,
 )
 
+import pandas as pd
 from pandas.core.arrays.arrow.array import ArrowExtensionArray
 import pyarrow as pa
 import pytest
 
 from tests import check
+from tests._typing import (
+    PyArrowBooleanDtypeArg,
+    PyArrowFloatDtypeArg,
+    PyArrowIntDtypeArg,
+    PyArrowUIntDtypeArg,
+)
+from tests.dtypes import (
+    PYARROW_BOOL_ARGS,
+    PYARROW_FLOAT_ARGS,
+    PYARROW_INT_ARGS,
+    PYARROW_UINT_ARGS,
+)
 
 
 @pytest.mark.parametrize(
@@ -73,3 +86,39 @@ def test_constructor(data: Sequence[Any]) -> None:
             ArrowExtensionArray(pa.chunked_array([[timedelta(seconds=1)]])),
             ArrowExtensionArray,
         )
+
+
+@pytest.mark.parametrize(("dtype", "target_dtype"), PYARROW_BOOL_ARGS.items(), ids=repr)
+def test_pd_array_boolean(dtype: PyArrowBooleanDtypeArg, target_dtype: type) -> None:
+    check(
+        assert_type(pd.array([True, False], dtype), ArrowExtensionArray),
+        ArrowExtensionArray,
+        target_dtype,
+    )
+
+
+@pytest.mark.parametrize(("dtype", "target_dtype"), PYARROW_INT_ARGS.items(), ids=repr)
+def test_pd_array_int(dtype: PyArrowIntDtypeArg, target_dtype: type) -> None:
+    check(
+        assert_type(pd.array([1, 2, 3], dtype), ArrowExtensionArray),
+        ArrowExtensionArray,
+        target_dtype,
+    )
+
+
+@pytest.mark.parametrize(("dtype", "target_dtype"), PYARROW_UINT_ARGS.items(), ids=repr)
+def test_pd_array_uint(dtype: PyArrowUIntDtypeArg, target_dtype: type) -> None:
+    check(
+        assert_type(pd.array([1, 2, 3], dtype), ArrowExtensionArray),
+        ArrowExtensionArray,
+        target_dtype,
+    )
+
+
+@pytest.mark.parametrize(("dtype", "target_dtype"), PYARROW_FLOAT_ARGS.items(), ids=repr)
+def test_pd_array_float(dtype: PyArrowFloatDtypeArg, target_dtype: type) -> None:
+    check(
+        assert_type(pd.array([1.0, 2.0, 3.0], dtype), ArrowExtensionArray),
+        ArrowExtensionArray,
+        target_dtype,
+    )


### PR DESCRIPTION
- [x] Closes #1908
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
