### PR TITLE
TYP: #1799 enable `ty` in Index and Series tests

### DIFF
--- a/pandas-stubs/core/series.pyi
+++ b/pandas-stubs/core/series.pyi
@@ -391,6 +391,26 @@ class Series(IndexOpsMixin[S1], ElementOpsMixin[S1], NDFrame):
     __hash__: ClassVar[None]  # pyright: ignore[reportIncompatibleMethodOverride]
 
     @overload
+    def __new__(  # type: ignore[overload-overlap] # pyright: ignore[reportOverlappingOverload]
+        cls,
+        data: _str,
+        index: AxesData | None = None,
+        *,
+        dtype: CategoryDtypeArg,
+        name: Hashable = None,
+        copy: bool | None = None,
+    ) -> Series[CategoricalDtype[_str]]: ...
+    # ty intentionally treats "" as an empty sequence: astral-sh/ty#4365
+    @overload
+    def __new__(
+        cls,
+        data: _str,
+        index: AxesData | None = None,
+        dtype: StrDtypeArg | None = None,
+        name: Hashable = None,
+        copy: bool | None = None,
+    ) -> Series[_str]: ...
+    @overload
     def __new__(
         cls,
         data: Sequence[Never],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -440,6 +440,9 @@ exclude = [
   "tests/arrays/test_integer.py",
   "tests/arrays/test_string_.py",
   "tests/arrays/test_string_arrow.py",
-  "tests/indexes/**/*",
-  "tests/series/**/*",
+  "tests/**/*add.py",
+  "tests/**/*sub.py",
+  "tests/**/*truediv.py",
+  "tests/**/*mul.py",
+  "tests/**/*floordiv.py",
 ]

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -238,21 +238,21 @@ def test_multiindex_constructors() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.MultiIndex()  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue]
+        pd.MultiIndex()  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue] # ty: ignore[missing-argument]
 
         data = [(1,), (2,)]
-        pd.MultiIndex(data)  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue]
-        pd.MultiIndex(UserList(data))  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue]
-        pd.MultiIndex(deque(data))  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue]
+        pd.MultiIndex(data)  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue] # ty: ignore[missing-argument]
+        pd.MultiIndex(UserList(data))  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue] # ty: ignore[missing-argument]
+        pd.MultiIndex(deque(data))  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue] # ty: ignore[missing-argument]
 
-        pd.MultiIndex(UserList([[1, 2, 3], [4, 5, 6]]))  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue]
-        pd.MultiIndex(UserList([UserList([1, 2, 3]), UserList([4, 5, 6])]))  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue]
+        pd.MultiIndex(UserList([[1, 2, 3], [4, 5, 6]]))  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue] # ty: ignore[missing-argument]
+        pd.MultiIndex(UserList([UserList([1, 2, 3]), UserList([4, 5, 6])]))  # type: ignore[call-arg] # pyrefly: ignore[missing-argument] # pyright: ignore[reportCallIssue] # ty: ignore[missing-argument]
 
-        pd.MultiIndex("12345", "abcde")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        pd.MultiIndex([[1, 2, 3], [4, 5, 6]], "abcdef")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        pd.MultiIndex("abcdef", [[1, 2, 3], [4, 5, 6]])  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        pd.MultiIndex(["abcdef"], [[1, 2, 3], [4, 5, 6]])  # type: ignore[list-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        pd.MultiIndex([[1], [4]], codes=[["b"], ["a"]])  # type: ignore[list-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        pd.MultiIndex("12345", "abcde")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        pd.MultiIndex([[1, 2, 3], [4, 5, 6]], "abcdef")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        pd.MultiIndex("abcdef", [[1, 2, 3], [4, 5, 6]])  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        pd.MultiIndex(["abcdef"], [[1, 2, 3], [4, 5, 6]])  # type: ignore[list-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        pd.MultiIndex([[1], [4]], codes=[["b"], ["a"]])  # type: ignore[list-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_index_tolist() -> None:
@@ -1000,15 +1000,15 @@ def test_index_operators() -> None:
     check(assert_type(divmod(10, i1), tuple["pd.Index[int]", "pd.Index[int]"]), tuple)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _i1_a_i2 = i1 & i2  # type: ignore[operator,var-annotated] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _i1_a_10 = i1 & 10  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _1_a_i1 = 1 & i1  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _i1_o_i2 = i1 | i2  # type: ignore[operator,var-annotated] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _i1_o_10 = i1 | 10  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _1_o_i1 = 1 | i1  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _i1_x_i2 = i1 ^ i2  # type: ignore[operator,var-annotated] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _i1_x_10 = i1 ^ 10  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _1_x_i1 = 1 ^ i1  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _i1_a_i2 = i1 & i2  # type: ignore[operator,var-annotated] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _i1_a_10 = i1 & 10  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1_a_i1 = 1 & i1  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _i1_o_i2 = i1 | i2  # type: ignore[operator,var-annotated] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _i1_o_10 = i1 | 10  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1_o_i1 = 1 | i1  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _i1_x_i2 = i1 ^ i2  # type: ignore[operator,var-annotated] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _i1_x_10 = i1 ^ 10  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1_x_i1 = 1 ^ i1  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
 
 def test_getitem() -> None:
@@ -1124,7 +1124,14 @@ def test_append_int() -> None:
     """Test pd.Index[int].append"""
     first = pd.Index([1])
     second = pd.Index([2])
-    check(assert_type(first.append([]), "pd.Index[int]"), pd.Index, np.int64)
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(
+            first.append([]), "pd.Index[int]"
+        ),  # ty: ignore[type-assertion-failure]
+        pd.Index,
+        np.int64,
+    )
     check(assert_type(first.append(second), "pd.Index[int]"), pd.Index, np.int64)
     check(assert_type(first.append([second]), "pd.Index[int]"), pd.Index, np.int64)
 
@@ -1133,7 +1140,14 @@ def test_append_str() -> None:
     """Test pd.Index[str].append"""
     first = pd.Index(["str"])
     second = pd.Index(["rts"])
-    check(assert_type(first.append([]), "pd.Index[str]"), pd.Index, str)
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(
+            first.append([]), "pd.Index[str]"
+        ),  # ty: ignore[type-assertion-failure]
+        pd.Index,
+        str,
+    )
     check(assert_type(first.append(second), "pd.Index[str]"), pd.Index, str)
     check(assert_type(first.append([second]), "pd.Index[str]"), pd.Index, str)
 
