### PR TITLE
TST: #1914 standardise fixture style for left operands in arithmetic tests

### DIFF
--- a/tests/indexes/bool/test_add.py
+++ b/tests/indexes/bool/test_add.py
@@ -3,6 +3,7 @@ from typing import assert_type
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import (
@@ -10,11 +11,15 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-# left operand
-left = pd.Index([True, True, False])
+
+@pytest.fixture
+def left() -> "pd.Index[bool]":
+    """Left operand"""
+    lo = pd.Index([True, True, False])
+    return check(assert_type(lo, "pd.Index[bool]"), pd.Index, np.bool_)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Index[bool]") -> None:
     """Test pd.Index[bool] + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -29,7 +34,7 @@ def test_add_py_scalar() -> None:
     check(assert_type(c + left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Index[bool]") -> None:
     """Test pd.Index[bool] + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -44,7 +49,7 @@ def test_add_py_sequence() -> None:
     check(assert_type(c + left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Index[bool]") -> None:
     """Test pd.Index[bool] + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -69,7 +74,7 @@ def test_add_numpy_array() -> None:
     )
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Index[bool]") -> None:
     """Test pd.Index[bool] + pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])

--- a/tests/indexes/bool/test_sub.py
+++ b/tests/indexes/bool/test_sub.py
@@ -6,6 +6,7 @@ from typing import (
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
@@ -13,10 +14,15 @@ from tests import (
 )
 from tests._typing import np_ndarray_int64
 
-left = pd.Index([True, True, False])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Index[bool]":
+    """Left operand"""
+    lo = pd.Index([True, True, False])
+    return check(assert_type(lo, "pd.Index[bool]"), pd.Index, np.bool_)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Index[bool]") -> None:
     """Test pd.Index[bool] - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -33,7 +39,7 @@ def test_sub_py_scalar() -> None:
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Index[bool]") -> None:
     """Test pd.Index[bool] - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -50,7 +56,7 @@ def test_sub_py_sequence() -> None:
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Index[bool]") -> None:
     """Test pd.Index[bool] - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -77,7 +83,7 @@ def test_sub_numpy_array() -> None:
     )
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Index[bool]") -> None:
     """Test pd.Index[bool] - pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])

