### PR TITLE
TST: add focused Period scalar addition tests

### DIFF
--- a/tests/scalars/period/test_add.py
+++ b/tests/scalars/period/test_add.py
@@ -1,0 +1,80 @@
+from datetime import (
+    datetime,
+    timedelta,
+)
+from typing import assert_type
+
+import numpy as np
+import pandas as pd
+from pandas.api.typing import NaTType
+import pytest
+
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    check,
+)
+
+
+@pytest.fixture
+def left() -> pd.Period:
+    """Left operand"""
+    return pd.Period("2025-08-20", freq="D")
+
+
+def test_add_py_scalar(left: pd.Period) -> None:
+    """Test pd.Period + Python native scalars"""
+    d = timedelta(days=1)
+    i = 1
+    s = datetime(2025, 8, 20)
+
+    check(assert_type(left + d, pd.Period), pd.Period)
+    check(assert_type(d + left, pd.Period), pd.Period)
+
+    check(assert_type(left + i, pd.Period), pd.Period)
+    check(assert_type(i + left, pd.Period), pd.Period)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        _0 = left + s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = s + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _2 = left + "str"  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _3 = "str" + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _4 = left + 1.5  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _5 = 1.5 + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+
+
+def test_add_numpy_scalar(left: pd.Period) -> None:
+    """Test pd.Period + numpy scalars"""
+    d = np.timedelta64(1, "D")
+    i = np.int64(1)
+    s = np.datetime64("2025-08-20")
+
+    check(assert_type(left + d, pd.Period), pd.Period)
+    check(assert_type(d + left, pd.Period), pd.Period)
+
+    check(assert_type(left + i, pd.Period), pd.Period)
+    check(assert_type(i + left, pd.Period), pd.Period)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        _0 = left + s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = s + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+
+
+def test_add_pd_scalar(left: pd.Period) -> None:
+    """Test pd.Period + pandas scalars"""
+    d = pd.Timedelta(days=1)
+    off = pd.offsets.Day(1)
+    p = pd.Period("2025-08-20", freq="D")
+    nat = pd.NaT
+
+    check(assert_type(left + d, pd.Period), pd.Period)
+    check(assert_type(d + left, pd.Period), pd.Period)
+
+    check(assert_type(left + off, pd.Period), pd.Period)
+    check(assert_type(off + left, pd.Period), pd.Period)
+
+    check(assert_type(left + nat, NaTType), NaTType)
+    check(assert_type(nat + left, NaTType), NaTType)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        _0 = left + p  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = p + left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -556,7 +556,6 @@ def test_timedelta_add_sub() -> None:
     as_nat = pd.NaT
 
     check(assert_type(td + td, pd.Timedelta), pd.Timedelta)
-    check(assert_type(td + as_period, pd.Period), pd.Period)
     check(assert_type(td + as_timestamp, pd.Timestamp), pd.Timestamp)
     check(assert_type(td + as_datetime, pd.Timestamp), pd.Timestamp)
     check(assert_type(td + as_date, dt.date), dt.date)
@@ -570,7 +569,6 @@ def test_timedelta_add_sub() -> None:
     check(assert_type(td + as_ndarray_dt64, np_ndarray_dt), np_ndarray, np.datetime64)
     check(assert_type(td + as_nat, NaTType), NaTType)
 
-    check(assert_type(as_period + td, pd.Period), pd.Period)
     check(assert_type(as_timestamp + td, pd.Timestamp), pd.Timestamp)
     check(assert_type(as_datetime + td, dt.datetime), dt.datetime)
     check(assert_type(as_date + td, dt.date), dt.date)
@@ -1733,12 +1731,6 @@ def test_period_add_subtract() -> None:
     as_timedelta_idx = pd.timedelta_range(scale, scale, freq="D")
     as_nat = pd.NaT
 
-    check(assert_type(p + as_pd_td, pd.Period), pd.Period)
-    check(assert_type(p + as_dt_td, pd.Period), pd.Period)
-    check(assert_type(p + as_np_td, pd.Period), pd.Period)
-    check(assert_type(p + as_np_i64, pd.Period), pd.Period)
-    check(assert_type(p + as_int, pd.Period), pd.Period)
-    check(assert_type(p + p.freq, pd.Period), pd.Period)
     # offset_index is tested below
     offset_index = p - as_period_index
     # https://github.com/pandas-dev/pandas/issues/50162 dtype=object
@@ -1751,7 +1743,6 @@ def test_period_add_subtract() -> None:
 
     check(assert_type(p + as_td_series, "pd.Series[pd.Period]"), pd.Series, pd.Period)
     check(assert_type(p + as_timedelta_idx, pd.PeriodIndex), pd.PeriodIndex)
-    check(assert_type(p + as_nat, NaTType), NaTType)
     offset_series = as_period_series - as_period_series
     check(assert_type(offset_series, "pd.Series[BaseOffset]"), pd.Series)
     check(assert_type(p + offset_series, "pd.Series[pd.Period]"), pd.Series, pd.Period)