@@ -1358,7 +1372,7 @@ def test_index_categorical() -> None:
 def test_disallow_empty_index() -> None:
     # From GH 826
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = pd.Index()  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload]
+        _0 = pd.Index()  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_periodindex_shift() -> None:
@@ -1697,17 +1711,17 @@ def test_index_droplevel() -> None:
     check(assert_type(mi.droplevel(("elk",)), pd.MultiIndex | pd.Index), pd.Index)
     check(assert_type(mi.droplevel(0), pd.MultiIndex | pd.Index), pd.Index)
     if TYPE_CHECKING_INVALID_USAGE:
-        idx.droplevel()  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[missing-argument]
-        idx.droplevel(0)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        idx.droplevel()  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[missing-argument] # ty: ignore[missing-argument]
+        idx.droplevel(0)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
         # TODO: the following change is caused by python/mypy#21497. Remove unused-ignore after mypy 2.2.0.
-        idx.droplevel([0])  # type: ignore[arg-type,list-item,unused-ignore] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        idx.droplevel("name")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        idx.droplevel([0])  # type: ignore[arg-type,list-item,unused-ignore] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        idx.droplevel("name")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_index_setitem() -> None:
     idx = pd.Index([1, 2])
     if TYPE_CHECKING_INVALID_USAGE:
-        idx[0] = 999  # type: ignore[index] # pyright: ignore[reportIndexIssue] # pyrefly: ignore[unsupported-operation]
+        idx[0] = 999  # type: ignore[index] # pyright: ignore[reportIndexIssue] # pyrefly: ignore[unsupported-operation] # ty: ignore[invalid-assignment]
 
 
 def test_index_putmask() -> None:
@@ -2049,13 +2063,30 @@ def test_diff() -> None:
     # Any -> Any
     s_o = ind.astype(object)
     assert_type(s_o, pd.Index)
-    check(assert_type(s_o.diff(), pd.Index), pd.Index, float)
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(s_o.diff(), pd.Index),  # ty: ignore[type-assertion-failure]
+        pd.Index,
+        float,
+    )
     mi = pd.MultiIndex.from_arrays(
         [range(4), pd.date_range("2026-01-30", "2026-02-02")], names=["a", "b"]
     )
-    check(assert_type(mi.get_level_values("a").diff(), pd.Index), pd.Index, float)
+    # TODO: remove the ignore astral-sh/ty#4055
     check(
-        assert_type(mi.get_level_values("b").diff(), pd.Index),
+        assert_type(  # ty: ignore[type-assertion-failure]
+            mi.get_level_values("a").diff(),
+            pd.Index,
+        ),
+        pd.Index,
+        float,
+    )
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(  # ty: ignore[type-assertion-failure]
+            mi.get_level_values("b").diff(),
+            pd.Index,
+        ),
         pd.Index,
         pd.Timedelta,
         index_to_check_for_type=-1,
@@ -2067,10 +2098,10 @@ def test_diff() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         # dtype -> TypeError: unsupported operand type(s) for -: 'type' and 'type'
-        pd.Index([str, int, bool]).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        pd.Index([str, int, bool]).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
         # str -> TypeError: unsupported operand type(s) for -: 'str' and 'str'
-        pd.Index(["a", "b"]).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        pd.Index(["a", "b"]).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
         def _diff_invalid0() -> None:  # pyright: ignore[reportUnusedFunction]
             # interval -> TypeError: IntervalArray has no 'diff' method. Convert to a suitable dtype prior to calling 'diff'.

--- a/tests/series/test_agg.py
+++ b/tests/series/test_agg.py
@@ -15,10 +15,26 @@ from tests import (
 
 def test_agg_any_float() -> None:
     series = pd.DataFrame({"A": [1.0, float("nan"), 2.0]})["A"]
-    check(assert_type(series.mean(), float), np.float64)
-    check(assert_type(series.median(), float), np.float64)
-    check(assert_type(series.std(), float), np.float64)
-    check(assert_type(series.var(), float), np.float64)
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(series.mean(), float),  # ty: ignore[type-assertion-failure]
+        np.float64,
+    )
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(series.median(), float),  # ty: ignore[type-assertion-failure]
+        np.float64,
+    )
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(series.std(), float),  # ty: ignore[type-assertion-failure]
+        np.float64,
+    )
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(series.var(), float),  # ty: ignore[type-assertion-failure]
+        np.float64,
+    )
 
 
 def test_agg_bool() -> None:
@@ -75,10 +91,10 @@ def test_agg_complex() -> None:
 def test_agg_str() -> None:
     series = pd.Series(["1", "a", "pd"])
     if TYPE_CHECKING_INVALID_USAGE:
-        series.mean()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        series.median()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        series.std()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
-        series.var()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        series.mean()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        series.median()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        series.std()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        series.var()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_agg_ts() -> None:

--- a/tests/series/test_indexing.py
+++ b/tests/series/test_indexing.py
@@ -30,7 +30,7 @@ def test_types_iloc_iat() -> None:
     s2.iat[0] = None
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.iat[0, 0]  # type: ignore[index] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-index]
+        s.iat[0, 0]  # type: ignore[index] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-index] # ty: ignore[invalid-argument-type]
 
 
 def test_types_loc_at() -> None:

--- a/tests/series/test_properties.py
+++ b/tests/series/test_properties.py
@@ -1,6 +1,5 @@
 # mypy: disable-error-code=type-arg
 # pyright: reportMissingTypeArgument=false