--- a/tests/indexes/complex/test_add.py
+++ b/tests/indexes/complex/test_add.py
@@ -3,6 +3,7 @@ from typing import assert_type
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import (
@@ -10,11 +11,15 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-# left operand
-left = pd.Index([1j, 2j, 3j])
+
+@pytest.fixture
+def left() -> "pd.Index[complex]":
+    """Left operand"""
+    lo = pd.Index([1j, 2j, 3j])
+    return check(assert_type(lo, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Index[complex]") -> None:
     """Test pd.Index[complex] + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -29,7 +34,7 @@ def test_add_py_scalar() -> None:
     check(assert_type(c + left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Index[complex]") -> None:
     """Test pd.Index[complex] + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -44,7 +49,7 @@ def test_add_py_sequence() -> None:
     check(assert_type(c + left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Index[complex]") -> None:
     """Test pd.Index[complex] + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -71,7 +76,7 @@ def test_add_numpy_array() -> None:
     )
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Index[complex]") -> None:
     """Test pd.Index[complex] + pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])

--- a/tests/indexes/complex/test_sub.py
+++ b/tests/indexes/complex/test_sub.py
@@ -6,15 +6,20 @@ from typing import (
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import np_ndarray_int64
 
-# left operand
-left = pd.Index([1j, 2j, 3j])
+
+@pytest.fixture
+def left() -> "pd.Index[complex]":
+    """Left operand"""
+    lo = pd.Index([1j, 2j, 3j])
+    return check(assert_type(lo, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Index[complex]") -> None:
     """Test pd.Index[complex] - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -29,7 +34,7 @@ def test_sub_py_scalar() -> None:
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Index[complex]") -> None:
     """Test pd.Index[complex] - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -44,7 +49,7 @@ def test_sub_py_sequence() -> None:
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Index[complex]") -> None:
     """Test pd.Index[complex] - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -73,7 +78,7 @@ def test_sub_numpy_array() -> None:
     )
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Index[complex]") -> None:
     """Test pd.Index[complex] - pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])

--- a/tests/indexes/float/test_add.py
+++ b/tests/indexes/float/test_add.py
@@ -3,6 +3,7 @@ from typing import assert_type
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import (
@@ -10,11 +11,15 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-# left operand
-left = pd.Index([1.0, 2.0, 3.0])
+
+@pytest.fixture
+def left() -> "pd.Index[float]":
+    """Left operand"""
+    lo = pd.Index([1.0, 2.0, 3.0])
+    return check(assert_type(lo, "pd.Index[float]"), pd.Index, np.floating)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Index[float]") -> None:
     """Test pd.Index[float] + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -29,7 +34,7 @@ def test_add_py_scalar() -> None:
     check(assert_type(c + left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Index[float]") -> None:
     """Test pd.Index[float] + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -44,7 +49,7 @@ def test_add_py_sequence() -> None:
     check(assert_type(c + left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Index[float]") -> None:
     """Test pd.Index[float] + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -69,7 +74,7 @@ def test_add_numpy_array() -> None:
     )
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Index[float]") -> None:
     """Test pd.Index[float] + pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])

--- a/tests/indexes/float/test_sub.py
+++ b/tests/indexes/float/test_sub.py
@@ -6,15 +6,20 @@ from typing import (
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import np_ndarray_int64
 
-# left operand
-left = pd.Index([1.0, 2.0, 3.0])
+
+@pytest.fixture
+def left() -> "pd.Index[float]":
+    """Left operand"""
+    lo = pd.Index([1.0, 2.0, 3.0])
+    return check(assert_type(lo, "pd.Index[float]"), pd.Index, np.floating)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Index[float]") -> None:
     """Test pd.Index[float] - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -29,7 +34,7 @@ def test_sub_py_scalar() -> None:
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Index[float]") -> None:
     """Test pd.Index[float] - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -44,7 +49,7 @@ def test_sub_py_sequence() -> None:
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Index[float]") -> None:
     """Test pd.Index[float] - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -71,7 +76,7 @@ def test_sub_numpy_array() -> None:
     )
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Index[float]") -> None:
     """Test pd.Index[float] - pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])

--- a/tests/indexes/int/test_add.py
+++ b/tests/indexes/int/test_add.py
@@ -3,6 +3,7 @@ from typing import assert_type
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import (
@@ -10,11 +11,15 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-# left operand
-left = pd.Index([1, 2, 3])
+
+@pytest.fixture
+def left() -> "pd.Index[int]":
+    """Left operand"""
+    lo = pd.Index([1, 2, 3])
+    return check(assert_type(lo, "pd.Index[int]"), pd.Index, np.integer)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Index[int]") -> None:
     """Test pd.Index[int] + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -29,7 +34,7 @@ def test_add_py_scalar() -> None:
     check(assert_type(c + left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Index[int]") -> None:
     """Test pd.Index[int] + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -44,7 +49,7 @@ def test_add_py_sequence() -> None:
     check(assert_type(c + left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Index[int]") -> None:
     """Test pd.Index[int] + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -69,7 +74,7 @@ def test_add_numpy_array() -> None:
     )
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Index[int]") -> None:
     """Test pd.Index[int] + pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])

--- a/tests/indexes/int/test_sub.py
+++ b/tests/indexes/int/test_sub.py
@@ -6,15 +6,20 @@ from typing import (
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import np_ndarray_int64
 
-# left operand
-left = pd.Index([1, 2, 3])
+
+@pytest.fixture
+def left() -> "pd.Index[int]":
+    """Left operand"""
+    lo = pd.Index([1, 2, 3])
+    return check(assert_type(lo, "pd.Index[int]"), pd.Index, np.integer)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Index[int]") -> None:
     """Test pd.Index[int] - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -29,7 +34,7 @@ def test_sub_py_scalar() -> None:
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Index[int]") -> None:
     """Test pd.Index[int] - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -44,7 +49,7 @@ def test_sub_py_sequence() -> None:
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Index[int]") -> None:
     """Test pd.Index[int] - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -71,7 +76,7 @@ def test_sub_numpy_array() -> None:
     )
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Index[int]") -> None:
     """Test pd.Index[int] - pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])

--- a/tests/indexes/str/test_add.py
+++ b/tests/indexes/str/test_add.py
@@ -5,6 +5,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from pandas.errors import Pandas4Warning
 
@@ -18,10 +19,15 @@ from tests._typing import (
     np_ndarray_str,
 )
 
-left = pd.Index(["1", "23", "456"])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Index[str]":
+    """Left operand"""
+    lo = pd.Index(["1", "23", "456"])
+    return check(assert_type(lo, "pd.Index[str]"), pd.Index, str)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Index[str]") -> None:
     """Test pd.Index[str] + Python native 'scalar's"""
     i = 4
     r0 = "right"
@@ -35,7 +41,7 @@ def test_add_py_scalar() -> None:
     check(assert_type(r0 + left, "pd.Index[str]"), pd.Index, str)
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Index[str]") -> None:
     """Test pd.Index[str] + Python native sequences"""
     i = [3, 5, 8]
     r0 = ["a", "bc", "def"]
@@ -54,7 +60,7 @@ def test_add_py_sequence() -> None:
         check(assert_type(r1 + left, "pd.Index[str]"), pd.Index, str)
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Index[str]") -> None:
     """Test pd.Index[str] + numpy arrays"""
     i = np.array([3, 5, 8], np.int64)
     r0 = np.array(["a", "bc", "def"], np.str_)
@@ -74,7 +80,7 @@ def test_add_numpy_array() -> None:
     check(assert_type(r0 + left, np_ndarray_str), pd.Index, str)
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Index[str]") -> None:
     """Test pd.Index[str] + pandas Indexes"""
     i = pd.Index([3, 5, 8])
     r0 = pd.Index(["a", "bc", "def"])

--- a/tests/indexes/test_add.py
+++ b/tests/indexes/test_add.py
@@ -5,18 +5,22 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
     check,
 )
 
-# left operands
-left_i = pd.MultiIndex.from_tuples([(1,), (2,), (3,)]).levels[0]
-left_str = pd.MultiIndex.from_tuples([("1",), ("2",), ("3_",)]).levels[0]
+
+@pytest.fixture
+def left_i() -> pd.Index:
+    """Left operand"""
+    lo = pd.MultiIndex.from_tuples([(1,), (2,), (3,)]).levels[0]
+    return check(assert_type(lo, pd.Index), pd.Index)
 
 
-def test_add_i_py_scalar() -> None:
+def test_add_i_py_scalar(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -31,7 +35,7 @@ def test_add_i_py_scalar() -> None:
     check(assert_type(c + left_i, pd.Index), pd.Index)
 
 
-def test_add_i_py_sequence() -> None:
+def test_add_i_py_sequence(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -46,7 +50,7 @@ def test_add_i_py_sequence() -> None:
     check(assert_type(c + left_i, pd.Index), pd.Index)
 
 
-def test_add_i_numpy_array() -> None:
+def test_add_i_numpy_array(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -89,7 +93,7 @@ def test_add_i_numpy_array() -> None:
     )
 
 
-def test_add_i_pd_index() -> None:
+def test_add_i_pd_index(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) + pandas Indexes"""
     a = pd.MultiIndex.from_tuples([(1,), (2,), (3,)]).levels[0]
     b = pd.Index([True, False, True])
@@ -110,7 +114,7 @@ def test_add_i_pd_index() -> None:
     check(assert_type(c + left_i, pd.Index), pd.Index)
 
 
-def test_add_i_py_str() -> None:
+def test_add_i_py_str(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) + Python str"""
     s = "abc"
     midx = pd.MultiIndex.from_tuples([("a",)])

--- a/tests/indexes/test_sub.py
+++ b/tests/indexes/test_sub.py
@@ -5,17 +5,22 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
     check,
 )
 
-# left operand
-left_i = pd.MultiIndex.from_tuples([(1,), (2,), (3,)]).levels[0]
+
+@pytest.fixture
+def left_i() -> pd.Index:
+    """Left operand"""
+    lo = pd.MultiIndex.from_tuples([(1,), (2,), (3,)]).levels[0]
+    return check(assert_type(lo, pd.Index), pd.Index)
 
 
-def test_sub_i_py_scalar() -> None:
+def test_sub_i_py_scalar(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -30,7 +35,7 @@ def test_sub_i_py_scalar() -> None:
     check(assert_type(c - left_i, pd.Index), pd.Index)
 
 
-def test_sub_i_py_sequence() -> None:
+def test_sub_i_py_sequence(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -45,7 +50,7 @@ def test_sub_i_py_sequence() -> None:
     check(assert_type(c - left_i, pd.Index), pd.Index)
 
 
-def test_sub_i_numpy_array() -> None:
+def test_sub_i_numpy_array(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -88,7 +93,7 @@ def test_sub_i_numpy_array() -> None:
     )
 
 
-def test_sub_i_pd_index() -> None:
+def test_sub_i_pd_index(left_i: pd.Index) -> None:
     """Test pd.Index[Any] (int) - pandas Indexes"""
     a = pd.MultiIndex.from_tuples([(1,), (2,), (3,)]).levels[0]
     b = pd.Index([True, False, True])
@@ -109,7 +114,7 @@ def test_sub_i_pd_index() -> None:
     check(assert_type(c - left_i, pd.Index), pd.Index)
 
 
-def test_sub_str_py_str() -> None:
+def test_sub_str_py_str(left_i: pd.Index) -> None:
     """Test pd.Series[Any] (int) - Python str"""
     s = "abc"
 

--- a/tests/series/bool/test_add.py
+++ b/tests/series/bool/test_add.py
@@ -3,6 +3,7 @@ from typing import assert_type
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import (
@@ -10,10 +11,15 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-left = pd.Series([True, True, False])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[bool]":
+    """Left operand"""
+    lo = pd.Series([True, True, False])
+    return check(assert_type(lo, "pd.Series[bool]"), pd.Series, np.bool_)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -40,7 +46,7 @@ def test_add_py_scalar() -> None:
     )
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -67,7 +73,7 @@ def test_add_py_sequence() -> None:
     )
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -104,7 +110,7 @@ def test_add_numpy_array() -> None:
     )
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] + pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])
@@ -134,7 +140,7 @@ def test_add_pd_index() -> None:
     )
 
 
