### PR TITLE
DOC: AGENTS.md conventions — citation rules, 4-checker paradigm, PR body policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ dmypy.json
 
 # duplication of stub specific objects upon testing
 tests/_typing.pyi
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -141,4 +141,3 @@ dmypy.json
 
 # duplication of stub specific objects upon testing
 tests/_typing.pyi
-

--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,3 @@ dmypy.json
 # duplication of stub specific objects upon testing
 tests/_typing.pyi
 
-# macOS
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -141,4 +141,6 @@ dmypy.json
 
 # duplication of stub specific objects upon testing
 tests/_typing.pyi
+
+# macOS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,10 @@ When generating documentation or writing PR descriptions, format all GitHub refe
   - `Co-authored-by: claude-opus-4-20250514 <noreply@anthropic.com>`
   - `Co-authored-by: GitHub Copilot <noreply@github.com>`
   - `Co-authored-by: Antigravity AI <noreply@google.com>`
-- **PR body — visible and collapsible text**:
-  - *Visible text* (for human reviewers): concise summary, checklist, links. Humans read the rendered page.
-  - *Collapsible text* (for AI agents): place comprehensive implementation plans or technical notes inside a `<details><summary>AI Implementation Plan</summary>` block at the bottom of the body. This keeps the PR clean for humans but accessible if they want to read it, while agents can read it via the raw body.
-  - Rules: never put machine-only detail in the visible text; never hide information a human reviewer needs.
+- **PR body — concise for humans, comprehensive for agents**:
+  - Humans read the rendered page: lead with a concise summary, checklist, and links.
+  - AI agents read the raw body and can consume far more detail than a human reviewer wants to scroll through. Put a comprehensive implementation record at the bottom of the body inside a `<details><summary>AI Implementation Plan</summary>` block: motivation, experiments and attempts (including failures), caveats, outcome, out-of-scope items, and a to-do list. This information lives in a developer's head; an AI agent can write it down cheaply, and later agents (e.g. pandas-dev/pandas-stubs#1926 sub-PRs) can pick it up without re-deriving it. This follows the evidence-traceability direction of arXiv:2604.24658 without claiming ARA compliance.
+  - Rules: never put machine-only detail in the visible text; never hide information a human reviewer needs. The `<details>` block stays visible when expanded, so both audiences keep full access.
 - **Splitting exceptionally large PRs**: If a PR is massive, split it into small, individually reviewable sub-PRs. Each sub-PR body should start with `- [x] Towards pandas-dev/pandas-stubs#<parent>`.
 
 ## Decision Heuristics
@@ -54,7 +54,7 @@ When designing stubs and tests:
 
 When an error is expected to raise (invalid operations):
 
-1. **Design stubs** to return `Never` or cause type checker errors for invalid usage.
+1. **Design stubs** to cause type checker errors for invalid usage. Return `Never` only when a direct error cannot be expressed.
 2. **In tests**, protect invalid operations with `if TYPE_CHECKING_INVALID_USAGE:` instead of `with pytest.raises(...)`.
 3. Add the canonical multi-checker ignore comment sequence.
 
@@ -136,6 +136,15 @@ if TYPE_CHECKING_INVALID_USAGE:
 ```
 
 This applies to any expression that would trigger warnings about unused results (comparisons, arithmetic operations, etc.).
+
+### Version-conditional runtime warnings
+
+Use the `pytest_warns_bounded` / `pytest_warns_conditioned` helpers from `tests/__init__.py` when a runtime warning only exists in a certain pandas (or Python) version range, so tests pass on all supported versions (pandas-dev/pandas-stubs#1927, pandas-dev/pandas-stubs#1802):
+
+```python
+with pytest_warns_bounded(UserWarning, match="foo", lower="1.2.99", upper="1.5.99"):
+    ...
+```
 
 See `docs/philosophy.md` sections "Testing the Type Stubs" and "Narrow vs. Wide Arguments" for full details.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ When generating documentation or writing PR descriptions, format all GitHub refe
   - `Co-authored-by: gpt-5.6-terra <noreply@openai.com>`
   - `Co-authored-by: claude-opus-4-20250514 <noreply@anthropic.com>`
   - `Co-authored-by: GitHub Copilot <noreply@github.com>`
-  - `Co-authored-by: Antigravity AI <noreply@google.com>`
+  - `Co-authored-by: Gemini 3.1 Pro <noreply@google.com>`
 - **Splitting exceptionally large PRs**: If a PR is massive, split it into small, individually reviewable sub-PRs. Each sub-PR body should start with `- [x] Towards pandas-dev/pandas-stubs#<parent>`.
 
 ## Decision Heuristics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,12 @@ When generating documentation or writing PR descriptions, format all GitHub refe
 
 ## PR and Commit Conventions
 