-# ty: ignore[missing-type-argument]
 from typing import (
     TYPE_CHECKING,
     assert_type,
@@ -56,29 +55,33 @@ def test_property_dt() -> None:
 
     df = DataFrame({"ts": [Timestamp(2025, 12, 6)], "td": [Timedelta(1, "s")]})
     # python/mypy#19952: mypy gives Any
+    # TODO: remove the ignore astral-sh/ty#4055
     check(
-        assert_type(df["ts"].dt, CombinedDatetimelikeProperties),  # type: ignore[assert-type]
+        assert_type(df["ts"].dt, CombinedDatetimelikeProperties),  # type: ignore[assert-type] # ty: ignore[type-assertion-failure]
         DatetimeProperties,
     )
+    # TODO: remove the ignore astral-sh/ty#4055
     check(
-        assert_type(df["td"].dt, CombinedDatetimelikeProperties),  # type: ignore[assert-type]
+        assert_type(df["td"].dt, CombinedDatetimelikeProperties),  # type: ignore[assert-type] # ty: ignore[type-assertion-failure]
         TimedeltaProperties,
     )
 
+    # TODO: remove the ignore astral-sh/ty#4055
     check(
-        assert_type(df["ts"].dt.year, "Series[int]"),  # type: ignore[assert-type]
+        assert_type(df["ts"].dt.year, "Series[int]"),  # type: ignore[assert-type] # ty: ignore[type-assertion-failure]
         Series,
         np.integer,
     )
+    # TODO: remove the ignore astral-sh/ty#4055
     check(
-        assert_type(df["td"].dt.total_seconds(), "Series[float]"),  # type: ignore[assert-type]
+        assert_type(df["td"].dt.total_seconds(), "Series[float]"),  # type: ignore[assert-type] # ty: ignore[type-assertion-failure]
         Series,
         np.floating,
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = Series([1]).dt  # type: ignore[arg-type] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload]
-        _1 = Series(["2025-01-01"]).dt  # type: ignore[arg-type] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload]
+        _0 = Series([1]).dt  # type: ignore[arg-type] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-attribute-access]
+        _1 = Series(["2025-01-01"]).dt  # type: ignore[arg-type] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-attribute-access]
 
 
 def test_property_array() -> None:

--- a/tests/series/test_properties.py
+++ b/tests/series/test_properties.py
@@ -1,5 +1,6 @@
 # mypy: disable-error-code=type-arg
 # pyright: reportMissingTypeArgument=false
+# ty: ignore[missing-type-argument,unused-ignore-comment,unused-ignore-comment]
 from typing import (
     TYPE_CHECKING,
     assert_type,

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -879,8 +879,7 @@ def test_types_element_wise_arithmetic() -> None:
     s = pd.Series([0, 1, -10])
     s2 = pd.Series([7, -5, 10])
 
-    # TODO: pandas-dev/pandas-stubs#1799 investigate why ty infers
-    # Series[Unknown] instead of Series[int] for add and mul.
+    # TODO: remove the ignore astral-sh/ty#4401
     check(
         assert_type(
             s.add(s2, fill_value=0), "pd.Series[int]"
@@ -891,8 +890,7 @@ def test_types_element_wise_arithmetic() -> None:
 
     check(assert_type(s.sub(s2, fill_value=0), "pd.Series[int]"), pd.Series, np.integer)
 
-    # TODO: pandas-dev/pandas-stubs#1799 investigate why ty infers
-    # Series[Unknown] instead of Series[int] for add and mul.
+    # TODO: remove the ignore astral-sh/ty#4401
     check(
         assert_type(
             s.mul(s2, fill_value=0), "pd.Series[int]"

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -2244,10 +2244,11 @@ def test_types_to_numpy() -> None:
             np.integer,
         )
     else:
+        # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
         check(
             assert_type(
                 s_date.to_numpy(dtype=np.dtype("i8")), np_1darray[np.int64]
-            ),  # ty: ignore[type-assertion-failure]
+            ),  # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
             np_1darray,
             np.integer,
         )
@@ -2503,10 +2504,11 @@ def test_types_to_numpy() -> None:
             pd.Period,
         )
     else:
+        # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
         check(
             assert_type(
                 s_period.to_numpy(dtype=np.dtype("O")), np_1darray_object
-            ),  # ty: ignore[type-assertion-failure]
+            ),  # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
             np_1darray_object,
             pd.Period,
         )
@@ -2721,10 +2723,11 @@ def test_types_to_numpy() -> None:
             np.datetime64,
         )
     else:
+        # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
         check(
             assert_type(
                 s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt
-            ),  # ty: ignore[type-assertion-failure]
+            ),  # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
             np_1darray,
             np.datetime64,
         )
@@ -2743,10 +2746,11 @@ def test_types_to_numpy() -> None:
             np.timedelta64,
         )
     else:
+        # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
-            ),  # ty: ignore[type-assertion-failure]
+            ),  # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
             np_1darray,
             np.timedelta64,
         )
@@ -2767,11 +2771,12 @@ def test_types_to_numpy() -> None:
             np.void,
         )
     else:
+        # TODO: reduce the double unused-ignore-comment when astral-sh/ty#2681 is resolved
         check(
             assert_type(
                 s_td_small.to_numpy(dtype=np.dtype([("x", np.float64)])),
                 np_1darray[np.void],
-            ),  # ty: ignore[type-assertion-failure]
+            ),  # ty: ignore[type-assertion-failure,unused-ignore-comment,unused-ignore-comment]
             np_1darray,
             np.void,
         )

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -15,6 +15,7 @@ import io
 import math
 from pathlib import Path
 import re
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -2234,11 +2235,22 @@ def test_types_to_numpy() -> None:
         np_1darray,
         np.integer,
     )
-    check(
-        assert_type(s_date.to_numpy(dtype=np.dtype("i8")), np_1darray[np.int64]),
-        np_1darray,
-        np.integer,
-    )
+    # Python 3.11 resolves NumPy 2.4, where ty incorrectly infers these
+    # np.dtype(...) expressions as np.dtype[np.float64]. NumPy 2.5 fixes this.
+    if sys.version_info >= (3, 12):  # NumPy >= 2.5 eliminates the ty errors
+        check(
+            assert_type(s_date.to_numpy(dtype=np.dtype("i8")), np_1darray[np.int64]),
+            np_1darray,
+            np.integer,
+        )
+    else:
+        check(
+            assert_type(
+                s_date.to_numpy(dtype=np.dtype("i8")), np_1darray[np.int64]
+            ),  # ty: ignore[type-assertion-failure]
+            np_1darray,
+            np.integer,
+        )
 
     # --- Unsigned integers ---
     check(
@@ -2484,11 +2496,20 @@ def test_types_to_numpy() -> None:
         np_1darray_object,
         pd.Interval,
     )