-def test_add_pd_series() -> None:
+def test_add_pd_series(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] + pandas Series"""
     b = pd.Series([True, False, True])
     i = pd.Series([2, 3, 5])

--- a/tests/series/bool/test_sub.py
+++ b/tests/series/bool/test_sub.py
@@ -6,6 +6,7 @@ from typing import (
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
@@ -13,10 +14,15 @@ from tests import (
 )
 from tests._typing import np_ndarray_int64
 
-left = pd.Series([True, True, False])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[bool]":
+    """Left operand"""
+    lo = pd.Series([True, True, False])
+    return check(assert_type(lo, "pd.Series[bool]"), pd.Series, np.bool_)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -47,7 +53,7 @@ def test_sub_py_scalar() -> None:
     )
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -78,7 +84,7 @@ def test_sub_py_sequence() -> None:
     )
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -119,7 +125,7 @@ def test_sub_numpy_array() -> None:
     )
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] - pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])
@@ -153,7 +159,7 @@ def test_sub_pd_index() -> None:
     )
 
 
-def test_sub_pd_series() -> None:
+def test_sub_pd_series(left: "pd.Series[bool]") -> None:
     """Test pd.Series[bool] - pandas Series"""
     b = pd.Series([True, False, True])
     i = pd.Series([2, 3, 5])

--- a/tests/series/complex/test_add.py
+++ b/tests/series/complex/test_add.py
@@ -3,6 +3,7 @@ from typing import assert_type
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import (
@@ -10,10 +11,15 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-left = pd.Series([1j, 2j, 3j])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[complex]":
+    """Left operand"""
+    lo = pd.Series([1j, 2j, 3j])
+    return check(assert_type(lo, "pd.Series[complex]"), pd.Series, np.complexfloating)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -46,7 +52,7 @@ def test_add_py_scalar() -> None:
     )
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -79,7 +85,7 @@ def test_add_py_sequence() -> None:
     )
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -124,7 +130,7 @@ def test_add_numpy_array() -> None:
     )
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] + pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])
@@ -160,7 +166,7 @@ def test_add_pd_index() -> None:
     )
 
 
-def test_add_pd_series() -> None:
+def test_add_pd_series(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] + pandas Series"""
     b = pd.Series([True, False, True])
     i = pd.Series([2, 3, 5])