@@ -1767,35 +1758,9 @@ def test_period_add_subtract() -> None:
     check(assert_type(p - as_nat, NaTType), NaTType)
     check(assert_type(p - p.freq, pd.Period), pd.Period)
 
-    # The __radd__ and __rsub__ methods are included to
-    # establish the location of the concrete implementation
-    # Those missing are using the __add__ of the other class
-    check(assert_type(as_pd_td + p, pd.Period), pd.Period)
-    check(assert_type(p.__radd__(as_pd_td), pd.Period), pd.Period)
-
-    check(assert_type(as_dt_td + p, pd.Period), pd.Period)
-    check(assert_type(p.__radd__(as_dt_td), pd.Period), pd.Period)
-
-    check(assert_type(as_np_td + p, pd.Period), pd.Period)
-    check(assert_type(p.__radd__(as_np_td), pd.Period), pd.Period)
-
-    # TODO: facebook/pyrefly#4422
-    # pyrefly: ignore[assert-type]
-    check(assert_type(as_np_i64 + p, pd.Period), pd.Period)
-    check(assert_type(p.__radd__(as_np_i64), pd.Period), pd.Period)
-
-    check(assert_type(as_int + p, pd.Period), pd.Period)
-    check(assert_type(p.__radd__(as_int), pd.Period), pd.Period)
-
     check(assert_type(as_td_series + p, "pd.Series[pd.Period]"), pd.Series, pd.Period)
 
     check(assert_type(as_timedelta_idx + p, pd.PeriodIndex), pd.PeriodIndex)
-
-    check(assert_type(as_nat + p, NaTType), NaTType)
-    check(assert_type(p.__radd__(as_nat), NaTType), NaTType)
-
-    check(assert_type(p.freq + p, pd.Period), pd.Period)
-    check(assert_type(p.__radd__(p.freq), pd.Period), pd.Period)
 
     check(assert_type(as_period_index - p, pd.Index), pd.Index)
 


### PR DESCRIPTION
- [x] Towards pandas-dev/pandas-stubs#1914
- [x] Tests added (using `assert_type()` for return values)
- [x] AI-assisted development followed `AGENTS.md`

Moves `Period` scalar addition coverage into a focused test module. It covers valid Python, NumPy, and pandas scalar operands in both orders, plus invalid datetime-like, string, float, and `Period` additions.

This is test-only: no stubs, aliases, or public interfaces change. Existing Series, Index, subtraction, and unrelated scalar coverage remains in `tests/scalars/test_scalars.py`.

<details><summary>AI Implementation Plan</summary>

### Motivation

Extract the independently useful `Period` scalar-addition tests from pandas-dev/pandas-stubs#1914 so they can be reviewed and merged without the parent PR's larger typing and helper-type changes.

### Implementation

- Added the `tests/scalars/period` package and `test_add.py`.
- Added valid addition cases for Python `timedelta` and `int`, NumPy `timedelta64` and `int64`, and pandas `Timedelta`, `Day`, and `NaT`, with `Period` in both operand positions.
- Added negative tests under `TYPE_CHECKING_INVALID_USAGE` for Python `datetime`, `str`, and `float`, NumPy `datetime64`, and pandas `Period`.
- Removed only superseded scalar-addition assertions from `tests/scalars/test_scalars.py`.
- Retained its Series additions, Index additions, all subtraction checks, construction/property/comparison coverage, and unrelated scalar tests.

### Experiments and validation

- `poetry run pytest tests/scalars/period/test_add.py`: 3 passed.
- Pre-commit hooks for all changed files: passed.
- First sandboxed `poetry run poe test_all`: all four static checkers passed and 3,361 runtime tests passed; seven unrelated I/O tests failed because sandbox restrictions blocked PyArrow macOS sysctl access and returned an empty clipboard.
- Re-ran `poetry run poe test_all` with host access: passed completely, including ty, pyrefly, mypy, pyright, 3,368 runtime tests with 6 skipped, pre-commit, wheel build/install, and installed-stub checker runs.

### Caveats and out of scope

- This does not change typing behavior.
- The helper-type relocation and remaining add-family work stay in pandas-dev/pandas-stubs#1914 and remain candidates for further splitting.
- Parent-PR integration is intentionally deferred until this PR merges.

### Outcome

Focused `Period` scalar-addition coverage passes independently against current `main` without relying on pandas-dev/pandas-stubs#1914 stub changes.

### Follow-up to-do

- [ ] Merge this PR first.
- [ ] Merge updated `upstream/main` into `align-add-family`.
- [ ] Resolve `tests/scalars/test_scalars.py` by retaining pandas-dev/pandas-stubs#1914's remaining non-scalar migrations while accepting this scalar extraction.
- [ ] Run `poetry run poe test_all` on the updated parent branch.
- [ ] Update pandas-dev/pandas-stubs#1914's description to list this PR alongside pandas-dev/pandas-stubs#1917 and pandas-dev/pandas-stubs#1923.

</details>