-    check(
-        assert_type(s_period.to_numpy(dtype=np.dtype("O")), np_1darray_object),
-        np_1darray_object,
-        pd.Period,
-    )
+    if sys.version_info >= (3, 12):  # NumPy >= 2.5 eliminates the ty errors
+        check(
+            assert_type(s_period.to_numpy(dtype=np.dtype("O")), np_1darray_object),
+            np_1darray_object,
+            pd.Period,
+        )
+    else:
+        check(
+            assert_type(
+                s_period.to_numpy(dtype=np.dtype("O")), np_1darray_object
+            ),  # ty: ignore[type-assertion-failure]
+            np_1darray_object,
+            pd.Period,
+        )
 
     # np.dtypes signed int instances
     # TODO: remove the ignore astral-sh/ty#4364
@@ -2691,24 +2712,44 @@ def test_types_to_numpy() -> None:
         np.str_,
     )
     # DateTime64DType — parametric
-    check(
-        assert_type(s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt),
-        np_1darray,
-        np.datetime64,
-    )
+    if sys.version_info >= (3, 12):  # NumPy >= 2.5 eliminates the ty errors
+        check(
+            assert_type(
+                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt
+            ),
+            np_1darray,
+            np.datetime64,
+        )
+    else:
+        check(
+            assert_type(
+                s_date.to_numpy(dtype=np.dtype("datetime64[ns]")), np_1darray_dt
+            ),  # ty: ignore[type-assertion-failure]
+            np_1darray,
+            np.datetime64,
+        )
     check(
         assert_type(s_date.to_numpy(dtype="datetime64[ns]"), np_1darray_dt),
         np_1darray,
         np.datetime64,
     )
     # TimeDelta64DType — parametric
-    check(
-        assert_type(
-            s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
-        ),
-        np_1darray,
-        np.timedelta64,
-    )
+    if sys.version_info >= (3, 12):  # NumPy >= 2.5 eliminates the ty errors
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
+            ),
+            np_1darray,
+            np.timedelta64,
+        )
+    else:
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype("timedelta64[ns]")), np_1darray_td
+            ),  # ty: ignore[type-assertion-failure]
+            np_1darray,
+            np.timedelta64,
+        )
     check(
         assert_type(s_td_small.to_numpy(dtype="timedelta64[ns]"), np_1darray_td),
         np_1darray,
@@ -2716,14 +2757,24 @@ def test_types_to_numpy() -> None:
     )
 
     # VoidDType — parametric, use np.dtype(...)