--- a/tests/series/complex/test_sub.py
+++ b/tests/series/complex/test_sub.py
@@ -6,14 +6,20 @@ from typing import (
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import np_ndarray_int64
 
-left = pd.Series([1j, 2j, 3j])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[complex]":
+    """Left operand"""
+    lo = pd.Series([1j, 2j, 3j])
+    return check(assert_type(lo, "pd.Series[complex]"), pd.Series, np.complexfloating)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -46,7 +52,7 @@ def test_sub_py_scalar() -> None:
     )
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -79,7 +85,7 @@ def test_sub_py_sequence() -> None:
     )
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -126,7 +132,7 @@ def test_sub_numpy_array() -> None:
     )
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] - pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])
@@ -162,7 +168,7 @@ def test_sub_pd_index() -> None:
     )
 
 
-def test_sub_pd_series() -> None:
+def test_sub_pd_series(left: "pd.Series[complex]") -> None:
     """Test pd.Series[complex] - pandas Series"""
     b = pd.Series([True, False, True])
     i = pd.Series([2, 3, 5])

--- a/tests/series/float/test_add.py
+++ b/tests/series/float/test_add.py
@@ -3,6 +3,7 @@ from typing import assert_type
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import (
@@ -10,10 +11,15 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-left = pd.Series([1.0, 2.0, 3.0])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[float]":
+    """Left operand"""
+    lo = pd.Series([1.0, 2.0, 3.0])
+    return check(assert_type(lo, "pd.Series[float]"), pd.Series, np.floating)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -40,7 +46,7 @@ def test_add_py_scalar() -> None:
     )
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -67,7 +73,7 @@ def test_add_py_sequence() -> None:
     )
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -104,7 +110,7 @@ def test_add_numpy_array() -> None:
     )
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] + pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])
@@ -134,7 +140,7 @@ def test_add_pd_index() -> None:
     )
 
 
-def test_add_pd_series() -> None:
+def test_add_pd_series(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] + pandas Series"""
     b = pd.Series([True, False, True])
     i = pd.Series([2, 3, 5])

--- a/tests/series/float/test_sub.py
+++ b/tests/series/float/test_sub.py
@@ -6,14 +6,20 @@ from typing import (
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import np_ndarray_int64
 
-left = pd.Series([1.0, 2.0, 3.0])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[float]":
+    """Left operand"""
+    lo = pd.Series([1.0, 2.0, 3.0])
+    return check(assert_type(lo, "pd.Series[float]"), pd.Series, np.floating)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -40,7 +46,7 @@ def test_sub_py_scalar() -> None:
     )
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -67,7 +73,7 @@ def test_sub_py_sequence() -> None:
     )
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -106,7 +112,7 @@ def test_sub_numpy_array() -> None:
     )
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] - pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])
@@ -136,7 +142,7 @@ def test_sub_pd_index() -> None:
     )
 
 
-def test_sub_pd_series() -> None:
+def test_sub_pd_series(left: "pd.Series[float]") -> None:
     """Test pd.Series[float] - pandas Series"""
     b = pd.Series([True, False, True])
     i = pd.Series([2, 3, 5])

--- a/tests/series/int/test_add.py
+++ b/tests/series/int/test_add.py
@@ -3,6 +3,7 @@ from typing import assert_type
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import (
@@ -10,10 +11,15 @@ from tests._typing import (
     np_ndarray_int64,
 )
 
-left = pd.Series([1, 2, 3])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[int]":
+    """Left operand"""
+    lo = pd.Series([1, 2, 3])
+    return check(assert_type(lo, "pd.Series[int]"), pd.Series, np.integer)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -40,7 +46,7 @@ def test_add_py_scalar() -> None:
     )
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] + Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -67,7 +73,7 @@ def test_add_py_sequence() -> None:
     )
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -104,7 +110,7 @@ def test_add_numpy_array() -> None:
     )
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] + pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])
@@ -134,7 +140,7 @@ def test_add_pd_index() -> None:
     )
 
 
-def test_add_pd_series() -> None:
+def test_add_pd_series(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] + pandas Series"""
     b = pd.Series([True, False, True])
     i = pd.Series([2, 3, 5])