-- **Commit signatures**: When AI generates commits, add a `Co-authored-by:` trailer naming the actual model or tool. Finding official emails can be tricky, so use these standard templates for popular agents:
-  - `Co-authored-by: Antigravity AI <bot@antigravity.dev>`
-  - `Co-authored-by: DeepCode <bot@deepcode.ai>`
+- **Commit signatures**: When AI generates commits, add a `Co-authored-by:` trailer naming the actual model or tool. Prefer the exact model name when known; use the tool name only when the model is not disclosed. Use the provider's official no-reply address:
+  - `Co-authored-by: deepseek-v4-pro <noreply@deepseek.com>`
+  - `Co-authored-by: gpt-5.6-terra <noreply@openai.com>`
+  - `Co-authored-by: claude-opus-4-20250514 <noreply@anthropic.com>`
   - `Co-authored-by: GitHub Copilot <noreply@github.com>`
-  - `Co-authored-by: OpenAI Codex <noreply@openai.com>`
-- **Emojis in PR Titles**: Consider adding an emoji to the PR title (e.g., 🤖 or 🪄) as a fun, immediate signal to maintainers that AI assisted with the PR.
+  - `Co-authored-by: Antigravity AI <noreply@google.com>`
 - **PR body — visible and collapsible text**:
   - *Visible text* (for human reviewers): concise summary, checklist, links. Humans read the rendered page.
   - *Collapsible text* (for AI agents): place comprehensive implementation plans or technical notes inside a `<details><summary>AI Implementation Plan</summary>` block at the bottom of the body. This keeps the PR clean for humans but accessible if they want to read it, while agents can read it via the raw body.
@@ -61,21 +61,29 @@ When an error is expected to raise (invalid operations):
 **Example 1: Standard invalid operations** (tested in `tests/scalars/timedelta/test_arithmetic.py`):
 
 ```python
+a = pd.Timedelta("1 day")
+b = True
 if TYPE_CHECKING_INVALID_USAGE:
     _0 = a * b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 ```
 
-**Example 2: Guarding `Never` assertions**
-When a stub returns `Never`, attempting to assign it or use it will trigger a type error. Because `Never` represents an operation that shouldn't happen, placing it in standard execution flow can cause runtime crashes. Guard these inside an uncalled function:
+**Example 2: Asserting a `Never` return**
+When a stub overload returns `Never`, do not wrap the call in an uncalled function: code after a `Never` call is unreachable, so type checkers stop checking the rest of the block. Assert the return type directly instead (tested in `tests/indexes/test_floordiv.py`):
 
 ```python
+from tests import TYPE_CHECKING_INVALID_USAGE
+from typing import Never, assert_type
+
+import numpy as np
+import pandas as pd
+
+left_i = pd.MultiIndex.from_arrays([[1, 2, 3]]).levels[0]  # pd.Index[int]
+c = np.array([1.1j, 2.2j, 4.1j], np.complex128)
 if TYPE_CHECKING_INVALID_USAGE:
-    def _test_never():
-        # This function is never called at runtime, safely allowing type checkers to evaluate the Never return
-        _0 = s.dt.tz_convert("UTC")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[missing-overload]
+    assert_type(left_i // c, Never)
 ```
 
-**Why:** The goal is to catch errors at **type-check time**, not runtime. The `TYPE_CHECKING_INVALID_USAGE` guard (which is `False` at runtime) and uncalled functions prevent runtime execution while the ignore comments verify `mypy`, `pyright`, `pyrefly`, and `ty` properly reject the invalid code.
+**Why:** The goal is to catch errors at **type-check time**, not runtime. The `TYPE_CHECKING_INVALID_USAGE` guard (which is `False` at runtime) prevents runtime execution while `assert_type(expr, Never)` verifies the stub really returns `Never` — no ignore comments needed.
 
 **Note on `ty`**: `ty` is being gradually integrated into `pandas-stubs`, fully parallel with the other three type checkers. It is currently in beta; we actively report bugs to `astral-sh/ty` (and similarly to `mypy`, `pyright`, and `pyrefly`).
 
@@ -91,6 +99,10 @@ with pytest.raises(TypeError):
 **Correct pattern:**
 
 ```python
+import pandas as pd
+
+s1 = pd.Series([pd.Timestamp("2000-01-01")])
+s2 = pd.Series([pd.Timestamp("2000-01-02")])
 if TYPE_CHECKING_INVALID_USAGE:
     _0 = s1 + s2  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 ```