-    check(
-        assert_type(
-            s_td_small.to_numpy(dtype=np.dtype([("x", np.float64)])),
-            np_1darray[np.void],
-        ),
-        np_1darray,
-        np.void,
-    )
+    if sys.version_info >= (3, 12):  # NumPy >= 2.5 eliminates the ty errors
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype([("x", np.float64)])),
+                np_1darray[np.void],
+            ),
+            np_1darray,
+            np.void,
+        )
+    else:
+        check(
+            assert_type(
+                s_td_small.to_numpy(dtype=np.dtype([("x", np.float64)])),
+                np_1darray[np.void],
+            ),  # ty: ignore[type-assertion-failure]
+            np_1darray,
+            np.void,
+        )
 
 
 def test_where() -> None:

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -174,7 +174,7 @@ def test_types_any() -> None:
     check(assert_type(pd.Series([np.nan]).any(skipna=False), np.bool), np.bool)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.Series([False, True]).any(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
+        pd.Series([False, True]).any(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
 
 
 def test_types_all() -> None:
@@ -183,7 +183,7 @@ def test_types_all() -> None:
     check(assert_type(pd.Series([np.nan]).all(skipna=False), np.bool), np.bool)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        pd.Series([False, True]).all(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
+        pd.Series([False, True]).all(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
 
 
 def test_types_csv(tmp_path: Path) -> None:
@@ -276,9 +276,9 @@ def test_arguments_drop() -> None:
     # GH 950
     s = pd.Series([0, 1, 2])
     if TYPE_CHECKING_INVALID_USAGE:
-        _res1 = s.drop()  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload]
-        _res2 = s.drop([0], columns=["col1"])  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload]
-        _res3 = s.drop([0], index=[0])  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload]
+        _res1 = s.drop()  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _res2 = s.drop([0], columns=["col1"])  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _res3 = s.drop([0], index=[0])  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
     def _never_checker0() -> None:  # pyright: ignore[reportUnusedFunction]
         assert_type(s.drop(columns=None), Never)
@@ -413,7 +413,7 @@ def test_types_sort_values() -> None:
     s = pd.Series([4, 2, 1, 3])
     check(assert_type(s.sort_values(), "pd.Series[int]"), pd.Series, np.integer)
     if TYPE_CHECKING_INVALID_USAGE:
-        s.sort_values(0)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload]
+        s.sort_values(0)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
     check(assert_type(s.sort_values(axis=0), "pd.Series[int]"), pd.Series, np.integer)
     check(
         assert_type(s.sort_values(ascending=False), "pd.Series[int]"),
@@ -468,7 +468,7 @@ def test_types_shift() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.shift(freq="1D", fill_value=4)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        s.shift(freq="1D", fill_value=4)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
 
 
 def test_series_pct_change() -> None:
@@ -519,7 +519,7 @@ def test_types_median() -> None:
     check(assert_type(s.median(numeric_only=False), float), float)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.median(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload]
+        s.median(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_types_sum() -> None:
@@ -580,7 +580,7 @@ def test_types_min() -> None:
     check(assert_type(s.min(skipna=False), float), np.floating)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.min(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
+        s.min(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
 
 
 def test_types_max() -> None:
@@ -595,7 +595,7 @@ def test_types_max() -> None:
     check(assert_type(s.max(skipna=False), float), np.floating)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.max(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
+        s.max(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
 
 
 def test_types_groupby_level() -> None:
@@ -790,8 +790,8 @@ def test_types_clip() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.clip(lower=lower, axis=1)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        s.clip(lower=lower, axis="column")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        s.clip(lower=lower, axis=1)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        s.clip(lower=lower, axis="column")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_types_abs() -> None:
@@ -879,11 +879,27 @@ def test_types_element_wise_arithmetic() -> None:
     s = pd.Series([0, 1, -10])
     s2 = pd.Series([7, -5, 10])
 
-    check(assert_type(s.add(s2, fill_value=0), "pd.Series[int]"), pd.Series, np.integer)
+    # TODO: pandas-dev/pandas-stubs#1799 investigate why ty infers
+    # Series[Unknown] instead of Series[int] for add and mul.
+    check(
+        assert_type(
+            s.add(s2, fill_value=0), "pd.Series[int]"
+        ),  # ty: ignore[type-assertion-failure]
+        pd.Series,
+        np.integer,
+    )
 
     check(assert_type(s.sub(s2, fill_value=0), "pd.Series[int]"), pd.Series, np.integer)
 
-    check(assert_type(s.mul(s2, fill_value=0), "pd.Series[int]"), pd.Series, np.integer)
+    # TODO: pandas-dev/pandas-stubs#1799 investigate why ty infers
+    # Series[Unknown] instead of Series[int] for add and mul.
+    check(
+        assert_type(
+            s.mul(s2, fill_value=0), "pd.Series[int]"
+        ),  # ty: ignore[type-assertion-failure]
+        pd.Series,
+        np.integer,
+    )
 
     check(
         assert_type(s.div(s2, fill_value=0), "pd.Series[float]"), pd.Series, np.float64
@@ -942,11 +958,11 @@ def test_series_frame_ops() -> None:
     s = pd.Series([0, 1, -10])
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = s.add(df)  # type: ignore[type-var] # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        _1 = s.sub(df)  # type: ignore[arg-type] # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        _2 = s.mul(df)  # type: ignore[type-var] # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        _3 = s.truediv(df)  # type: ignore[arg-type] # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType] # pyrefly: ignore[no-matching-overload]
-        _4 = s.divmod(df)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        _0 = s.add(df)  # type: ignore[type-var] # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _1 = s.sub(df)  # type: ignore[arg-type] # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _2 = s.mul(df)  # type: ignore[type-var] # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _3 = s.truediv(df)  # type: ignore[arg-type] # pyright: ignore[reportCallIssue,reportUnknownVariableType,reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _4 = s.divmod(df)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_types_groupby() -> None:
@@ -994,13 +1010,13 @@ def test_types_groupby_methods() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.sum(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        s.prod(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
-        s.std(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        s.var(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        s.sem(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
-        s.skew(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
-        s.kurt(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count]
+        s.sum(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        s.prod(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
+        s.std(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        s.var(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        s.sem(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
+        s.skew(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
+        s.kurt(0)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue] # pyrefly: ignore[bad-argument-count] # ty: ignore[too-many-positional-arguments]
 
 
 def test_groupby_result() -> None:
@@ -1308,7 +1324,7 @@ def test_update() -> None:
     # Series.update() accepting objects that can be coerced to a Series was added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
     s1.update([1, 2, -4, 3])
     if TYPE_CHECKING_INVALID_USAGE:
-        s1.update([1, "b", "c", "d"])  # type: ignore[list-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        s1.update([1, "b", "c", "d"])  # type: ignore[list-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
     s1.update({1: 9, 3: 4})
 
 
@@ -1448,7 +1464,7 @@ def test_types_rename_axis() -> None:
     check(assert_type(s.rename_axis(index=None), "pd.Series[int]"), pd.Series)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.rename_axis(columns="A")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload]
+        s.rename_axis(columns="A")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_types_values() -> None:
@@ -1534,9 +1550,9 @@ def test_types_rename() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[dict-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        _s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[dict-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
         # copy argument is deprecated from 3.0
-        _s8 = pd.Series([1, 2, 3]).rename("A", copy=True)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload]
+        _s8 = pd.Series([1, 2, 3]).rename("A", copy=True)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_types_ne() -> None:
@@ -1726,7 +1742,7 @@ def test_series_replace() -> None:
     check(assert_type(s_i.replace({1: 2}), "pd.Series[int]"), pd.Series, np.integer)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.replace({"1": "2"}, regex={"1": "2"})  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
+        s.replace({"1": "2"}, regex={"1": "2"})  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_cat_accessor() -> None:
@@ -1803,8 +1819,11 @@ def test_cat_ctor_values() -> None:
     s = ["a", "b", "a"]
     check(assert_type(pd.Categorical(s), "pd.Categorical[str]"), pd.Categorical)
     # GH 107
+    # TODO: remove the ignore astral-sh/ty#4366
     check(
-        assert_type(pd.Categorical([1, 2, 3, 1, 1]), "pd.Categorical[int]"),
+        assert_type(  # ty: ignore[type-assertion-failure]
+            pd.Categorical([1, 2, 3, 1, 1]), "pd.Categorical[int]"
+        ),
         pd.Categorical,
     )
 
@@ -2021,7 +2040,13 @@ def test_types_to_numpy() -> None:
         np_1darray_object,
     )
 
-    check(assert_type(pd.Series().to_numpy(), np_1darray), np_1darray)
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(
+            pd.Series().to_numpy(), np_1darray
+        ),  # ty: ignore[type-assertion-failure]
+        np_1darray,
+    )
 
     check(
         assert_type(
@@ -2468,177 +2493,202 @@ def test_types_to_numpy() -> None:
     )
 
     # np.dtypes signed int instances
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.Int8DType()), np_1darray[np.int8]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.int8,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.Int16DType()), np_1darray[np.int16]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.int16,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.Int32DType()), np_1darray[np.int32]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.int32,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.Int64DType()), np_1darray[np.int64]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.int64,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.IntDType()), np_1darray[np.intc]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.intc,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.LongDType()), np_1darray[np.long]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.long,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.LongLongDType()),
             np_1darray[np.longlong],
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.longlong,
     )
 
     # np.dtypes unsigned int instances
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.UInt8DType()), np_1darray[np.uint8]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.uint8,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.UInt16DType()), np_1darray[np.uint16]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.uint16,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.UInt32DType()), np_1darray[np.uint32]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.uint32,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.UInt64DType()), np_1darray[np.uint64]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.uint64,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.UIntDType()), np_1darray[np.uintc]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.uintc,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.ULongDType()), np_1darray[np.ulong]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.ulong,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.ULongLongDType()),
             np_1darray[np.ulonglong],
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.ulonglong,
     )
 
     # np.dtypes float instances
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.Float16DType()), np_1darray[np.float16]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.float16,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.Float32DType()), np_1darray[np.float32]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.float32,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_timedelta.to_numpy(dtype=np.dtypes.Float64DType()), np_1darray[np.float64]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.float64,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.LongDoubleDType()),
             np_1darray[np.longdouble],
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.longdouble,
     )
 
     # np.dtypes complex instances
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.Complex64DType()),
             np_1darray[np.complex64],
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.complex64,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.Complex128DType()),
             np_1darray[np.complex128],
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.complex128,
     )
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.CLongDoubleDType()),
             np_1darray[np.clongdouble],
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.clongdouble,
     )
 
     # np.dtypes.BytesDType(size) — fixed-width bytes
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
         assert_type(
             s_td_small.to_numpy(dtype=np.dtypes.BytesDType(4)), np_1darray[np.bytes_]
-        ),
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.bytes_,
     )
     # np.dtypes.StrDType(size) — fixed-width unicode
