### PR TITLE
TST: add focused Period scalar subtraction tests

### DIFF
--- a/tests/scalars/period/test_sub.py
+++ b/tests/scalars/period/test_sub.py
@@ -30,20 +30,24 @@ def test_sub_py_scalar(left: pd.Period) -> None:
     """Test pd.Period - Python native scalars"""
     d = timedelta(days=1)
     i = 1
+    f = 1.5
     s = datetime(2025, 8, 20)
+    st = "str"
 
     check(assert_type(left - d, pd.Period), pd.Period)
     check(assert_type(left - i, pd.Period), pd.Period)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
-        _1 = left - "str"  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
-        _2 = left - 1.5  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _0 = left - f  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _2 = left - st  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+
+    if TYPE_CHECKING_INVALID_USAGE:
         _3 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
         _4 = i - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
-        _5 = s - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
-        _6 = "str" - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
-        _7 = 1.5 - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _5 = f - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _6 = s - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _7 = st - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
 
 def test_sub_numpy_scalar(left: pd.Period) -> None:
@@ -57,6 +61,8 @@ def test_sub_numpy_scalar(left: pd.Period) -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+
+    if TYPE_CHECKING_INVALID_USAGE:
         _1 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
         _2 = i - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
         _3 = s - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]

--- a/tests/scalars/period/test_sub.py
+++ b/tests/scalars/period/test_sub.py
@@ -1,0 +1,67 @@
+from datetime import (
+    datetime,
+    timedelta,
+)
+from typing import assert_type
+
+import numpy as np
+import pandas as pd
+from pandas.api.typing import NaTType
+import pytest
+
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    check,
+)
+
+from pandas.tseries.offsets import (
+    BaseOffset,
+    Day,
+)
+
+
+@pytest.fixture
+def left() -> pd.Period:
+    """Left operand"""
+    return pd.Period("2025-08-20", freq="D")
+
+
+def test_sub_py_scalar(left: pd.Period) -> None:
+    """Test pd.Period - Python native scalars"""
+    d = timedelta(days=1)
+    i = 1
+    s = datetime(2025, 8, 20)
+
+    check(assert_type(left - d, pd.Period), pd.Period)
+    check(assert_type(left - i, pd.Period), pd.Period)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = left - "str"  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _2 = left - 1.5  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+
+
+def test_sub_numpy_scalar(left: pd.Period) -> None:
+    """Test pd.Period - numpy scalars"""
+    d = np.timedelta64(1, "D")
+    i = np.int64(1)
+    s = np.datetime64("2025-08-20")
+
+    check(assert_type(left - d, pd.Period), pd.Period)
+    check(assert_type(left - i, pd.Period), pd.Period)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+
+
+def test_sub_pd_scalar(left: pd.Period) -> None:
+    """Test pd.Period - pandas scalars"""
+    d = pd.Timedelta(days=1)
+    off = pd.offsets.Day(1)
+    p = pd.Period("2025-08-20", freq="D")
+    nat = pd.NaT
+
+    check(assert_type(left - d, pd.Period), pd.Period)
+    check(assert_type(left - off, pd.Period), pd.Period)
+    check(assert_type(left - p, BaseOffset), Day)
+    check(assert_type(left - nat, NaTType), NaTType)

--- a/tests/scalars/period/test_sub.py
+++ b/tests/scalars/period/test_sub.py
@@ -39,6 +39,11 @@ def test_sub_py_scalar(left: pd.Period) -> None:
         _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
         _1 = left - "str"  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
         _2 = left - 1.5  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _3 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _4 = i - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _5 = s - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _6 = "str" - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _7 = 1.5 - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
 
 def test_sub_numpy_scalar(left: pd.Period) -> None:
@@ -52,6 +57,9 @@ def test_sub_numpy_scalar(left: pd.Period) -> None:
 
     if TYPE_CHECKING_INVALID_USAGE:
         _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _2 = i - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _3 = s - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
 
 
 def test_sub_pd_scalar(left: pd.Period) -> None:
@@ -65,3 +73,7 @@ def test_sub_pd_scalar(left: pd.Period) -> None:
     check(assert_type(left - off, pd.Period), pd.Period)
     check(assert_type(left - p, BaseOffset), Day)
     check(assert_type(left - nat, NaTType), NaTType)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        _0 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
+        _1 = off - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -595,10 +595,9 @@ def test_timedelta_add_sub() -> None:
 
     # sub is not symmetric with dates. In general date_like - timedelta is
     # sensible, while timedelta - date_like is not