--- a/tests/series/int/test_sub.py
+++ b/tests/series/int/test_sub.py
@@ -6,14 +6,20 @@ from typing import (
 import numpy as np
 from numpy import typing as npt  # noqa: F401
 import pandas as pd
+import pytest
 
 from tests import check
 from tests._typing import np_ndarray_int64
 
-left = pd.Series([1, 2, 3])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[int]":
+    """Left operand"""
+    lo = pd.Series([1, 2, 3])
+    return check(assert_type(lo, "pd.Series[int]"), pd.Series, np.integer)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -40,7 +46,7 @@ def test_sub_py_scalar() -> None:
     )
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -67,7 +73,7 @@ def test_sub_py_sequence() -> None:
     )
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -106,7 +112,7 @@ def test_sub_numpy_array() -> None:
     )
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] - pandas Indexes"""
     b = pd.Index([True, False, True])
     i = pd.Index([2, 3, 5])
@@ -136,7 +142,7 @@ def test_sub_pd_index() -> None:
     )
 
 
-def test_sub_pd_series() -> None:
+def test_sub_pd_series(left: "pd.Series[int]") -> None:
     """Test pd.Series[int] - pandas Series"""
     b = pd.Series([True, False, True])
     i = pd.Series([2, 3, 5])

--- a/tests/series/str/test_add.py
+++ b/tests/series/str/test_add.py
@@ -5,6 +5,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from pandas.errors import Pandas4Warning
 
@@ -18,10 +19,15 @@ from tests._typing import (
     np_ndarray_str,
 )
 
-left = pd.Series(["1", "23", "456"])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[str]":
+    """Left operand"""
+    lo = pd.Series(["1", "23", "456"])
+    return check(assert_type(lo, "pd.Series[str]"), pd.Series, str)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Series[str]") -> None:
     """Test pd.Series[str] + Python native 'scalar's"""
     i = 4
     r0 = "right"
@@ -43,7 +49,7 @@ def test_add_py_scalar() -> None:
     check(assert_type(left.radd(r0), "pd.Series[str]"), pd.Series, str)
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Series[str]") -> None:
     """Test pd.Series[str] + Python native sequences"""
     i = [3, 5, 8]
     r0 = ["a", "bc", "def"]
@@ -92,7 +98,7 @@ def test_add_py_sequence() -> None:
         check(assert_type(left.radd(r1), "pd.Series[str]"), pd.Series, str)
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Series[str]") -> None:
     """Test pd.Series[str] + numpy arrays"""
     i = np.array([3, 5, 8], np.int64)
     r0 = np.array(["a", "bc", "def"], np.str_)
@@ -120,7 +126,7 @@ def test_add_numpy_array() -> None:
     check(assert_type(left.radd(r0), "pd.Series[str]"), pd.Series, str)
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Series[str]") -> None:
     """Test pd.Series[str] + pandas Indexes"""
     i = pd.Index([3, 5, 8])
     r0 = pd.Index(["a", "bc", "def"])
@@ -142,7 +148,7 @@ def test_add_pd_index() -> None:
     check(assert_type(left.radd(r0), "pd.Series[str]"), pd.Series, str)
 
 
-def test_add_pd_series() -> None:
+def test_add_pd_series(left: "pd.Series[str]") -> None:
     """Test pd.Series[str] + pandas Series"""
     i = pd.Series([3, 5, 8])
     r0 = pd.Series(["a", "bc", "def"])

--- a/tests/series/test_add.py
+++ b/tests/series/test_add.py
@@ -6,15 +6,19 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from tests import check
 
-# left operands
-left_i = pd.DataFrame({"a": [1, 2, 3]})["a"]
-left_str = pd.DataFrame({"a": ["1", "2", "3_"]})["a"]
+
+@pytest.fixture
+def left_i() -> pd.Series:
+    """Left operand"""
+    lo = pd.DataFrame({"a": [1, 2, 3]})["a"]
+    return check(assert_type(lo, pd.Series), pd.Series)
 
 
-def test_add_i_py_scalar() -> None:
+def test_add_i_py_scalar(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) + Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -39,7 +43,7 @@ def test_add_i_py_scalar() -> None:
     check(assert_type(left_i.radd(c), pd.Series), pd.Series)
 
 
-def test_add_i_py_sequence() -> None:
+def test_add_i_py_sequence(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) + Python native sequences"""
     # mypy believe it is already list[Any], whereas pyright gives list[bool | int | complex]
     a = cast(list[Any], [True, 3, 5j])  # type: ignore[redundant-cast]
@@ -73,7 +77,7 @@ def test_add_i_py_sequence() -> None:
     check(assert_type(left_i.radd(c), pd.Series), pd.Series)
 
 
-def test_add_i_numpy_array() -> None:
+def test_add_i_numpy_array(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) + numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -126,7 +130,7 @@ def test_add_i_numpy_array() -> None:
     check(assert_type(left_i.radd(c), pd.Series), pd.Series)
 
 