+    # TODO: remove the ignore astral-sh/ty#4364
     check(
-        assert_type(s_td_small.to_numpy(dtype=np.dtypes.StrDType(4)), np_1darray_str),
+        assert_type(
+            s_td_small.to_numpy(dtype=np.dtypes.StrDType(4)), np_1darray_str
+        ),  # ty: ignore[type-assertion-failure]
         np_1darray,
         np.str_,
     )
@@ -2735,14 +2785,14 @@ def test_bitwise_operators() -> None:
     check(assert_type(s2 ^ s, "pd.Series[int]"), pd.Series, np.integer)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = s & [1, 2, 3, 4]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _1 = [1, 2, 3, 4] & s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _0 = s & [1, 2, 3, 4]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = [1, 2, 3, 4] & s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
-        _2 = s | [1, 2, 3, 4]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _3 = [1, 2, 3, 4] | s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _2 = s | [1, 2, 3, 4]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _3 = [1, 2, 3, 4] | s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
-        _4 = s ^ [1, 2, 3, 4]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _5 = [1, 2, 3, 4] ^ s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _4 = s ^ [1, 2, 3, 4]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _5 = [1, 2, 3, 4] ^ s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
 
 def test_logical_operators() -> None:
@@ -2772,12 +2822,12 @@ def test_logical_operators() -> None:
     check(assert_type(True ^ (df["a"] >= 2), "pd.Series[bool]"), pd.Series, np.bool_)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = (df["a"] >= 2) & [True, False, True]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _1 = [True, False, True] & (df["a"] >= 2)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _2 = (df["a"] >= 2) | [True, False, True]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _3 = [True, False, True] | (df["a"] >= 2)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _4 = (df["a"] >= 2) ^ [True, False, True]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
-        _5 = [True, False, True] ^ (df["a"] >= 2)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        _0 = (df["a"] >= 2) & [True, False, True]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = [True, False, True] & (df["a"] >= 2)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _2 = (df["a"] >= 2) | [True, False, True]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _3 = [True, False, True] | (df["a"] >= 2)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _4 = (df["a"] >= 2) ^ [True, False, True]  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _5 = [True, False, True] ^ (df["a"] >= 2)  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
 
 def test_AnyArrayLike_and_clip() -> None:
@@ -2835,7 +2885,7 @@ def test_astype_other() -> None:
 
     # Test incorrect Literal
     if TYPE_CHECKING_INVALID_USAGE:
-        s.astype("foobar")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
+        s.astype("foobar")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
     # Test self-consistent with s.dtype (#747)
     # NOTE: https://github.com/python/typing/issues/801#issuecomment-1646171898
@@ -2930,8 +2980,8 @@ def test_check_xs() -> None:
     check(assert_type(s4, "pd.Series[int]"), pd.Series, np.integer)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s4.xs([0])  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        s4.xs(0, axis=1)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        s4.xs([0])  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        s4.xs(0, axis=1)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_types_apply_set() -> None:
@@ -2965,8 +3015,8 @@ def test_prefix_summix_axis() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        s.add_prefix("_item", axis=1)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        s.add_suffix("_item", axis="columns")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        s.add_prefix("_item", axis=1)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        s.add_suffix("_item", axis="columns")  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
 
 def test_convert_dtypes_convert_floating() -> None:
@@ -3004,8 +3054,8 @@ def test_to_json_mode() -> None:
     check(assert_type(result2, str), str)
     check(assert_type(result4, str), str)
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = s.to_json(orient="records", lines=False, mode="a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload]
-        _1 = s.to_json(date_format="epoch")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        _0 = s.to_json(orient="records", lines=False, mode="a")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        _1 = s.to_json(date_format="epoch")  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[invalid-argument-type]
 
 
 def test_interpolate() -> None:
@@ -3110,7 +3160,8 @@ def test_round() -> None:
     check(assert_type(round(pd.Series([1], dtype=int)), "pd.Series[int]"), pd.Series)
 
 
-def test_get() -> None:
+@pytest.mark.parametrize(("c", "b"), [("a", True)])  # workaround astral-sh/ty#4363
+def test_get(c: str, b: bool) -> None:
     s_int = pd.Series([1, 2, 3], index=[1, 2, 3])
 
     check(assert_type(s_int.get(1), int | None), np.int64)
@@ -3118,7 +3169,7 @@ def test_get() -> None:
     check(assert_type(s_int.get(1, default=None), int | None), np.int64)
     check(assert_type(s_int.get(99, default=None), int | None), type(None))
     check(assert_type(s_int.get(1, default=2), int), np.int64)
-    check(assert_type(s_int.get(99, default="a"), int | str), str)
+    check(assert_type(s_int.get(99, default=c), int | str), str)
 
     s_str = pd.Series(list("abc"), index=list("abc"))
 
@@ -3127,7 +3178,7 @@ def test_get() -> None:
     check(assert_type(s_str.get("a", default=None), str | None), str)
     check(assert_type(s_str.get("z", default=None), str | None), type(None))
     check(assert_type(s_str.get("a", default="b"), str), str)
-    check(assert_type(s_str.get("z", default=True), str | bool), bool)
+    check(assert_type(s_str.get("z", default=b), str | bool), bool)
 
 
 def test_series_new_empty() -> None:
@@ -3203,49 +3254,49 @@ def test_pipe() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        ser.pipe(  # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             first_arg_series,
             "a",  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue]
             [1.0, 2.0],
             argument_2="hi",
             keyword_only=(1, 2),
         )
-        ser.pipe(  # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             first_arg_series,
             1,
             [1.0, "b"],  # type: ignore[list-item] # pyright: ignore[reportArgumentType,reportCallIssue]
             argument_2="hi",
             keyword_only=(1, 2),
         )