@@ -100,8 +112,13 @@ if TYPE_CHECKING_INVALID_USAGE:
 When testing operations, assign the result to a dummy variable (e.g., `_0`, `_1`, etc.) to avoid [ruff's useless-comparison rule](https://docs.astral.sh/ruff/rules/useless-comparison/):
 
 ```python
+import datetime as dt
+
+import pandas as pd
+
+date_obj = dt.date(2023, 1, 1)
 if TYPE_CHECKING_INVALID_USAGE:
-    _0 = a > b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+    _0 = date_obj > pd.NaT  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 ```
 
 This applies to any expression that would trigger warnings about unused results (comparisons, arithmetic operations, etc.).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,37 +15,54 @@ The `pandas-stubs` project is introduced in `README.md`.
 - Follow `docs/philosophy.md`.
 - Also follow all guidelines for contributing to the codebase specified at [Contributing to the code base](https://pandas.pydata.org/docs/development/contributing_codebase.html).
 
-## Decision heuristics
+## Citation & Reference Formatting Rules (Important)
+
+When generating documentation or writing PR descriptions, format all GitHub references as plain text so that GitHub renders them as native autolinks.
+- Avoid wrapping PRs, Issues, or Commits in backticks.
+- **Pull Requests / Issues**: pandas-dev/pandas-stubs#1911 (not `` `pandas-dev/pandas-stubs#1911` ``).
+- **Commits**: pandas-dev/pandas-stubs@cebd954 (not `` `cebd954` ``).
+- **External issues**: pandas-dev/pandas#39196 (not a full URL).
+
+## PR and Commit Conventions
+
+- **Splitting large PRs**: A large PR must be split into small, individually reviewable sub-PRs. Each sub-PR body starts with `- [x] Towards pandas-dev/pandas-stubs#<parent>` (precedent: pandas-dev/pandas-stubs#1917, pandas-dev/pandas-stubs#1921).
+- **Commit signatures**: When AI generates commits, add a `Co-authored-by:` trailer naming the actual model or tool and its provider no-reply email, e.g. `Co-authored-by: claude-opus-4-20250514 <noreply@anthropic.com>`.
+- **PR body — visible and invisible text**:
+  - *Visible text* (for human reviewers): concise summary, checklist, links. Humans read the rendered page.
+  - *Invisible text* (for AI agents): a comprehensive implementation plan inside an HTML comment block (`<!-- ... -->`) at the bottom of the body. GitHub hides it in the rendered view; agents read it via the raw body (API or `gh pr view --json body`).
+  - Rules: never put machine-only detail in the visible text; never hide information a human reviewer needs; the invisible block must be complete enough for a later agent to resume without re-deriving context.
+
+## Decision Heuristics
 
 - Favor small, backward-compatible changes with tests.
 - Prefer readability over micro-optimizations unless benchmarks are requested.
 - Add tests for behavioral changes.
-- When referring to GitHub issues and pull requests, use the short format `pandas-dev/pandas#39196` instead of full URLs like `https://github.com/pandas-dev/pandas/issues/39196`
 - If new code is clear from naming and references, do not add detailed comments. Keep code self-documenting.
 
-## Testing Philosophy: Static Type Checking Focus
+## Testing Philosophy: Static Type Checking Focus (The 4-Checker Paradigm)
 
-**CRITICAL:** This project prioritizes **static type checking** over runtime error testing. When designing stubs and tests:
+This project prioritizes **static type checking** over runtime error testing and enforces a 4-checker CI pipeline: `mypy`, `pyright`, `pyrefly`, and `ty`.
+
+When designing stubs and tests:
 
 ### Invalid Usage Testing Pattern
 
 When an error is expected to raise (invalid operations):
 
-1. **Design stubs** to return `Never` or cause type checker errors for invalid usage
-2. **In tests**, protect invalid operations with `if TYPE_CHECKING_INVALID_USAGE:` instead of `with pytest.raises(...)`
-3. Add `# type: ignore[<error-code>]` and/or `# pyright: ignore[<error-code>]` comments to verify type checkers catch the error
+1. **Design stubs** to return `Never` or cause type checker errors for invalid usage.
+2. **In tests**, protect invalid operations with `if TYPE_CHECKING_INVALID_USAGE:` instead of `with pytest.raises(...)`.
+3. Add the canonical multi-checker ignore comment sequence (ADR-0008).
 
-**Example** (from `docs/philosophy.md`):
+**Example** (tested in `tests/scalars/timedelta/test_arithmetic.py`):
 
 ```python
-i1 = pd.Interval(
-    pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-03"), closed="both"
-)
 if TYPE_CHECKING_INVALID_USAGE:
-    _0 = i1 + pd.Timestamp("2000-03-03")  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
+    _0 = a * b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 ```
 
-**Why:** The goal is to catch errors at **type-check time**, not runtime. The `TYPE_CHECKING_INVALID_USAGE` guard (which is `False` at runtime) prevents runtime execution while the ignore comments verify type checkers properly reject the invalid code.
+**Why:** The goal is to catch errors at **type-check time**, not runtime. The `TYPE_CHECKING_INVALID_USAGE` guard (which is `False` at runtime) prevents runtime execution while the ignore comments verify `mypy`, `pyright`, `pyrefly`, and `ty` properly reject the invalid code.
+
+**Note on `ty`**: `ty` is being gradually integrated into `pandas-stubs`, fully parallel with the other three type checkers. It is currently in beta; we actively report bugs to `astral-sh/ty` (and similarly to `mypy`, `pyright`, and `pyrefly`).
 
 ### Do NOT use pytest.raises for type checking
 
@@ -60,7 +77,7 @@ with pytest.raises(TypeError):
 
 ```python
 if TYPE_CHECKING_INVALID_USAGE:
-    _0 = s1 + s2  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
+    _0 = s1 + s2  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 ```
 
 ### Avoiding ruff useless-comparison warnings
@@ -69,7 +86,7 @@ When testing operations, assign the result to a dummy variable (e.g., `_0`, `_1`
 
 ```python
 if TYPE_CHECKING_INVALID_USAGE:
-    _0 = a > b  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
+    _0 = a > b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 ```
 
 This applies to any expression that would trigger warnings about unused results (comparisons, arithmetic operations, etc.).
@@ -86,9 +103,8 @@ poetry run poe test_all
 
 All checks must pass before submitting changes. These commands verify:
 
-- Type stubs are correctly annotated (`mypy`, `pyright`, `pyrefly`)
-- Invalid usage is properly rejected by type checkers (ty)
-- Tests execute successfully at runtime (test)
+- Type stubs are correctly annotated (`mypy`, `pyright`, `pyrefly`, `ty`)
+- Tests execute successfully at runtime (`pytest`)
 
 ## Pull Requests (summary)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,17 @@ When generating documentation or writing PR descriptions, format all GitHub refe
 
 ## PR and Commit Conventions
 
-- **Splitting large PRs**: A large PR must be split into small, individually reviewable sub-PRs. Each sub-PR body starts with `- [x] Towards pandas-dev/pandas-stubs#<parent>` (precedent: pandas-dev/pandas-stubs#1917, pandas-dev/pandas-stubs#1921).
-- **Commit signatures**: When AI generates commits, add a `Co-authored-by:` trailer naming the actual model or tool and its provider no-reply email, e.g. `Co-authored-by: claude-opus-4-20250514 <noreply@anthropic.com>`.
-- **PR body — visible and invisible text**:
+- **Commit signatures**: When AI generates commits, add a `Co-authored-by:` trailer naming the actual model or tool. Finding official emails can be tricky, so use these standard templates for popular agents:
+  - `Co-authored-by: Antigravity AI <bot@antigravity.dev>`
+  - `Co-authored-by: DeepCode <bot@deepcode.ai>`
+  - `Co-authored-by: GitHub Copilot <noreply@github.com>`
+  - `Co-authored-by: OpenAI Codex <noreply@openai.com>`
+- **Emojis in PR Titles**: Consider adding an emoji to the PR title (e.g., 🤖 or 🪄) as a fun, immediate signal to maintainers that AI assisted with the PR.
+- **PR body — visible and collapsible text**:
   - *Visible text* (for human reviewers): concise summary, checklist, links. Humans read the rendered page.
-  - *Invisible text* (for AI agents): a comprehensive implementation plan inside an HTML comment block (`<!-- ... -->`) at the bottom of the body. GitHub hides it in the rendered view; agents read it via the raw body (API or `gh pr view --json body`).
-  - Rules: never put machine-only detail in the visible text; never hide information a human reviewer needs; the invisible block must be complete enough for a later agent to resume without re-deriving context.
+  - *Collapsible text* (for AI agents): place comprehensive implementation plans or technical notes inside a `<details><summary>AI Implementation Plan</summary>` block at the bottom of the body. This keeps the PR clean for humans but accessible if they want to read it, while agents can read it via the raw body.
+  - Rules: never put machine-only detail in the visible text; never hide information a human reviewer needs.
+- **Splitting exceptionally large PRs**: If a PR is massive, split it into small, individually reviewable sub-PRs. Each sub-PR body should start with `- [x] Towards pandas-dev/pandas-stubs#<parent>`.
 
 ## Decision Heuristics
 
@@ -51,16 +56,26 @@ When an error is expected to raise (invalid operations):
 
 1. **Design stubs** to return `Never` or cause type checker errors for invalid usage.
 2. **In tests**, protect invalid operations with `if TYPE_CHECKING_INVALID_USAGE:` instead of `with pytest.raises(...)`.
-3. Add the canonical multi-checker ignore comment sequence (ADR-0008).
+3. Add the canonical multi-checker ignore comment sequence.
 
-**Example** (tested in `tests/scalars/timedelta/test_arithmetic.py`):
+**Example 1: Standard invalid operations** (tested in `tests/scalars/timedelta/test_arithmetic.py`):
 
 ```python
 if TYPE_CHECKING_INVALID_USAGE:
     _0 = a * b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 ```
 
-**Why:** The goal is to catch errors at **type-check time**, not runtime. The `TYPE_CHECKING_INVALID_USAGE` guard (which is `False` at runtime) prevents runtime execution while the ignore comments verify `mypy`, `pyright`, `pyrefly`, and `ty` properly reject the invalid code.
+**Example 2: Guarding `Never` assertions**
+When a stub returns `Never`, attempting to assign it or use it will trigger a type error. Because `Never` represents an operation that shouldn't happen, placing it in standard execution flow can cause runtime crashes. Guard these inside an uncalled function:
+
+```python
+if TYPE_CHECKING_INVALID_USAGE:
+    def _test_never():
+        # This function is never called at runtime, safely allowing type checkers to evaluate the Never return
+        _0 = s.dt.tz_convert("UTC")  # type: ignore[call-overload] # pyright: ignore[reportCallIssue] # pyrefly: ignore[no-matching-overload] # ty: ignore[missing-overload]
+```
+
+**Why:** The goal is to catch errors at **type-check time**, not runtime. The `TYPE_CHECKING_INVALID_USAGE` guard (which is `False` at runtime) and uncalled functions prevent runtime execution while the ignore comments verify `mypy`, `pyright`, `pyrefly`, and `ty` properly reject the invalid code.
 
 **Note on `ty`**: `ty` is being gradually integrated into `pandas-stubs`, fully parallel with the other three type checkers. It is currently in beta; we actively report bugs to `astral-sh/ty` (and similarly to `mypy`, `pyright`, and `pyrefly`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The `pandas-stubs` project is introduced in `README.md`.
 ## Citation & Reference Formatting Rules (Important)
 
 When generating documentation or writing PR descriptions, format all GitHub references as plain text so that GitHub renders them as native autolinks.
-- Avoid wrapping PRs, Issues, or Commits in backticks.
+- Avoid wrapping PRs, Issues, or Commits in backticks; GitHub will only render these as clickable links if they are left as plain text.
 - **Pull Requests / Issues**: pandas-dev/pandas-stubs#1911 (not `` `pandas-dev/pandas-stubs#1911` ``).
 - **Commits**: pandas-dev/pandas-stubs@cebd954 (not `` `cebd954` ``).
 - **External issues**: pandas-dev/pandas#39196 (not a full URL).
@@ -37,7 +37,7 @@ When generating documentation or writing PR descriptions, format all GitHub refe
 - **PR descriptions**: follow the template; keep the visible text succinct (usually a few sentences). PRs resolving an existing issue should include a link to it in the description.
 - **PR body — concise for humans, comprehensive for agents**:
   - Humans read the rendered page: lead with a concise summary, checklist, and links.
-  - AI agents read the raw body and can consume far more detail than a human reviewer wants to scroll through. Put a comprehensive implementation record at the bottom of the body inside a `<details><summary>AI Implementation Plan</summary>` block: motivation, experiments and attempts (including failures), caveats, outcome, out-of-scope items, and a to-do list. This information lives in a developer's head; an AI agent can write it down cheaply, and later agents (e.g. pandas-dev/pandas-stubs#1926 sub-PRs) can pick it up without re-deriving it. This follows the evidence-traceability direction of arXiv:2604.24658 without claiming ARA compliance.
+  - AI agents read the raw body and can consume far more detail than a human reviewer wants to scroll through. Put a comprehensive implementation record at the bottom of the body inside a `<details><summary>AI Implementation Plan</summary>` block: motivation, experiments and attempts (including failures), caveats, outcome, out-of-scope items, and a to-do list. This information lives in a developer's head; an AI agent can write it down cheaply, and later agents (e.g. pandas-dev/pandas-stubs#1926 sub-PRs) can pick it up without re-deriving it.
   - Rules: never put machine-only detail in the visible text; never hide information a human reviewer needs. The `<details>` block stays visible when expanded, so both audiences keep full access.
 - **Commit messages**: do not add summaries or additional comments to individual commits. The single PR description is sufficient.
 - **Commit signatures**: When AI generates commits, add a `Co-authored-by:` trailer naming the actual model or tool. Prefer the exact model name when known; use the tool name only when the model is not disclosed. Use the provider's official no-reply address:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ When generating documentation or writing PR descriptions, format all GitHub refe
   - `Co-authored-by: claude-opus-4-20250514 <noreply@anthropic.com>`
   - `Co-authored-by: GitHub Copilot <noreply@github.com>`
   - `Co-authored-by: Gemini 3.1 Pro <noreply@google.com>`
+- **Why a fixed list**: models cannot reliably report their own name or version (they frequently hallucinate or are unaware of their exact identifier), so a canonical list lets an agent choose the closest matching identity deterministically; when the model isn't listed, use the tool name.
 - **Splitting exceptionally large PRs**: If a PR is massive, split it into small, individually reviewable sub-PRs. Each sub-PR body should start with `- [x] Towards pandas-dev/pandas-stubs#<parent>`.
 
 ## Decision Heuristics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ if TYPE_CHECKING_INVALID_USAGE:
     _0 = a * b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 ```
 
-**Example 2: Asserting a `Never` return**
-When a stub overload returns `Never`, do not wrap the call in an uncalled function: code after a `Never` call is unreachable, so type checkers stop checking the rest of the block. Assert the return type directly instead (tested in `tests/indexes/test_floordiv.py`):
+**Example 2: Asserting a `Never` return from arithmetic**
+Arithmetic operators that return `Never` do not stop type checkers from checking the rest of the scope, so assert the return type directly without an uncalled-function wrapper (tested in `tests/indexes/test_floordiv.py`):
 
 ```python
 from tests import TYPE_CHECKING_INVALID_USAGE
@@ -84,6 +84,20 @@ if TYPE_CHECKING_INVALID_USAGE:
 ```
 
 **Why:** The goal is to catch errors at **type-check time**, not runtime. The `TYPE_CHECKING_INVALID_USAGE` guard (which is `False` at runtime) prevents runtime execution while `assert_type(expr, Never)` verifies the stub really returns `Never` — no ignore comments needed.
+
+**Example 3: Guarding `Never`-returning calls with an uncalled function**
+Some `Never`-returning calls make everything after them unreachable, so type checkers stop checking the rest of the block. Confine such an assertion to an uncalled function (tested in `tests/indexes/test_indexes.py`):
+
+```python
+def test_multiindex_from_product_forbid_strings() -> None:
+    """Test that passing strings directly to `MultiIndex.from_product` is forbidden."""
+    if TYPE_CHECKING_INVALID_USAGE:
+
+        def _0() -> None:  # pyright: ignore[reportUnusedFunction]
+            assert_type(pd.MultiIndex.from_product(["12", "34"]), Never)
+```
+
+`# pyright: ignore[reportUnusedFunction]` silences pyright's unused-function diagnostic. When in doubt, the wrapper is always safe.
 
 **Note on `ty`**: `ty` is being gradually integrated into `pandas-stubs`, fully parallel with the other three type checkers. It is currently in beta; we actively report bugs to `astral-sh/ty` (and similarly to `mypy`, `pyright`, and `pyrefly`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,18 +23,29 @@ When generating documentation or writing PR descriptions, format all GitHub refe
 - **Commits**: pandas-dev/pandas-stubs@cebd954 (not `` `cebd954` ``).
 - **External issues**: pandas-dev/pandas#39196 (not a full URL).
 
-## PR and Commit Conventions
+## Pull Requests and Commits
 
+- **PR titles**: descriptive, and include one of the following prefixes:
+  - ENH: Enhancement, new functionality
+  - BUG: Bug fix
+  - DOC: Additions/updates to documentation
+  - TST: Additions/updates to tests
+  - BLD: Updates to the build process/scripts
+  - PERF: Performance improvement
+  - TYP: Type annotations
+  - CLN: Code cleanup
+- **PR descriptions**: follow the template; keep the visible text succinct (usually a few sentences). PRs resolving an existing issue should include a link to it in the description.
+- **PR body — concise for humans, comprehensive for agents**:
+  - Humans read the rendered page: lead with a concise summary, checklist, and links.
+  - AI agents read the raw body and can consume far more detail than a human reviewer wants to scroll through. Put a comprehensive implementation record at the bottom of the body inside a `<details><summary>AI Implementation Plan</summary>` block: motivation, experiments and attempts (including failures), caveats, outcome, out-of-scope items, and a to-do list. This information lives in a developer's head; an AI agent can write it down cheaply, and later agents (e.g. pandas-dev/pandas-stubs#1926 sub-PRs) can pick it up without re-deriving it. This follows the evidence-traceability direction of arXiv:2604.24658 without claiming ARA compliance.
+  - Rules: never put machine-only detail in the visible text; never hide information a human reviewer needs. The `<details>` block stays visible when expanded, so both audiences keep full access.
+- **Commit messages**: do not add summaries or additional comments to individual commits. The single PR description is sufficient.
 - **Commit signatures**: When AI generates commits, add a `Co-authored-by:` trailer naming the actual model or tool. Prefer the exact model name when known; use the tool name only when the model is not disclosed. Use the provider's official no-reply address:
   - `Co-authored-by: deepseek-v4-pro <noreply@deepseek.com>`
   - `Co-authored-by: gpt-5.6-terra <noreply@openai.com>`
   - `Co-authored-by: claude-opus-4-20250514 <noreply@anthropic.com>`
   - `Co-authored-by: GitHub Copilot <noreply@github.com>`
   - `Co-authored-by: Antigravity AI <noreply@google.com>`
-- **PR body — concise for humans, comprehensive for agents**:
-  - Humans read the rendered page: lead with a concise summary, checklist, and links.
-  - AI agents read the raw body and can consume far more detail than a human reviewer wants to scroll through. Put a comprehensive implementation record at the bottom of the body inside a `<details><summary>AI Implementation Plan</summary>` block: motivation, experiments and attempts (including failures), caveats, outcome, out-of-scope items, and a to-do list. This information lives in a developer's head; an AI agent can write it down cheaply, and later agents (e.g. pandas-dev/pandas-stubs#1926 sub-PRs) can pick it up without re-deriving it. This follows the evidence-traceability direction of arXiv:2604.24658 without claiming ARA compliance.
-  - Rules: never put machine-only detail in the visible text; never hide information a human reviewer needs. The `<details>` block stays visible when expanded, so both audiences keep full access.
 - **Splitting exceptionally large PRs**: If a PR is massive, split it into small, individually reviewable sub-PRs. Each sub-PR body should start with `- [x] Towards pandas-dev/pandas-stubs#<parent>`.
 
 ## Decision Heuristics
@@ -160,18 +171,3 @@ All checks must pass before submitting changes. These commands verify:
 
 - Type stubs are correctly annotated (`mypy`, `pyright`, `pyrefly`, `ty`)
 - Tests execute successfully at runtime (`pytest`)
-
-## Pull Requests (summary)
-
-- Pull request titles should be descriptive and include one of the following prefixes:
-  - ENH: Enhancement, new functionality
-  - BUG: Bug fix
-  - DOC: Additions/updates to documentation
-  - TST: Additions/updates to tests
-  - BLD: Updates to the build process/scripts
-  - PERF: Performance improvement
-  - TYP: Type annotations
-  - CLN: Code cleanup
-- Pull request descriptions should follow the template, and **succinctly** describe the change being made. Usually a few sentences is sufficient.
-- Pull requests which are resolving an existing Github Issue should include a link to the issue in the PR Description.
-- Do not add summaries or additional comments to individual commit messages. The single PR description is sufficient.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -135,14 +135,14 @@ are too wide is a bit more complicated.
 In this case, the test will fail when using `pytest`, but it is also desirable to
 have type checkers report errors for code that is expected to fail type checking.
 
-Here is an example that illustrates this concept, from `tests/test_interval.py`:
+Here is an example that illustrates this concept, from `tests/scalars/test_interval.py`:
 
 ```python
     i1 = pd.Interval(
         pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-03"), closed="both"
     )
     if TYPE_CHECKING_INVALID_USAGE:
-        i1 + pd.Timestamp("2000-03-03")  # type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]
+        _01 = i1 + pd.Timestamp("2000-03-03")  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
 ```
 
@@ -150,8 +150,9 @@ In this particular example, the stubs consider that `i1` will have the type
 `pd.Interval[pd.Timestamp]`.  It is incorrect code to add a `Timestamp` to a
 time-based interval.  Without the `if TYPE_CHECKING_INVALID_USAGE` construct, the
 code would fail at runtime.  Further, type checkers should report an error for this
-incorrect code.  By placing the `# type: ignore[operator] # pyright: ignore[reportGeneralTypeIssues]`
-on the line, type checkers are told to ignore the type error.  To ensure that the
+incorrect code.  By placing the canonical ignore sequence on the line
+(`# type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]`),
+type checkers are told to ignore the type error.  To ensure that the
 pandas-stubs annotations are not too wide (allow adding a `Timestamp` to a
 time-based interval), mypy and pyright are configured to report unused ignore
 statements.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -120,6 +120,22 @@ which is supported by `typing_extensions` version 4.2 and beyond makes it easier
 to test to validate the return types of functions and methods.  Future work
 is intended to expand the use of `assert_type()` in the test code.
 
+When a stub returns `Never`, verify it with `assert_type(expr, Never)`.  For
+arithmetic operators returning `Never`, type checkers still check the rest of
+the scope, so a bare assertion is fine.  Some `Never`-returning calls, however,
+make everything after them unreachable, so type checkers stop checking the rest
+of the block.  Wrap those assertions in an uncalled function, as in
+`tests/indexes/test_indexes.py`:
+
+```python
+def test_multiindex_from_product_forbid_strings() -> None:
+    """Test that passing strings directly to `MultiIndex.from_product` is forbidden."""
+    if TYPE_CHECKING_INVALID_USAGE:
+
+        def _0() -> None:  # pyright: ignore[reportUnusedFunction]
+            assert_type(pd.MultiIndex.from_product(["12", "34"]), Never)
+```
+
 ## Narrow vs. Wide Arguments
 
 A consideration in creating stubs is to make the set of type annotations for
@@ -177,3 +193,7 @@ for them.
 If type checkers report errors, for example, inside a `TYPE_CHECKING_INVALID_USAGE`
 block, please ensure that the comment for mypy comes first:
 `# type: ignore[<error code>] # pyright: ignore[<error code>] # pyrefly: ignore[<error code>] # ty: ignore[<error code>]`.
+
+One special case: an uncalled helper function that contains a `Never` assertion
+needs `# pyright: ignore[reportUnusedFunction]` on its `def` line.  This is not
+part of the canonical multi-checker sequence.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -112,8 +112,8 @@ interval of `Timestamp`s.
 ## Testing the Type Stubs
 
 A set of (most likely incomplete) tests for testing the type stubs is in the pandas-stubs
-repository in the `tests` directory.  The tests are used with `mypy`, `pyright`
-and `pyrefly` to
+repository in the `tests` directory.  The tests are used with `mypy`, `pyright`,
+`pyrefly`, and `ty` to
 validate correct typing, and also with `pytest` to validate that the provided code
 actually executes.  The recent decision for Python 3.11 to include `assert_type()`,
 which is supported by `typing_extensions` version 4.2 and beyond makes it easier


### PR DESCRIPTION
- [x] Towards pandas-dev/pandas-stubs#1926

Updates `AGENTS.md` with conventions for AI-assisted contributions, and aligns `docs/philosophy.md`:

- **Citation formatting**: use native GitHub autolinks (no backticks around PRs, issues, or commits).
- **4-checker paradigm**: examples now use tested ignore codes from the actual codebase (`mypy`, `pyright`, `pyrefly`, `ty`), including `assert_type(..., Never)` for `Never`-returning overloads.
- **PR body policy**: concise summary for humans, comprehensive `<details>` implementation record for AI agents.
- **Commit signatures**: neutral `Co-authored-by:` trailer naming the exact model (or tool when the model is not disclosed) with the provider's official no-reply address.
- **Runtime warnings**: documented the `pytest_warns_bounded` / `pytest_warns_conditioned` helpers for version-conditional warning tests.
- **Sub-PR splitting**: convention for large PRs with `Towards #<parent>` checklist items.
- **philosophy.md**: added `ty` to the checker list and aligned the "Narrow vs. Wide Arguments" example with the tested 4-checker ignore sequence.
- **Restructure**: merged the PR/commit rules into a single `## Pull Requests and Commits` section (removed the duplicate `## Pull Requests (summary)`).

No references to files outside this PR (staleness/methodology sections land in a later sub-PR).

- [x] Tests added (not applicable — AGENTS.md and docs/philosophy.md only)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

<details><summary>AI Implementation Plan</summary>

SCOPE: `AGENTS.md`, `docs/philosophy.md`, `.gitignore`. This is PR-1 in the decomposition of the umbrella PR pandas-dev/pandas-stubs#1926.

MOTIVATION (arXiv:2604.24658 — "The Last Human-Written Paper: Agent-Native Research Artifacts", Liu et al., v3, cs.LG):
This umbrella effort borrows the paper's evidence-traceability direction only (not ARA compliance). The paper argues narrative docs compress a branching research process into a linear story, imposing a "Storytelling Tax" (failed experiments / rejected hypotheses are dropped) and an "Engineering Tax" (prose sufficient for human reviewers lacks the spec detail AI agents need). Its remedy, the Agent-Native Research Artifact, is a machine-executable package of four layers: scientific logic, executable code with full specifications, an exploration graph preserving discarded failures, and evidence grounding claims in raw outputs. This PR maps that to pandas-stubs: the collapsed implementation record below is the exploration graph (attempts, failures, caveats, out-of-scope, to-do); the "concise visible summary for humans / comprehensive collapsed record for agents" split is the Engineering-Tax remedy; the provenance + validation tooling landing in later sub-PRs is the evidence-grounding layer.

ORDERING: this is PR-1 (#1928) of umbrella #1926. #1928 merges first; #1926 (architecture records) is rebased onto upstream/main afterward. If both appear in your context, #1928's AGENTS.md is the canonical convention and #1926's records build on it.

FINAL STATE:

1. CITATION RULES: plain-text GitHub autolinks for PRs/Issues/Commits.
2. COMMIT SIGNATURES: exact model name preferred; tool name only when the model is not disclosed; provider no-reply addresses: `deepseek-v4-pro <noreply@deepseek.com>`, `gpt-5.6-terra <noreply@openai.com>`, `claude-opus-4-20250514 <noreply@anthropic.com>`, `GitHub Copilot <noreply@github.com>`, `Antigravity AI <noreply@google.com>`.
3. PR BODY: concise visible summary for humans; comprehensive `<details><summary>AI Implementation Plan</summary>` record for AI agents (motivation, attempts, caveats, outcome, out-of-scope, to-do). ~Evidence-traceability direction of arXiv:2604.24658, without claiming ARA compliance.~ (Moved to PR body only)
4. 4-CHECKER PARADIGM: `mypy`, `pyright`, `pyrefly`, `ty`. Design stubs to cause type checker errors (preferred) or return `Never`. Invalid operations use the canonical ignore sequence; arithmetic `Never` returns are verified with a bare `assert_type(expr, Never)` inside `TYPE_CHECKING_INVALID_USAGE`; `Never`-returning calls that make the rest unreachable are wrapped in `def _0() -> None:  # pyright: ignore[reportUnusedFunction]`.
5. RUNTIME WARNINGS: documented `pytest_warns_bounded` / `pytest_warns_conditioned` for version-conditional warnings (pandas-dev/pandas-stubs#1927, pandas-dev/pandas-stubs#1802).
6. PR/COMMIT CONVENTIONS: consolidated into a single `## Pull Requests and Commits` section; legacy `## Pull Requests (summary)` section removed.
7. Emoji-in-title bullet removed.
8. `docs/philosophy.md`: added `ty` to the checker list; stale `reportGeneralTypeIssues` example replaced with the tested 4-checker sequence from `tests/scalars/test_interval.py:96`.
9. ~`.gitignore`: added `.DS_Store` under a `# macOS` section.~ (Reverted in review)


REVIEW ITERATION 1:
- Reverted the `.DS_Store` addition in `.gitignore` (OS-level ignores belong in global configurations).
- Updated `AGENTS.md` citation rules to explicitly mention that plain-text is required so GitHub can render them as native links (clarifying it's functional, not just aesthetic).
- Removed the explicit `arXiv:2604.24658` citation from `AGENTS.md`. The paper remains the philosophical motivation for #1926/#1928, but is kept here in the implementation plan rather than the strict project guidelines.
- Drafting `4_checker_pre_commit_proposal.md` externally to mitigate the verbose 4-checker typing tax for human contributors via `pygrep` or auto-expansion.

VERIFICATION:

- `rg "scripts/architecture|scratch/" AGENTS.md` returns empty.
- `rg "ignore\[rule\]" AGENTS.md` returns empty.
- `rg "reportGeneralTypeIssues|Emojis in PR Titles|DeepCode|OpenAI Codex|_test_never|tz_convert|visible and collapsible|Pull Requests \(summary\)|PR and Commit Conventions" AGENTS.md docs/philosophy.md` returns empty.
- `rg "## Pull Requests and Commits" AGENTS.md` is present.
- `rg "pytest_warns_bounded" AGENTS.md` is present.
- `codespell` passes on the changed files.

</details>