-def test_add_i_pd_index() -> None:
+def test_add_i_pd_index(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) + pandas Indexes"""
     a = pd.MultiIndex.from_tuples([(1,), (2,), (3,)]).levels[0]
     b = pd.Index([True, False, True])
@@ -159,7 +163,7 @@ def test_add_i_pd_index() -> None:
     check(assert_type(left_i.radd(c), pd.Series), pd.Series)
 
 
-def test_add_i_pd_series() -> None:
+def test_add_i_pd_series(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) + pandas Series"""
     a = pd.DataFrame({"a": [1, 2, 3]})["a"]
     b = pd.Series([True, False, True])

--- a/tests/series/test_sub.py
+++ b/tests/series/test_sub.py
@@ -9,6 +9,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
@@ -17,13 +18,29 @@ from tests import (
 
 anchor = datetime(2025, 8, 18)
 
-# left operands
-left_i = pd.DataFrame({"a": [1, 2, 3]})["a"]
-left_ts = pd.DataFrame({"a": [anchor + timedelta(hours=h + 1) for h in range(3)]})["a"]
-left_td = pd.DataFrame({"a": [timedelta(hours=h, minutes=1) for h in range(3)]})["a"]
+
+@pytest.fixture
+def left_i() -> pd.Series:
+    """Left operand"""
+    lo = pd.DataFrame({"a": [1, 2, 3]})["a"]
+    return check(assert_type(lo, pd.Series), pd.Series)
 
 
-def test_sub_i_py_scalar() -> None:
+@pytest.fixture
+def left_ts() -> pd.Series:
+    """Left operand"""
+    lo = pd.DataFrame({"a": [anchor + timedelta(hours=h + 1) for h in range(3)]})["a"]
+    return check(assert_type(lo, pd.Series), pd.Series)
+
+
+@pytest.fixture
+def left_td() -> pd.Series:
+    """Left operand"""
+    lo = pd.DataFrame({"a": [timedelta(hours=h, minutes=1) for h in range(3)]})["a"]
+    return check(assert_type(lo, pd.Series), pd.Series)
+
+
+def test_sub_i_py_scalar(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) - Python native scalars"""
     b, i, f, c = True, 1, 1.0, 1j
 
@@ -48,7 +65,7 @@ def test_sub_i_py_scalar() -> None:
     check(assert_type(left_i.rsub(c), pd.Series), pd.Series)
 
 
-def test_sub_i_py_sequence() -> None:
+def test_sub_i_py_sequence(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) - Python native sequences"""
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
@@ -73,7 +90,7 @@ def test_sub_i_py_sequence() -> None:
     check(assert_type(left_i.rsub(c), pd.Series), pd.Series)
 
 
-def test_sub_i_numpy_array() -> None:
+def test_sub_i_numpy_array(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) - numpy arrays"""
     b = np.array([True, False, True], np.bool_)
     i = np.array([2, 3, 5], np.int64)
@@ -126,7 +143,7 @@ def test_sub_i_numpy_array() -> None:
     check(assert_type(left_i.rsub(c), pd.Series), pd.Series)
 
 
-def test_sub_i_pd_index() -> None:
+def test_sub_i_pd_index(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) - pandas Indexes"""
     a = pd.MultiIndex.from_tuples([(1,), (2,), (3,)]).levels[0]
     b = pd.Index([True, False, True])
@@ -159,7 +176,7 @@ def test_sub_i_pd_index() -> None:
     check(assert_type(left_i.rsub(c), pd.Series), pd.Series)
 
 
-def test_sub_i_pd_series() -> None:
+def test_sub_i_pd_series(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) - pandas Series"""
     a = pd.DataFrame({"a": [1, 2, 3]})["a"]
     b = pd.Series([True, False, True])
@@ -192,7 +209,7 @@ def test_sub_i_pd_series() -> None:
     check(assert_type(left_i.rsub(c), pd.Series), pd.Series)
 
 
-def test_sub_ts_py_datetime() -> None:
+def test_sub_ts_py_datetime(left_ts: pd.Series, left_td: pd.Series) -> None:
     """Test pd.Series[Any] (Timestamp | Timedelta) - Python native datetime"""
     s = anchor
     a = [s + timedelta(minutes=m) for m in range(3)]
@@ -237,7 +254,7 @@ def test_sub_ts_py_datetime() -> None:
     check(assert_type(left_td.rsub(a), pd.Series), pd.Series, pd.Timestamp)
 
 
-def test_sub_ts_numpy_datetime() -> None:
+def test_sub_ts_numpy_datetime(left_ts: pd.Series, left_td: pd.Series) -> None:
     """Test pd.Series[Any] (Timestamp) - numpy datetime(s)"""
     s = np.datetime64(anchor)
     a = np.array([s + np.timedelta64(m, "m") for m in range(3)], np.datetime64)
@@ -290,7 +307,7 @@ def test_sub_ts_numpy_datetime() -> None:
     check(assert_type(left_td.rsub(a), pd.Series), pd.Series, pd.Timestamp)
 
 
-def test_sub_ts_pd_datetime() -> None:
+def test_sub_ts_pd_datetime(left_ts: pd.Series, left_td: pd.Series) -> None:
     """Test pd.Series[Any] (Timestamp) - Pandas datetime(s)"""
     s = pd.Timestamp(anchor)
     a = pd.Series([s + pd.Timedelta(minutes=m) for m in range(3)])
@@ -326,7 +343,7 @@ def test_sub_ts_pd_datetime() -> None:
     check(assert_type(left_td.rsub(a), pd.Series), pd.Series, pd.Timestamp)
 
 
-def test_sub_str_py_str() -> None:
+def test_sub_str_py_str(left_i: pd.Series) -> None:
     """Test pd.Series[Any] (int) - Python str"""
     s = "abc"
 

--- a/tests/series/timedelta/test_add.py
+++ b/tests/series/timedelta/test_add.py
@@ -6,6 +6,7 @@ from typing import assert_type
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
@@ -16,10 +17,15 @@ from tests._typing import (
     np_ndarray_td,
 )
 
-left = pd.Series([pd.Timedelta(1, "s")])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[pd.Timedelta]":
+    """Left operand"""
+    lo = pd.Series([pd.Timedelta(1, "s")])
+    return check(assert_type(lo, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] + Python native scalars"""
     s = datetime(2025, 8, 20)
     d = timedelta(seconds=1)
@@ -37,7 +43,7 @@ def test_add_py_scalar() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_add_numpy_scalar() -> None:
+def test_add_numpy_scalar(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] + numpy scalars"""
     s = np.datetime64("2025-08-20")
     d = np.timedelta64(1, "s")
@@ -55,7 +61,7 @@ def test_add_numpy_scalar() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_add_pd_scalar() -> None:
+def test_add_pd_scalar(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] + pandas scalars"""
     s = pd.Timestamp("2025-08-20")
     d = pd.Timedelta(seconds=1)
@@ -73,7 +79,7 @@ def test_add_pd_scalar() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] + Python native sequences"""
     s = [datetime(2025, 8, 20)]
     d = [timedelta(seconds=1)]
@@ -94,7 +100,7 @@ def test_add_py_sequence() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] + numpy arrays"""
     s = np.array([np.datetime64("2025-08-20")], np.datetime64)
     d = np.array([np.timedelta64(1, "s")], np.timedelta64)
