### PR TITLE
TST:  #1925 nightly expects `Pandas4Warning` for `DataFrame.query`/`eval` with `inplace`

### DIFF
--- a/tests/frame/test_frame.py
+++ b/tests/frame/test_frame.py
@@ -547,7 +547,16 @@ def test_types_set_index() -> None:
 def test_types_query() -> None:
     df = pd.DataFrame(data={"col1": [1, 2, 3, 4], "col2": [3, 0, 1, 7]})
     check(assert_type(df.query("col1 > col2"), pd.DataFrame), pd.DataFrame)
-    check(assert_type(df.query("col1 % col2 == 0", inplace=True), None), type(None))
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in DataFrame",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(df.query("col1 % col2 == 0", inplace=True), None),
+            type(None),
+        )
 
 
 def test_types_query_kwargs() -> None:
@@ -558,19 +567,42 @@ def test_types_query_kwargs() -> None:
         ),
         pd.DataFrame,
     )
-    check(
-        assert_type(
-            df.query("col1 > col2", parser="pandas", engine="numexpr", inplace=True),
-            None,
-        ),
-        type(None),
-    )
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in DataFrame",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(
+                df.query(
+                    "col1 > col2", parser="pandas", engine="numexpr", inplace=True
+                ),
+                None,
+            ),
+            type(None),
+        )
 
 
 def test_types_eval() -> None:
     df = pd.DataFrame(data={"col1": [1, 2, 3, 4], "col2": [3, 0, 1, 7]})
-    check(assert_type(df.eval("E = col1 > col2", inplace=True), None), type(None))
-    check(assert_type(df.eval("C = col1 % col2 == 0", inplace=True), None), type(None))
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in DataFrame",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(assert_type(df.eval("E = col1 > col2", inplace=True), None), type(None))
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in DataFrame",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(df.eval("C = col1 % col2 == 0", inplace=True), None),
+            type(None),
+        )
     check(
         assert_type(
             df.eval("E = col1 > col2"), Scalar | np_ndarray | pd.DataFrame | pd.Series


### PR DESCRIPTION
TST: expect `Pandas4Warning` for `DataFrame.query`/`DataFrame.eval` `inplace`.

- [x] Propagates pandas-dev/pandas#66977
- [x] Tests added (Please use `assert_type()` to assert the type of any return value)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

<!--
HIDDEN AGENT NOTES (not rendered by GitHub)

Failure
- Run: https://github.com/pandas-dev/pandas-stubs/actions/runs/33255298355
- Job: nightly (id 99107825344), step "Run pytest (against pandas nightly)".
- Result: 3 failed, 3363 passed, 5 skipped.
    FAILED tests/frame/test_frame.py::test_types_query
    FAILED tests/frame/test_frame.py::test_types_query_kwargs
    FAILED tests/frame/test_frame.py::test_types_eval
- Error: pandas.errors.Pandas4Warning: The inplace keyword in DataFrame.query
  is deprecated and will be removed in a future version. See PDEP-8 ...
  (same for DataFrame.eval).
- Nightly pandas installed by CI: pandas-3.1.0.dev0+1684.g9aeb2d9626
  (from https://pypi.anaconda.org/scientific-python-nightly-wheels/simple).

Root cause
- pandas-dev/pandas#66977 (merged 2026-08-27) deprecates the `inplace`
  keyword in DataFrame.query()/DataFrame.eval().
- pandas-stubs pyproject.toml has filterwarnings = ["error"], so any
  warning becomes a test failure.
- The three tests call query/eval with inplace=True with no warning
  expectation, so the new Pandas4Warning fails them.
- Hypothesis was already posted in pandas-stubs#1925 comment 5457652870
  pointing to pandas-dev/pandas#66977.

Fix
- Wrap each inplace=True call in
  pytest_warns_bounded(Pandas4Warning, "The inplace keyword in DataFrame",
  lower="3.0.99", upper="3.99").
- Mirrors the earlier fix in PR #1922 for pandas-dev/pandas#66971
  (sort_values/sort_index inplace deprecation).
- pytest_warns_bounded (tests/__init__.py) is version-conditional: it only
  expects the warning for 3.0.99 < pandas < 3.99, so released pandas 3.0.x
  tests still pass unchanged.
- Tests-only change in tests/frame/test_frame.py. Stub overloads in
  pandas-stubs/core/frame.pyi are unchanged; mypy_nightly / pyrefly_all /
  ty_all were already green in the failed run.

Validation
- poetry run poe style
- poetry run poe pytest --nightly  -> 3364 passed, 6 skipped
- poetry run poe test_all

Reproduce later
- Download job logs with:
  gh api repos/pandas-dev/pandas-stubs/actions/jobs/<job_id>/logs
  (returns raw text with ANSI escapes); search for FAILED / Pandas4Warning.
-->