-    # TypeError: as_period, as_timestamp, as_datetime, as_date, as_datetime64,
+    # TypeError: as_timestamp, as_datetime, as_date, as_datetime64,
     #            as_period_index, as_datetime_index, as_ndarray_dt64
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = td - as_period  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
         _1 = td - as_timestamp  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
         _2 = td - as_datetime  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]
         _3 = td - as_date  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation] # ty: ignore[unsupported-operator]

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -613,7 +613,6 @@ def test_timedelta_add_sub() -> None:
     check(assert_type(td - as_timedelta_index, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(td - as_ndarray_td64, np_ndarray_td), np_ndarray, np.timedelta64)
     check(assert_type(td - as_nat, NaTType), NaTType)
-    check(assert_type(as_period - td, pd.Period), pd.Period)
     check(assert_type(as_timestamp - td, pd.Timestamp), pd.Timestamp)
     check(assert_type(as_datetime - td, dt.datetime), dt.datetime)
     check(assert_type(as_date - td, dt.date), dt.date)
@@ -1724,7 +1723,6 @@ def test_period_add_subtract() -> None:
     as_int: int = 1
     as_period_index = pd.period_range("2012-1-1", periods=10, freq="D")
     check(assert_type(as_period_index, pd.PeriodIndex), pd.PeriodIndex)
-    as_period = pd.Period("2012-1-1", freq="D")
     scale = 24 * 60 * 60 * 10**9
     as_td_series = pd.Series(pd.timedelta_range(scale, scale, freq="D"))
     check(assert_type(as_td_series, "pd.Series[pd.Timedelta]"), pd.Series, pd.Timedelta)
@@ -1755,17 +1753,9 @@ def test_period_add_subtract() -> None:
     offset_series = as_period_series - as_period_series
     check(assert_type(offset_series, "pd.Series[BaseOffset]"), pd.Series)
     check(assert_type(p + offset_series, "pd.Series[pd.Period]"), pd.Series, pd.Period)
-    check(assert_type(p - as_pd_td, pd.Period), pd.Period)
-    check(assert_type(p - as_dt_td, pd.Period), pd.Period)
-    check(assert_type(p - as_np_td, pd.Period), pd.Period)
-    check(assert_type(p - as_np_i64, pd.Period), pd.Period)
-    check(assert_type(p - as_int, pd.Period), pd.Period)
     check(assert_type(offset_index, pd.Index), pd.Index)
-    check(assert_type(p - as_period, BaseOffset), Day)
     check(assert_type(p - as_td_series, "pd.Series[pd.Period]"), pd.Series, pd.Period)
     check(assert_type(p - as_timedelta_idx, pd.PeriodIndex), pd.PeriodIndex)
-    check(assert_type(p - as_nat, NaTType), NaTType)
-    check(assert_type(p - p.freq, pd.Period), pd.Period)
 
     # The __radd__ and __rsub__ methods are included to
     # establish the location of the concrete implementation


### PR DESCRIPTION
- [x] Tests added (using `assert_type()` for return values)
- [x] AI-assisted development followed `AGENTS.md`

Moves `Period` scalar subtraction coverage into a focused test module. It covers valid Python, NumPy, and pandas scalar operands, the valid `Period - Period` offset case, plus invalid datetime-like, string, and float subtractions in both operand orders.

This is test-only: no stubs, aliases, or public interfaces change. Existing Series, Index, addition, and unrelated scalar coverage remains in `tests/scalars/test_scalars.py`.

<details><summary>AI Implementation Plan</summary>

### Motivation

Extract the independently useful `Period` scalar-subtraction tests from the `align-sub-family` branch so they can be reviewed and merged without the parent PR's larger typing and helper-type changes. This mirrors the addition-test extraction (pandas-dev/pandas-stubs#1933).

### Implementation

- Added the `tests/scalars/period` package and `test_sub.py`.
- Added valid subtraction cases for Python `timedelta` and `int`, NumPy `timedelta64` and `int64`, and pandas `Timedelta`, `Day`, `NaT`, and `Period` (with `Period - Period` typed as `BaseOffset`, checked as `Day`).
- Added negative tests under `TYPE_CHECKING_INVALID_USAGE` for Python `datetime`, `str`, and `float`, NumPy `datetime64`, and the backward `scalar - Period` forms of `timedelta`/`int`/`datetime`/`str`/`float`, NumPy `timedelta64`/`int64`/`datetime64`, and pandas `Timedelta`/`Day`.
- Removed only superseded scalar-subtraction assertions from `tests/scalars/test_scalars.py`.
- Retained its Series subtractions, Index subtractions, all addition checks, construction/property/comparison coverage, and unrelated scalar tests.

### Experiments and validation

- `poetry run pytest tests/scalars/period/test_sub.py`: 3 passed.
- `poetry run poe test_all`: all four static checkers (mypy, pyright, pyrefly, ty) passed on both local and installed stubs, 3,368 runtime tests passed with 6 skipped, and pre-commit passed.

### Caveats and out of scope

- This does not change typing behavior.
- Backward subtraction (`scalar - Period`) raises `TypeError` at runtime for every `PeriodAddSub` operand (`Timedelta`, `datetime.timedelta`, `np.timedelta64`, `np.int64`, `int`, `BaseOffset`/`Day`), so `Period` correctly omits `__rsub__`. These cases are therefore exercised negatively under `TYPE_CHECKING_INVALID_USAGE`, the analogue of #1933's backward-invalid addition cases.
- `NaT - Period` returns `NaTType` at runtime but is left untested: `NaTType` declares no `__sub__`/`__rsub__`, a pre-existing `NaTType` gap outside this test-only PR.
- Index/Series subtraction and all addition coverage remain in `tests/scalars/test_scalars.py`.
- Parent-PR integration is intentionally deferred until this PR merges.

### Outcome

Focused `Period` scalar-subtraction coverage passes independently against current `main`.

### Follow-up to-do

- [ ] Merge this PR first.
- [ ] Merge updated `upstream/main` into `align-sub-family`.
- [ ] Resolve `tests/scalars/test_scalars.py` by retaining the remaining non-scalar migrations while accepting this scalar extraction.
- [ ] Run `poetry run poe test_all` on the updated parent branch.

</details>

