### PR TITLE
BUG: #1920 nightly sort inplace deprecation

### DIFF
--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -504,7 +504,16 @@ def test_types_sort_index() -> None:
     check(
         assert_type(df.sort_index(ascending=False, level=3), pd.DataFrame), pd.DataFrame
     )
-    check(assert_type(df.sort_index(kind="mergesort", inplace=True), None), type(None))
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in DataFrame",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(df.sort_index(kind="mergesort", inplace=True), None),
+            type(None),
+        )
 
 
 # This was added in 1.1.0 https://pandas.pydata.org/docs/whatsnew/v1.1.0.html
@@ -573,10 +582,16 @@ def test_types_eval() -> None:
 def test_types_sort_values() -> None:
     df = pd.DataFrame(data={"col1": [2, 1], "col2": [3, 4]})
     check(assert_type(df.sort_values("col1"), pd.DataFrame), pd.DataFrame)
-    check(
-        assert_type(df.sort_values("col1", ascending=False, inplace=True), None),
-        type(None),
-    )
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in DataFrame",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(df.sort_values("col1", ascending=False, inplace=True), None),
+            type(None),
+        )
     check(
         assert_type(
             df.sort_values(by=["col1", "col2"], ascending=[True, False]), pd.DataFrame

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -385,7 +385,13 @@ def test_types_sort_index() -> None:
         pd.Series,
         np.integer,
     )
-    assert assert_type(s.sort_index(ascending=False, inplace=True), None) is None
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in Series",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        assert assert_type(s.sort_index(ascending=False, inplace=True), None) is None
     check(
         assert_type(s.sort_index(kind="mergesort"), "pd.Series[int]"),
         pd.Series,
@@ -414,7 +420,13 @@ def test_types_sort_values() -> None:
         pd.Series,
         np.integer,
     )
-    assert assert_type(s.sort_values(inplace=True, kind="quicksort"), None) is None
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in Series",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        assert assert_type(s.sort_values(inplace=True, kind="quicksort"), None) is None
     check(
         assert_type(s.sort_values(na_position="last"), "pd.Series[int]"),
         pd.Series,


### PR DESCRIPTION
Deprecate inplace keyword in sort_values()/sort_index() methods (pandas-dev/pandas#66971).

- [x] Closes #1920
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
