### PR TITLE
TST: ignore ty assert_type failure in Series.quantile

### DIFF
--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -665,7 +665,13 @@ def test_types_quantile() -> None:
     )
     check(assert_type(a.quantile(0.75), np.floating), np.floating)
     check(assert_type(a.quantile(), np.floating), np.floating)
-    check(assert_type(a.quantile(interpolation="nearest"), np.floating), np.floating)
+    # TODO: remove the ignore astral-sh/ty#4055
+    check(
+        assert_type(  # ty: ignore[type-assertion-failure]
+            a.quantile(interpolation="nearest"), np.floating
+        ),
+        np.floating,
+    )
 
 
 def test_types_clip() -> None:


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Add `# ty: ignore[type-assertion-failure]` for `a.quantile(interpolation="nearest")` referencing astral-sh/ty#4055 where `ty` infers `Unknown` on `Series[Any]`.

Co-authored-by: Antigravity AI <bot@antigravity.dev>