-        ser.pipe(  # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             first_arg_series,
             1,
             [1.0, 2.0],
             argument_2=11,  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue]
             keyword_only=(1, 2),
         )
-        ser.pipe(  # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             first_arg_series,
             1,
             [1.0, 2.0],
             argument_2="hi",
             keyword_only=(1,),  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue]
         )
-        ser.pipe(  # type: ignore[call-arg] # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # type: ignore[call-arg] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             first_arg_series,
             1,
             [1.0, 2.0],
             argument_3="hi",  # pyright: ignore[reportCallIssue]
             keyword_only=(1, 2),
         )
-        ser.pipe(  # type: ignore[call-overload] # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # type: ignore[call-overload] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             first_arg_series,
             1,
             [1.0, 2.0],
             11,
             (1, 2),  # pyright: ignore[reportCallIssue]
         )
-        ser.pipe(  # type: ignore[call-overload] # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # type: ignore[call-overload] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             first_arg_series,
             positional_only=1,  # pyright: ignore[reportCallIssue]
             argument_1=[1.0, 2.0],
@@ -3259,14 +3310,14 @@ def test_pipe() -> None:
     check(assert_type(ser.pipe((first_arg_not_series, "ser"), 1), pd.Series), pd.Series)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        ser.pipe(  # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             (
                 first_arg_not_series,  # type: ignore[arg-type]
                 1,  # pyright: ignore[reportArgumentType,reportCallIssue]
             ),
             1,
         )