@@ -115,7 +121,7 @@ def test_add_numpy_array() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] + pandas Indexes"""
     s = pd.Index([pd.Timestamp("2025-08-20")])
     d = pd.Index([pd.Timedelta(seconds=1)])
@@ -133,7 +139,7 @@ def test_add_pd_index() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_add_pd_series() -> None:
+def test_add_pd_series(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] + pandas Series"""
     s = pd.Series([pd.Timestamp("2025-08-20")])
     d = pd.Series([pd.Timedelta(seconds=1)])

--- a/tests/series/timedelta/test_sub.py
+++ b/tests/series/timedelta/test_sub.py
@@ -9,6 +9,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
@@ -19,10 +20,15 @@ from tests._typing import (
     np_ndarray_td,
 )
 
-left = pd.Series([pd.Timedelta(1, "s")])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[pd.Timedelta]":
+    """Left operand"""
+    lo = pd.Series([pd.Timedelta(1, "s")])
+    return check(assert_type(lo, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] - Python native scalars"""
     s = datetime(2025, 8, 20)
     d = timedelta(seconds=1)
@@ -42,7 +48,7 @@ def test_sub_py_scalar() -> None:
     check(assert_type(left.rsub(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_sub_numpy_scalar() -> None:
+def test_sub_numpy_scalar(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] - numpy scalars"""
     s = np.datetime64("2025-08-20")
     d = np.timedelta64(1, "s")
@@ -62,7 +68,7 @@ def test_sub_numpy_scalar() -> None:
     check(assert_type(left.rsub(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_sub_pd_scalar() -> None:
+def test_sub_pd_scalar(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] - pandas scalars"""
     s = pd.Timestamp("2025-08-20")
     d = pd.Timedelta(seconds=1)
@@ -82,7 +88,7 @@ def test_sub_pd_scalar() -> None:
     check(assert_type(left.rsub(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] - Python native sequences"""
     s = [datetime(2025, 8, 20)]
     d = [timedelta(seconds=1)]
@@ -103,7 +109,7 @@ def test_sub_py_sequence() -> None:
     check(assert_type(left.rsub(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] - numpy arrays"""
     s = np.array([np.datetime64("2025-08-20")], np.datetime64)
     d = np.array([np.timedelta64(1, "s")], np.timedelta64)
@@ -126,7 +132,7 @@ def test_sub_numpy_array() -> None:
     check(assert_type(left.rsub(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] - pandas Indexes"""
     s = pd.Index([pd.Timestamp("2025-08-20")])
     d = pd.Index([pd.Timedelta(seconds=1)])
@@ -146,7 +152,7 @@ def test_sub_pd_index() -> None:
     check(assert_type(left.rsub(d), "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
 
 
-def test_sub_pd_series() -> None:
+def test_sub_pd_series(left: "pd.Series[pd.Timedelta]") -> None:
     """Test pd.Series[pd.Timedelta] - pandas Series"""
     s = pd.Series([pd.Timestamp("2025-08-20")])
     d = pd.Series([pd.Timedelta(seconds=1)])

--- a/tests/series/timestamp/test_add.py
+++ b/tests/series/timestamp/test_add.py
@@ -9,6 +9,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
@@ -19,10 +20,15 @@ from tests._typing import (
     np_ndarray_td,
 )
 
-left = pd.Series([pd.Timestamp(2025, 8, 20)])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[pd.Timestamp]":
+    """Left operand"""
+    lo = pd.Series([pd.Timestamp(2025, 8, 20)])
+    return check(assert_type(lo, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
 
-def test_add_py_scalar() -> None:
+def test_add_py_scalar(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] + Python native scalars"""
     s = datetime(2025, 8, 20)
     d = timedelta(seconds=1)
@@ -44,7 +50,7 @@ def test_add_py_scalar() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
 
-def test_add_numpy_scalar() -> None:
+def test_add_numpy_scalar(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] + numpy scalars"""
     s = np.datetime64("2025-08-20")
     d = np.timedelta64(1, "s")
@@ -66,7 +72,7 @@ def test_add_numpy_scalar() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
 
-def test_add_pd_scalar() -> None:
+def test_add_pd_scalar(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] + pandas scalars"""
     s = pd.Timestamp("2025-08-20")
     d = pd.Timedelta(seconds=1)
@@ -88,7 +94,7 @@ def test_add_pd_scalar() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
 
-def test_add_py_sequence() -> None:
+def test_add_py_sequence(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] + Python native sequences"""
     s = [datetime(2025, 8, 20)]
     d = [timedelta(seconds=1)]
@@ -110,7 +116,7 @@ def test_add_py_sequence() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
 
-def test_add_numpy_array() -> None:
+def test_add_numpy_array(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] + numpy arrays"""
     s = np.array([np.datetime64("2025-08-20")], np.datetime64)
     d = np.array([np.timedelta64(1, "s")], np.timedelta64)
@@ -137,7 +143,7 @@ def test_add_numpy_array() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
 
-def test_add_pd_index() -> None:
+def test_add_pd_index(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] + pandas Indexes"""
     s = pd.Index([pd.Timestamp("2025-08-20")])
     d = pd.Index([pd.Timedelta(seconds=1)])
@@ -159,7 +165,7 @@ def test_add_pd_index() -> None:
     check(assert_type(left.radd(d), "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
 
-def test_add_pd_series() -> None:
+def test_add_pd_series(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] + pandas Series"""
     s = pd.Series([pd.Timestamp("2025-08-20")])
     d = pd.Series([pd.Timedelta(seconds=1)])

--- a/tests/series/timestamp/test_sub.py
+++ b/tests/series/timestamp/test_sub.py
@@ -6,6 +6,7 @@ from typing import assert_type
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
@@ -16,10 +17,15 @@ from tests._typing import (
     np_ndarray_td,
 )
 
-left = pd.Series([pd.Timestamp(2025, 8, 20)])  # left operand
+
+@pytest.fixture
+def left() -> "pd.Series[pd.Timestamp]":
+    """Left operand"""
+    lo = pd.Series([pd.Timestamp(2025, 8, 20)])
+    return check(assert_type(lo, "pd.Series[pd.Timestamp]"), pd.Series, pd.Timestamp)
 
 
-def test_sub_py_scalar() -> None:
+def test_sub_py_scalar(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] - Python native scalars"""
     s = datetime(2025, 8, 20)
     d = timedelta(seconds=1)
@@ -39,7 +45,7 @@ def test_sub_py_scalar() -> None:
         left.rsub(d)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
-def test_sub_numpy_scalar() -> None:
+def test_sub_numpy_scalar(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] - numpy scalars"""
     s = np.datetime64("2025-08-20")
     d = np.timedelta64(1, "s")
@@ -59,7 +65,7 @@ def test_sub_numpy_scalar() -> None:
         left.rsub(d)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
-def test_sub_pd_scalar() -> None:
+def test_sub_pd_scalar(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] - pandas scalars"""
     s = pd.Timestamp("2025-08-20")
     d = pd.Timedelta(seconds=1)
@@ -79,7 +85,7 @@ def test_sub_pd_scalar() -> None:
         left.rsub(d)  # type: ignore[call-overload] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
-def test_sub_py_sequence() -> None:
+def test_sub_py_sequence(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] - Python native sequences"""
     s = [datetime(2025, 8, 20)]
     d = [timedelta(seconds=1)]
@@ -101,7 +107,7 @@ def test_sub_py_sequence() -> None:
         left.rsub(d)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
-def test_sub_numpy_array() -> None:
+def test_sub_numpy_array(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] - numpy arrays"""
     s = np.array([np.datetime64("2025-08-20")], np.datetime64)
     d = np.array([np.timedelta64(1, "s")], np.timedelta64)
@@ -124,7 +130,7 @@ def test_sub_numpy_array() -> None:
         left.rsub(d)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
-def test_sub_pd_index() -> None:
+def test_sub_pd_index(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] - pandas Indexes"""
     s = pd.Index([pd.Timestamp("2025-08-20")])
     d = pd.Index([pd.Timedelta(seconds=1)])
@@ -144,7 +150,7 @@ def test_sub_pd_index() -> None:
         left.rsub(d)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType,reportCallIssue] # pyrefly: ignore[no-matching-overload]
 
 
-def test_sub_pd_series() -> None:
+def test_sub_pd_series(left: "pd.Series[pd.Timestamp]") -> None:
     """Test pd.Series[pd.Timestamp] - pandas Series"""
     s = pd.Series([pd.Timestamp("2025-08-20")])
     d = pd.Series([pd.Timedelta(seconds=1)])


### PR DESCRIPTION
- [x] Towards #1914 
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