-        ser.pipe(  # pyrefly: ignore[no-matching-overload]
+        ser.pipe(  # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
             (
                 1,  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue]
                 "df",
@@ -3360,11 +3411,31 @@ def test_diff() -> None:
     # Any -> Any
     s_o = s.astype(object)
     assert_type(s_o, pd.Series)
-    check(assert_type(s_o.diff(), "pd.Series[Any]"), pd.Series, float)
-    df = pd.DataFrame({"a": range(4), "b": pd.date_range("2026-01-30", "2026-02-02")})
-    check(assert_type(df["a"].diff(), "pd.Series[Any]"), pd.Series, float)
+    # TODO: remove the ignore astral-sh/ty#4055
     check(
-        assert_type(df["b"].diff(), "pd.Series[Any]"),
+        assert_type(  # ty: ignore[type-assertion-failure]
+            s_o.diff(),
+            "pd.Series[Any]",
+        ),
+        pd.Series,
+        float,
+    )
+    df = pd.DataFrame({"a": range(4), "b": pd.date_range("2026-01-30", "2026-02-02")})
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(  # ty: ignore[type-assertion-failure]
+            df["a"].diff(),
+            "pd.Series[Any]",
+        ),
+        pd.Series,
+        float,
+    )
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(  # ty: ignore[type-assertion-failure]
+            df["b"].diff(),
+            "pd.Series[Any]",
+        ),
         pd.Series,
         pd.Timedelta,
         index_to_check_for_type=-1,
@@ -3376,13 +3447,13 @@ def test_diff() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         # bytes -> numpy.core._exceptions._UFuncNoLoopError: ufunc 'subtract' did not contain a loop with signature matching types (dtype('S21'), dtype('S21')) -> None
-        pd.Series([1, 1, 2, 3, 5, 8]).astype(bytes).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        pd.Series([1, 1, 2, 3, 5, 8]).astype(bytes).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
         # dtype -> TypeError: unsupported operand type(s) for -: 'type' and 'type'
-        pd.Series([str, int, bool]).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        pd.Series([str, int, bool]).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
         # str -> TypeError: unsupported operand type(s) for -: 'str' and 'str'
-        pd.Series(["a", "b"]).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        pd.Series(["a", "b"]).diff()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
         def _diff_invalid0() -> None:  # pyright: ignore[reportUnusedFunction]
             # interval -> TypeError: IntervalArray has no 'diff' method. Convert to a suitable dtype prior to calling 'diff'.
@@ -3587,8 +3658,15 @@ def test_series_empty_dtype() -> None:
     check(assert_type(pd.Series(new_tab), pd.Series), pd.Series)
     check(assert_type(pd.Series([]), pd.Series), pd.Series)
     # ensure that an empty string does not get matched to Sequence[Never]
-    # pyrefly: ignore[string-as-iterable]
     check(assert_type(pd.Series(""), "pd.Series[str]"), pd.Series)
+    check(assert_type(pd.Series("", dtype=str), "pd.Series[str]"), pd.Series)
+    check(assert_type(pd.Series("", dtype="string"), "pd.Series[str]"), pd.Series)
+    check(
+        assert_type(
+            pd.Series("", dtype="category"), "pd.Series[pd.CategoricalDtype[str]]"
+        ),
+        pd.Series,
+    )
 
 
 def test_series_bool_fails() -> None:
@@ -3660,7 +3738,7 @@ def test_series_reindex() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         # copy argument is deprecated from 3.0
-        _0 = s.reindex([2, 1, 0], copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _0 = s.reindex([2, 1, 0], copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
 
 
 def test_series_reindex_like() -> None:
@@ -3677,8 +3755,8 @@ def test_series_reindex_like() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         # copy argument is deprecated from 3.0
-        _0 = s.reindex_like(other, copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
-        _1 = s.reindex_like(other, method="nearest", tolerance=[0.5, 0.2])  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _0 = s.reindex_like(other, copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
+        _1 = s.reindex_like(other, method="nearest", tolerance=[0.5, 0.2])  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
 
 
 def test_info() -> None:
@@ -3708,7 +3786,7 @@ def test_align() -> None:
     check(assert_type(aligned_s1, pd.Series), pd.Series)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = s0.align(s1, fill_value=0, axis=0, level=0, copy=False)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _0 = s0.align(s1, fill_value=0, axis=0, level=0, copy=False)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
 
 
 def test_unknown() -> None:
@@ -3765,7 +3843,7 @@ def test_series_index_type() -> None:
     )
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _t = pd.Series([1, 2], index="ab")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue, reportArgumentType] # pyrefly: ignore[no-matching-overload]
+        _t = pd.Series([1, 2], index="ab")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue, reportArgumentType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_timedelta_index_cumprod() -> None:
@@ -3782,13 +3860,13 @@ def test_timedelta_index_cumprod() -> None:
     offset_series = as_period_series - as_period_series
 
     if TYPE_CHECKING_INVALID_USAGE:
-        offset_series.cumprod()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        offset_series.cumprod()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
-        pd.Series([pd.Timedelta(0), pd.Timedelta(1)]).cumprod()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        pd.Series([pd.Timedelta(0), pd.Timedelta(1)]).cumprod()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
-        pd.Series([pd.Timestamp("2024-04-29"), pd.Timestamp("2034-08-28")]).cumprod()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        pd.Series([pd.Timestamp("2024-04-29"), pd.Timestamp("2034-08-28")]).cumprod()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
-        as_period_series.cumprod()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload]
+        as_period_series.cumprod()  # type: ignore[misc] # pyright: ignore[reportAttributeAccessIssue,reportUnknownMemberType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
 
 
 def test_series_str_methods() -> None:
@@ -3849,23 +3927,23 @@ def test_series_copy_deprecated() -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         # truncate
-        _0 = s.truncate(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _0 = s.truncate(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
         # tz_convert
-        _1 = s.tz_convert("UTC", copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _1 = s.tz_convert("UTC", copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
         # tz_localize
-        _2 = s.tz_localize("UTC", copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _2 = s.tz_localize("UTC", copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
         # infer_objects
-        _3 = s.infer_objects(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _3 = s.infer_objects(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
         # set_axis
-        _4 = s.set_axis([1, 2, 3], copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _4 = s.set_axis([1, 2, 3], copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
         # to_period
-        _5 = s.to_period(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _5 = s.to_period(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
         # to_timestamp
-        _6 = s.to_timestamp(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _6 = s.to_timestamp(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
         # astype
-        _7 = s.astype(int, copy=True)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload]
+        _7 = s.astype(int, copy=True)  # type: ignore[call-overload] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
         # swaplevel
-        _8 = s.swaplevel(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword]
+        _8 = s.swaplevel(copy=True)  # type: ignore[call-arg] # pyright: ignore[reportCallIssue,reportUnknownVariableType] # pyrefly: ignore[unexpected-keyword] # ty: ignore[unknown-argument]
 
 
 def test_series_primitive_conversions() -> None:
@@ -3874,29 +3952,29 @@ def test_series_primitive_conversions() -> None:
     check(assert_type(bytes(s_int), bytes), bytes)
     check(assert_type(bytearray(s_int), bytearray), bytearray)
     if TYPE_CHECKING_INVALID_USAGE:
-        int(s_int)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        float(s_int)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        complex(s_int)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        math.trunc(s_int)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        math.ceil(s_int)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        math.floor(s_int)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        memoryview(s_int)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        int(s_int)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        float(s_int)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        complex(s_int)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        math.trunc(s_int)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        math.ceil(s_int)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        math.floor(s_int)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        memoryview(s_int)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
     s_any: pd.Series[Any] = pd.Series([1, 2, 3])
     check(assert_type(str(s_any), str), str)
     check(assert_type(bytes(s_any), bytes), bytes)
     check(assert_type(bytearray(s_any), bytearray), bytearray)
     if TYPE_CHECKING_INVALID_USAGE:
-        int(s_any)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        float(s_any)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        complex(s_any)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        math.trunc(s_any)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        math.ceil(s_any)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        math.floor(s_any)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
-        memoryview(s_any)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        int(s_any)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        float(s_any)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        complex(s_any)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        math.trunc(s_any)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        math.ceil(s_any)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        math.floor(s_any)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[no-matching-overload]
+        memoryview(s_any)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
 
     s_float = pd.Series([1.5, 2.5, 3.5])
     check(assert_type(str(s_float), str), str)
     if TYPE_CHECKING_INVALID_USAGE:
-        bytes(s_float)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
-        bytearray(s_float)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type]
+        bytes(s_float)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        bytearray(s_float)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -6,7 +6,6 @@ from collections.abc import (
     Hashable,
     Iterable,
     Iterator,
-    Sequence,
 )
 import datetime
 from decimal import Decimal
@@ -3571,7 +3570,7 @@ def test_map() -> None:
 
 
 def test_map_na() -> None:
-    s: pd.Series[int] = pd.Series([1, pd.NA, 3])
+    s = pd.Series([1, pd.NA, 3])
 
     mapping = {1: "a", 2: "b", 3: "c"}
     check(assert_type(s.map(mapping, na_action=None), "pd.Series[str]"), pd.Series, str)
@@ -3708,7 +3707,7 @@ def test_series_typed_dict() -> None:
 
 def test_series_empty_dtype() -> None:
     """Test for the creation of a Series from an empty list GH571 to map to a Series."""
-    new_tab: Sequence[Never] = []  # need to be typehinted to please mypy
+    new_tab = []  # type: ignore[var-annotated]
     check(assert_type(pd.Series(new_tab), pd.Series), pd.Series)
     check(assert_type(pd.Series([]), pd.Series), pd.Series)
     # ensure that an empty string does not get matched to Sequence[Never]


### PR DESCRIPTION
- [x] Towards #1799
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Enables `ty` type checking for `tests/indexes/` and `tests/series/` (excluding arithmetic tests pending astral-sh/ty#4401), and adds necessary `Series.__new__` overloads for string scalars.

### Summary of Changes

1. **Stub Updates (`pandas-stubs/core/series.pyi`)**:
   - Added `Series.__new__` overloads for `data: _str` before `Sequence[Never]` so empty strings resolve to `Series[str]` / `Series[CategoricalDtype[str]]` under `ty` (astral-sh/ty#4365).

2. **Config Updates (`pyproject.toml`)**:
   - Enabled `ty` on `tests/indexes/` and `tests/series/`, excluding binary arithmetic files (`*add.py`, `*sub.py`, `*truediv.py`, `*mul.py`, `*floordiv.py`) due to astral-sh/ty#4401.

3. **Test Annotations & Fixes**:
   - Added `# ty: ignore[...]` tags with `# TODO` markers for upstream issues (astral-sh/ty#4055, astral-sh/ty#4401, astral-sh/ty#4364, astral-sh/ty#2681).
   - Handled NumPy 2.4 vs 2.5 `np.dtype(...)` inference differences on Python 3.11 vs 3.12+ in `test_types_to_numpy()`.