### PR TITLE
TYP: align Index subtraction overloads

### DIFF
--- a/pandas-stubs/_stubs_only/__init__.pyi
+++ b/pandas-stubs/_stubs_only/__init__.pyi
@@ -6,7 +6,10 @@ from collections.abc import (
     Mapping,
     Sequence,
 )
-from datetime import timedelta
+from datetime import (
+    datetime,
+    timedelta,
+)
 from typing import (
     Any,
     Generic,
@@ -20,6 +23,7 @@ from typing import (
 import numpy as np
 from numpy import typing as npt
 from pandas.core.arrays import ExtensionArray
+from pandas.core.arrays.datetimes import DatetimeArray
 from pandas.core.arrays.floating import FloatingArray
 from pandas.core.arrays.integer import IntegerArray
 from pandas.core.arrays.timedeltas import TimedeltaArray
@@ -27,6 +31,7 @@ from pandas.core.base import T_INTERVAL_NP
 from pandas.core.groupby.base import ReductionKernelType
 from pandas.core.groupby.grouper import Grouper
 from pandas.core.indexes.base import Index
+from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.series import Series
 from typing_extensions import (
@@ -54,6 +59,7 @@ from pandas._typing import (
     np_ndarray_anyint,
     np_ndarray_bool,
     np_ndarray_complex,
+    np_ndarray_dt,
     np_ndarray_float,
     np_ndarray_td,
 )
@@ -150,6 +156,12 @@ ScalarArrayIndexComplex: TypeAlias = (
 SeriesComplex: TypeAlias = SeriesReal | Series[complex]
 ScalarArrayIndexSeriesComplex: TypeAlias = ScalarArrayIndexComplex | SeriesComplex
 
+ArrayIndexBoolNoSeq: TypeAlias = np_ndarray_bool | Index[bool]
+
+ArrayIndexBoolIntNoSeq: TypeAlias = (
+    np_ndarray_bool | np_ndarray_anyint | Index[bool] | Index[int]
+)
+
 ArrayIndexTimedeltaNoSeq: TypeAlias = np_ndarray_td | TimedeltaArray | TimedeltaIndex
 ScalarArrayIndexTimedelta: TypeAlias = (
     timedelta
@@ -160,6 +172,14 @@ ScalarArrayIndexTimedelta: TypeAlias = (
 ArrayIndexSeriesTimedeltaNoSeq: TypeAlias = ArrayIndexTimedeltaNoSeq | Series[Timedelta]
 ScalarArrayIndexSeriesTimedelta: TypeAlias = (
     ScalarArrayIndexTimedelta | Series[Timedelta]
+)
+
+ArrayIndexDatetimeNoSeq: TypeAlias = np_ndarray_dt | DatetimeArray | DatetimeIndex
+ScalarArrayIndexDatetime: TypeAlias = (
+    datetime
+    | np.datetime64
+    | Sequence[datetime | np.datetime64]
+    | ArrayIndexDatetimeNoSeq
 )
 
 NumListLike: TypeAlias = (  # TODO: pandas-dev/pandas-stubs#1474 deprecated, do not use
@@ -217,6 +237,55 @@ class ElementOpsMixin(Generic[S2]):
     ) -> ElementOpsMixin[complex]: ...
     @overload
     def _proto_radd(self: ElementOpsMixin[str], other: str) -> ElementOpsMixin[str]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[int], other: int | np.integer
+    ) -> ElementOpsMixin[int]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[float], other: float | np.floating
+    ) -> ElementOpsMixin[float]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[complex], other: complex | np.complexfloating
+    ) -> ElementOpsMixin[complex]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[Timedelta], other: timedelta | np.timedelta64 | Timedelta
+    ) -> ElementOpsMixin[Timedelta]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[Timestamp],
+        other: timedelta | np.timedelta64 | Timedelta | BaseOffset,
+    ) -> ElementOpsMixin[Timestamp]: ...
+    @overload
+    def _proto_sub(
+        self: ElementOpsMixin[Timestamp], other: datetime | np.datetime64 | Timestamp
+    ) -> ElementOpsMixin[Timedelta]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[int], other: int | np.integer
+    ) -> ElementOpsMixin[int]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[float], other: float | np.floating
+    ) -> ElementOpsMixin[float]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[complex], other: complex | np.complexfloating
+    ) -> ElementOpsMixin[complex]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[Timedelta], other: timedelta | np.timedelta64 | Timedelta
+    ) -> ElementOpsMixin[Timedelta]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[Timedelta], other: datetime | np.datetime64 | Timestamp
+    ) -> ElementOpsMixin[Timestamp]: ...
+    @overload
+    def _proto_rsub(
+        self: ElementOpsMixin[Timestamp], other: datetime | np.datetime64 | Timestamp
+    ) -> ElementOpsMixin[Timedelta]: ...
     @overload
     def _proto_mul(
         self: ElementOpsMixin[bool], other: bool | np.bool_
@@ -331,6 +400,14 @@ class Supports_ProtoAdd(Protocol[T_contra, S2]):
 @type_check_only
 class Supports_ProtoRAdd(Protocol[T_contra, S2]):
     def _proto_radd(self, other: T_contra, /) -> ElementOpsMixin[S2]: ...
+
+@type_check_only
+class Supports_ProtoSub(Protocol[T_contra, S2]):
+    def _proto_sub(self, other: T_contra, /) -> ElementOpsMixin[S2]: ...
+
+@type_check_only
+class Supports_ProtoRSub(Protocol[T_contra, S2]):
+    def _proto_rsub(self, other: T_contra, /) -> ElementOpsMixin[S2]: ...
 
 @type_check_only
 class Supports_ProtoMul(Protocol[T_contra, S2]):

--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -27,6 +27,8 @@ from _typeshed import (
     SupportsMul,
     SupportsRAdd,
     SupportsRMul,
+    SupportsRSub,
+    SupportsSub,
 )
 import numpy as np
 from pandas._stubs_only import (
@@ -758,13 +760,26 @@ class Index(IndexOpsMixin[S1], ElementOpsMixin[S1]):
     ) -> Index: ...
     @overload
     def __sub__(self, other: Index[Never], /) -> Index: ...
-    # Must precede `Supports_ProtoSub`: mypy matches it for `bool` (python/mypy#20061)
+    # Must precede `Supports_ProtoSub` (and `SupportsRSub`, which `Index[bool]`
+    # structurally satisfies because `bool <: int`): mypy matches it for `bool`
+    # (python/mypy#20061).
     @overload
-    def __sub__(self: Index[bool], other: bool | SequenceNotStr[bool], /) -> Never: ...
+    def __sub__(
+        self: Index[bool], other: bool | SequenceNotStr[bool] | np_ndarray_bool, /
+    ) -> Never: ...
     @overload
     def __sub__(
         self: Supports_ProtoSub[T_contra, S2], other: T_contra | Sequence[T_contra], /
     ) -> Index[S2]: ...
+    @overload
+    def __sub__(
+        self: Index[S2_contra],
+        other: (
+            SupportsRSub[S2_contra, S2_NSDT]
+            | Sequence[SupportsRSub[S2_contra, S2_NSDT]]
+        ),
+        /,
+    ) -> Index[S2_NSDT]: ...
     @overload
     def __sub__(self: Index[int], other: ArrayIndexBoolNoSeq, /) -> Index[int]: ...
     @overload
@@ -806,6 +821,14 @@ class Index(IndexOpsMixin[S1], ElementOpsMixin[S1]):
     def __rsub__(
         self: Supports_ProtoRSub[T_contra, S2], other: T_contra | Sequence[T_contra], /
     ) -> Index[S2]: ...
+    @overload
+    def __rsub__(
+        self: Index[S2_contra],
+        other: (
+            SupportsSub[S2_contra, S2_NSDT] | Sequence[SupportsSub[S2_contra, S2_NSDT]]
+        ),
+        /,
+    ) -> Index[S2_NSDT]: ...
     @overload
     def __rsub__(self: Index[int], other: ArrayIndexBoolNoSeq, /) -> Index[int]: ...
     @overload

--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -27,8 +27,6 @@ from _typeshed import (
     SupportsMul,
     SupportsRAdd,
     SupportsRMul,
-    SupportsRSub,
-    SupportsSub,
 )
 import numpy as np
 from pandas._stubs_only import (
@@ -760,26 +758,20 @@ class Index(IndexOpsMixin[S1], ElementOpsMixin[S1]):
     ) -> Index: ...
     @overload
     def __sub__(self, other: Index[Never], /) -> Index: ...
-    # Must precede `Supports_ProtoSub` (and `SupportsRSub`, which `Index[bool]`
-    # structurally satisfies because `bool <: int`): mypy matches it for `bool`
-    # (python/mypy#20061).
+    # Must precede `Supports_ProtoSub`: mypy matches it for `bool` (python/mypy#20061)
     @overload
-    def __sub__(
-        self: Index[bool], other: bool | SequenceNotStr[bool] | np_ndarray_bool, /
-    ) -> Never: ...
+    def __sub__(self: Index[bool], other: bool | SequenceNotStr[bool], /) -> Never: ...
+    # `-` follows `/`, not `+`/`*`: only the internal, self-bound
+    # `Supports_ProtoSub` plus explicit `Never` guards, with no external
+    # `_typeshed.Supports*` overload. `bool <: int` plus `Index[bool]`'s
+    # `Never`-guarded dunders structurally satisfy `SupportsRSub[bool, Never]`,
+    # so an external `Supports*` overload would greedily capture `Index[bool]`
+    # and resolve the invalid `Index[bool] - Index[bool]` to `Index[Never]`.
+    # See ADR-0023.
     @overload
     def __sub__(
         self: Supports_ProtoSub[T_contra, S2], other: T_contra | Sequence[T_contra], /
     ) -> Index[S2]: ...
-    @overload
-    def __sub__(
-        self: Index[S2_contra],
-        other: (
-            SupportsRSub[S2_contra, S2_NSDT]
-            | Sequence[SupportsRSub[S2_contra, S2_NSDT]]
-        ),
-        /,
-    ) -> Index[S2_NSDT]: ...
     @overload
     def __sub__(self: Index[int], other: ArrayIndexBoolNoSeq, /) -> Index[int]: ...
     @overload
@@ -817,18 +809,17 @@ class Index(IndexOpsMixin[S1], ElementOpsMixin[S1]):
     # Must precede `Supports_ProtoRSub`: mypy matches it for `bool` (python/mypy#20061)
     @overload
     def __rsub__(self: Index[bool], other: bool | SequenceNotStr[bool], /) -> Never: ...
+    # `-` follows `/`, not `+`/`*`: only the internal, self-bound
+    # `Supports_ProtoRSub` plus explicit `Never` guards, with no external
+    # `_typeshed.Supports*` overload. `bool <: int` plus `Index[bool]`'s
+    # `Never`-guarded dunders structurally satisfy `SupportsSub[bool, Never]`,
+    # so an external `Supports*` overload would greedily capture `Index[bool]`
+    # and resolve the invalid `Index[bool] - Index[bool]` to `Index[Never]`.
+    # See ADR-0023.
     @overload
     def __rsub__(
         self: Supports_ProtoRSub[T_contra, S2], other: T_contra | Sequence[T_contra], /
     ) -> Index[S2]: ...
-    @overload
-    def __rsub__(
-        self: Index[S2_contra],
-        other: (
-            SupportsSub[S2_contra, S2_NSDT] | Sequence[SupportsSub[S2_contra, S2_NSDT]]
-        ),
-        /,
-    ) -> Index[S2_NSDT]: ...
     @overload
     def __rsub__(self: Index[int], other: ArrayIndexBoolNoSeq, /) -> Index[int]: ...
     @overload

--- a/pandas-stubs/core/indexes/base.pyi
+++ b/pandas-stubs/core/indexes/base.pyi
@@ -30,6 +30,8 @@ from _typeshed import (
 )
 import numpy as np
 from pandas._stubs_only import (
+    ArrayIndexBoolIntNoSeq,
+    ArrayIndexBoolNoSeq,
     ArrayIndexTimedeltaNoSeq,
     ElementOpsMixin,
     IndexComplex,
@@ -47,7 +49,9 @@ from pandas._stubs_only import (
     Supports_ProtoRAdd,
     Supports_ProtoRFloorDiv,
     Supports_ProtoRMul,
+    Supports_ProtoRSub,
     Supports_ProtoRTrueDiv,
+    Supports_ProtoSub,
     Supports_ProtoTrueDiv,
     T_contra,
 )
@@ -98,7 +102,6 @@ from pandas._typing import (
     IgnoreRaise,
     IntDtypeArg,
     JoinHow,
-    Just,
     Label,
     Level,
     MaskType,
@@ -750,158 +753,84 @@ class Index(IndexOpsMixin[S1], ElementOpsMixin[S1]):
     @overload
     def __sub__(self: Index[Never], other: DatetimeIndex, /) -> Never: ...
     @overload
-    def __sub__(
+    def __sub__(  # type: ignore[overload-overlap]
         self: Index[Never], other: complex | ArrayLike | SequenceNotStr[S1] | Index, /
     ) -> Index: ...
     @overload
     def __sub__(self, other: Index[Never], /) -> Index: ...
+    # Must precede `Supports_ProtoSub`: mypy matches it for `bool` (python/mypy#20061)
+    @overload
+    def __sub__(self: Index[bool], other: bool | SequenceNotStr[bool], /) -> Never: ...
     @overload
     def __sub__(
-        self: Index[bool],
-        other: Just[int] | Sequence[Just[int]] | np_ndarray_anyint | Index[int],
-        /,
+        self: Supports_ProtoSub[T_contra, S2], other: T_contra | Sequence[T_contra], /
+    ) -> Index[S2]: ...
+    @overload
+    def __sub__(self: Index[int], other: ArrayIndexBoolNoSeq, /) -> Index[int]: ...
+    @overload
+    def __sub__(
+        self: Index[bool] | Index[int], other: ScalarArrayIndexJustInt, /
     ) -> Index[int]: ...
     @overload
     def __sub__(
-        self: Index[bool],
-        other: Just[float] | Sequence[Just[float]] | np_ndarray_float | Index[float],
-        /,
+        self: Index[float], other: ArrayIndexBoolIntNoSeq, /
     ) -> Index[float]: ...
     @overload
     def __sub__(
-        self: Index[int],
-        other: (
-            int
-            | Sequence[int]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | Index[bool]
-            | Index[int]
-        ),
-        /,
-    ) -> Index[int]: ...
-    @overload
-    def __sub__(
-        self: Index[int],
-        other: Just[float] | Sequence[Just[float]] | np_ndarray_float | Index[float],
-        /,
-    ) -> Index[float]: ...
-    @overload
-    def __sub__(
-        self: Index[float],
-        other: (
-            float
-            | Sequence[float]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | np_ndarray_float
-            | Index[bool]
-            | Index[int]
-            | Index[float]
-        ),
-        /,
-    ) -> Index[float]: ...
-    @overload
-    def __sub__(
-        self: Index[complex],
-        other: (
-            T_COMPLEX
-            | Sequence[T_COMPLEX]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | np_ndarray_float
-            | Index[T_COMPLEX]
-        ),
-        /,
+        self: Index[complex], other: ArrayIndexBoolIntNoSeq, /
     ) -> Index[complex]: ...
     @overload
     def __sub__(
-        self: Index[T_COMPLEX],
-        other: (
-            Just[complex]
-            | Sequence[Just[complex]]
-            | np_ndarray_complex
-            | Index[complex]
-        ),
-        /,
+        self: Index[bool] | Index[int], other: ScalarArrayIndexJustFloat, /
+    ) -> Index[float]: ...
+    @overload
+    def __sub__(
+        self: Index[T_COMPLEX], other: ScalarArrayIndexJustFloat, /
+    ) -> Index[T_COMPLEX]: ...
+    @overload
+    def __sub__(
+        self: IndexComplex, other: ScalarArrayIndexJustComplex, /
     ) -> Index[complex]: ...
     @overload
     def __rsub__(self: Index[Never], other: DatetimeIndex, /) -> Never: ...  # type: ignore[misc]
     @overload
-    def __rsub__(
+    def __rsub__(  # type: ignore[overload-overlap]
         self: Index[Never], other: complex | ArrayLike | SequenceNotStr[S1] | Index, /
     ) -> Index: ...
     @overload
     def __rsub__(self, other: Index[Never], /) -> Index: ...
+    # Must precede `Supports_ProtoRSub`: mypy matches it for `bool` (python/mypy#20061)
+    @overload
+    def __rsub__(self: Index[bool], other: bool | SequenceNotStr[bool], /) -> Never: ...
     @overload
     def __rsub__(
-        self: Index[bool],
-        other: Just[int] | Sequence[Just[int]] | np_ndarray_anyint | Index[int],
-        /,
+        self: Supports_ProtoRSub[T_contra, S2], other: T_contra | Sequence[T_contra], /
+    ) -> Index[S2]: ...
+    @overload
+    def __rsub__(self: Index[int], other: ArrayIndexBoolNoSeq, /) -> Index[int]: ...
+    @overload
+    def __rsub__(
+        self: Index[bool] | Index[int], other: ScalarArrayIndexJustInt, /
     ) -> Index[int]: ...
     @overload
-    def __rsub__(
-        self: Index[bool],
-        other: Just[float] | Sequence[Just[float]] | np_ndarray_float | Index[float],
-        /,
+    def __rsub__(  # type: ignore[misc]
+        self: Index[float], other: ArrayIndexBoolIntNoSeq, /
     ) -> Index[float]: ...
     @overload
     def __rsub__(
-        self: Index[int],
-        other: (
-            int
-            | Sequence[int]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | Index[bool]
-            | Index[int]
-        ),
-        /,
-    ) -> Index[int]: ...
-    @overload
-    def __rsub__(
-        self: Index[int],
-        other: Just[float] | Sequence[Just[float]] | np_ndarray_float | Index[float],
-        /,
-    ) -> Index[float]: ...
-    @overload
-    def __rsub__(
-        self: Index[float],
-        other: (
-            float
-            | Sequence[float]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | np_ndarray_float
-            | Index[bool]
-            | Index[int]
-            | Index[float]
-        ),
-        /,
-    ) -> Index[float]: ...
-    @overload
-    def __rsub__(
-        self: Index[complex],
-        other: (
-            T_COMPLEX
-            | Sequence[T_COMPLEX]
-            | np_ndarray_bool
-            | np_ndarray_anyint
-            | np_ndarray_float
-            | Index[T_COMPLEX]
-        ),
-        /,
+        self: Index[complex], other: ArrayIndexBoolIntNoSeq, /
     ) -> Index[complex]: ...
     @overload
     def __rsub__(
-        self: Index[T_COMPLEX],
-        other: (
-            Just[complex]
-            | Sequence[Just[complex]]
-            | np_ndarray_complex
-            | Index[complex]
-        ),
-        /,
+        self: Index[bool] | Index[int], other: ScalarArrayIndexJustFloat, /
+    ) -> Index[float]: ...
+    @overload
+    def __rsub__(
+        self: Index[T_COMPLEX], other: ScalarArrayIndexJustFloat, /
+    ) -> Index[T_COMPLEX]: ...
+    @overload
+    def __rsub__(
+        self: IndexComplex, other: ScalarArrayIndexJustComplex, /
     ) -> Index[complex]: ...
     @overload
     def __mul__(

--- a/pandas-stubs/core/indexes/datetimes.pyi
+++ b/pandas-stubs/core/indexes/datetimes.pyi
@@ -3,7 +3,6 @@ from collections.abc import (
     Sequence,
 )
 from datetime import (
-    datetime,
     time,
     timedelta,
 )
@@ -17,6 +16,10 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+from pandas._stubs_only import (
+    ScalarArrayIndexDatetime,
+    ScalarArrayIndexTimedelta,
+)
 from pandas.core.frame import DataFrame
 from pandas.core.indexes.accessors import DatetimeIndexProperties
 from pandas.core.indexes.base import Index
@@ -36,8 +39,6 @@ from pandas._typing import (
     np_1darray_intp,
     np_ndarray,
     np_ndarray_bool,
-    np_ndarray_dt,
-    np_ndarray_td,
 )
 
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
@@ -69,12 +70,16 @@ class DatetimeIndex(
     @overload  # type: ignore[override]
     @override
     def __sub__(  # pyrefly: ignore[bad-override]
-        self, other: datetime | np.datetime64 | np_ndarray_dt | Self, /
+        self, other: ScalarArrayIndexDatetime, /
     ) -> TimedeltaIndex: ...
     @overload
     def __sub__(  # pyright: ignore[reportIncompatibleMethodOverride] # ty: ignore[invalid-method-override]
-        self, other: timedelta | np.timedelta64 | np_ndarray_td | BaseOffset, /
+        self, other: ScalarArrayIndexTimedelta | BaseOffset, /
     ) -> Self: ...
+    @override
+    def __rsub__(  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override] # ty: ignore[invalid-method-override]
+        self, other: ScalarArrayIndexDatetime, /
+    ) -> TimedeltaIndex: ...
     @override
     def __truediv__(self, other: np_ndarray, /) -> Never: ...  # type: ignore[override]
     @override

--- a/pandas-stubs/core/indexes/timedeltas.pyi
+++ b/pandas-stubs/core/indexes/timedeltas.pyi
@@ -16,6 +16,10 @@ from typing import (
 )
 
 import numpy as np
+from pandas._stubs_only import (
+    ScalarArrayIndexDatetime,
+    ScalarArrayIndexTimedelta,
+)
 from pandas.core.indexes.accessors import TimedeltaIndexProperties
 from pandas.core.indexes.base import Index
 from pandas.core.indexes.datetimelike import DatetimeTimedeltaMixin
@@ -26,7 +30,6 @@ from typing_extensions import override
 
 from pandas._libs import Timedelta
 from pandas._libs.lib import NoDefault
-from pandas._libs.tslibs import BaseOffset
 from pandas._libs.tslibs.period import Period
 from pandas._typing import (
     AxesData,
@@ -88,20 +91,22 @@ class TimedeltaIndex(
     def __radd__(  # pyright: ignore[reportIncompatibleMethodOverride] # ty: ignore[invalid-method-override]
         self, other: timedelta | Self, /
     ) -> Self: ...
-    @override
-    def __sub__(  # type: ignore[override] # pyright: ignore[reportIncompatibleMethodOverride] # pyrefly: ignore[bad-override] # ty: ignore[invalid-method-override]
-        self, other: timedelta | np.timedelta64 | np_ndarray_td | BaseOffset | Self, /
-    ) -> Self: ...
     @overload  # type: ignore[override]
     @override
     # pyrefly: ignore[bad-override]
-    def __rsub__(
-        self, other: timedelta | np.timedelta64 | np_ndarray_td | BaseOffset | Self, /
-    ) -> Self: ...
+    def __sub__(self, other: ScalarArrayIndexTimedelta, /) -> Self: ...
+    @overload
+    def __sub__(  # pyright: ignore[reportIncompatibleMethodOverride] # ty: ignore[invalid-method-override]
+        self, other: ScalarArrayIndexDatetime, /
+    ) -> Never: ...
+    @overload  # type: ignore[override]
+    @override
+    # pyrefly: ignore[bad-override]
+    def __rsub__(self, other: ScalarArrayIndexDatetime, /) -> DatetimeIndex: ...
     @overload
     def __rsub__(  # pyright: ignore[reportIncompatibleMethodOverride] # ty: ignore[invalid-method-override]
-        self, other: datetime | np.datetime64 | np_ndarray_dt | DatetimeIndex, /
-    ) -> DatetimeIndex: ...
+        self, other: ScalarArrayIndexTimedelta, /
+    ) -> Self: ...
     @overload  # type: ignore[override]
     @override
     def __mul__(self, other: np_ndarray_bool | np_ndarray_complex, /) -> Never: ...

--- a/tests/indexes/bool/test_sub.py
+++ b/tests/indexes/bool/test_sub.py
@@ -27,13 +27,13 @@ def test_sub_py_scalar(left: "pd.Index[bool]") -> None:
     b, i, f, c = True, 1, 1.0, 1j
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        assert_type(left - b, Never)
     check(assert_type(left - i, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(left - f, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(left - c, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _1 = b - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        assert_type(b - left, Never)
     check(assert_type(i - left, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(f - left, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
@@ -44,13 +44,13 @@ def test_sub_py_sequence(left: "pd.Index[bool]") -> None:
     b, i, f, c = [True, False, True], [2, 3, 5], [1.0, 2.0, 3.0], [1j, 1j, 4j]
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        assert_type(left - b, Never)
     check(assert_type(left - i, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(left - f, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(left - c, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _1 = b - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        assert_type(b - left, Never)
     check(assert_type(i - left, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(f - left, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)

--- a/tests/indexes/bool/test_sub.py
+++ b/tests/indexes/bool/test_sub.py
@@ -91,13 +91,13 @@ def test_sub_pd_index(left: "pd.Index[bool]") -> None:
     c = pd.Index([1.1j, 2.2j, 4.1j])
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _0 = left - b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        assert_type(left - b, "pd.Index[Never]")
     check(assert_type(left - i, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(left - f, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(left - c, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        _1 = b - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+        assert_type(b - left, "pd.Index[Never]")
     check(assert_type(i - left, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(f - left, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)

--- a/tests/indexes/bool/test_sub.py
+++ b/tests/indexes/bool/test_sub.py
@@ -91,13 +91,13 @@ def test_sub_pd_index(left: "pd.Index[bool]") -> None:
     c = pd.Index([1.1j, 2.2j, 4.1j])
 
     if TYPE_CHECKING_INVALID_USAGE:
-        assert_type(left - b, "pd.Index[Never]")
+        _0 = left - b  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
     check(assert_type(left - i, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(left - f, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(left - c, "pd.Index[complex]"), pd.Index, np.complexfloating)
 
     if TYPE_CHECKING_INVALID_USAGE:
-        assert_type(b - left, "pd.Index[Never]")
+        _1 = b - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
     check(assert_type(i - left, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(f - left, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)

--- a/tests/indexes/datetimeindex/test_sub.py
+++ b/tests/indexes/datetimeindex/test_sub.py
@@ -113,8 +113,8 @@ def test_sub_numpy_array(left: pd.DatetimeIndex) -> None:
     check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
 
     # `numpy` typing gives the corresponding `ndarray`s in the static type
-    # checking, where our `__rsub__` cannot override. At runtime, they return
-    # `TimedeltaIndex`.
+    # checking, where our `__rsub__` cannot override. At runtime, `s - left`
+    # returns a `TimedeltaIndex`, while `d - left` raises `TypeError`.
     check(assert_type(s - left, np_ndarray_dt), pd.TimedeltaIndex, pd.Timedelta)
     if TYPE_CHECKING_INVALID_USAGE:
         assert_type(d - left, np_ndarray_td)

--- a/tests/indexes/datetimeindex/test_sub.py
+++ b/tests/indexes/datetimeindex/test_sub.py
@@ -1,0 +1,133 @@
+from datetime import (
+    datetime,
+    timedelta,
+)
+from typing import (
+    Never,
+    assert_type,
+)
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    check,
+)
+from tests._typing import (
+    np_ndarray_dt,
+    np_ndarray_td,
+)
+
+
+@pytest.fixture
+def left() -> pd.DatetimeIndex:
+    """Left operand"""
+    lo = pd.DatetimeIndex(["2025-08-20"])
+    return check(assert_type(lo, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+
+def test_sub_py_scalar(left: pd.DatetimeIndex) -> None:
+    """Test pd.DatetimeIndex - Python native scalars"""
+    s = datetime(2025, 8, 20)
+    d = timedelta(seconds=1)
+
+    check(assert_type(left - s, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+    check(assert_type(s - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    if TYPE_CHECKING_INVALID_USAGE:
+        _1 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+
+
+def test_sub_numpy_scalar(left: pd.DatetimeIndex) -> None:
+    """Test pd.DatetimeIndex - numpy scalars"""
+    s = np.datetime64("2025-08-20")
+    d = np.timedelta64(1, "s")
+
+    check(assert_type(left - s, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+    check(assert_type(s - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    if TYPE_CHECKING_INVALID_USAGE:
+        _1 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+
+
+def test_sub_pd_scalar(left: pd.DatetimeIndex) -> None:
+    """Test pd.DatetimeIndex - pandas scalars"""
+    s = pd.Timestamp("2025-08-20")
+    d = pd.Timedelta(seconds=1)
+
+    check(assert_type(left - s, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+    check(assert_type(s - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    if TYPE_CHECKING_INVALID_USAGE:
+        _1 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+
+
+def test_sub_py_sequence(left: pd.DatetimeIndex) -> None:
+    """Test pd.DatetimeIndex - Python native sequences"""
+    s = [datetime(2025, 8, 20)]
+    d = [timedelta(seconds=1)]
+
+    check(assert_type(left - s, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+    check(assert_type(s - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    if TYPE_CHECKING_INVALID_USAGE:
+        _1 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+
+
+def test_sub_numpy_scalar_sequence(left: pd.DatetimeIndex) -> None:
+    """Test pd.DatetimeIndex - sequences of numpy scalars"""
+    s = [np.datetime64("2025-08-20")]
+    d = [np.timedelta64(1, "s")]
+
+    check(assert_type(left - s, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+    check(assert_type(s - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    if TYPE_CHECKING_INVALID_USAGE:
+        _1 = d - left  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+
+
+def test_sub_pd_array(left: pd.DatetimeIndex) -> None:
+    """Test pd.DatetimeIndex - pandas extension arrays"""
+    s = pd.array([datetime(2025, 8, 20)])
+    d = pd.array([timedelta(seconds=1)])
+
+    check(assert_type(left - s, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+    check(s - left, pd.TimedeltaIndex, pd.Timedelta)
+
+
+def test_sub_numpy_array(left: pd.DatetimeIndex) -> None:
+    """Test pd.DatetimeIndex - numpy arrays"""
+    s = np.array([np.datetime64("2025-08-20")], np.datetime64)
+    d = np.array([np.timedelta64(1, "s")], np.timedelta64)
+
+    check(assert_type(left - s, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+    # `numpy` typing gives the corresponding `ndarray`s in the static type
+    # checking, where our `__rsub__` cannot override. At runtime, they return
+    # `TimedeltaIndex`.
+    check(assert_type(s - left, np_ndarray_dt), pd.TimedeltaIndex, pd.Timedelta)
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(d - left, np_ndarray_td)
+
+
+def test_sub_pd_index(left: pd.DatetimeIndex) -> None:
+    """Test pd.DatetimeIndex - pandas Indexes"""
+    s = pd.Index([pd.Timestamp("2025-08-20")])
+    d = pd.Index([pd.Timedelta(seconds=1)])
+
+    check(assert_type(left - s, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(left - d, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+
+    check(assert_type(s - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(d - left, Never)

--- a/tests/indexes/int/test_sub.py
+++ b/tests/indexes/int/test_sub.py
@@ -8,8 +8,28 @@ from numpy import typing as npt  # noqa: F401
 import pandas as pd
 import pytest
 
-from tests import check
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    check,
+)
 from tests._typing import np_ndarray_int64
+
+
+class _ReflectedSub:
+    """External scalar whose reflected ``__sub__``/``__rsub__`` returns an int.
+
+    Stands in for a user (or third-party) object that pandas subtracts an
+    :class:`Index` against. Because its reflected dunders return a scalar
+    element type, the ``_typeshed.SupportsRSub``/``SupportsSub`` overloads on
+    ``Index.__sub__``/``__rsub__`` are selected and the result is pinned to
+    ``Index[int]`` rather than falling through to the untyped/error path.
+    """
+
+    def __rsub__(self, other: int, /) -> int:
+        return other
+
+    def __sub__(self, other: int, /) -> int:
+        return other
 
 
 @pytest.fixture
@@ -92,3 +112,17 @@ def test_sub_pd_index(left: "pd.Index[int]") -> None:
     check(assert_type(i - left, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(f - left, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
+
+
+def test_sub_external_reflected(left: "pd.Index[int]") -> None:
+    """Test pd.Index[int] - an external operand with reflected subtraction.
+
+    The ``SupportsRSub``/``SupportsSub`` overloads give element-type precision
+    for an operand whose reflected ``__sub__``/``__rsub__`` returns a scalar
+    dtype (``int`` here). These are rejected as unsupported operators without
+    those overloads; the reflected dunders do not run at runtime, so this is
+    asserted only under ``TYPE_CHECKING_INVALID_USAGE``.
+    """
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - _ReflectedSub(), "pd.Index[int]")
+        assert_type(_ReflectedSub() - left, "pd.Index[int]")

--- a/tests/indexes/int/test_sub.py
+++ b/tests/indexes/int/test_sub.py
@@ -8,28 +8,8 @@ from numpy import typing as npt  # noqa: F401
 import pandas as pd
 import pytest
 
-from tests import (
-    TYPE_CHECKING_INVALID_USAGE,
-    check,
-)
+from tests import check
 from tests._typing import np_ndarray_int64
-
-
-class _ReflectedSub:
-    """External scalar whose reflected ``__sub__``/``__rsub__`` returns an int.
-
-    Stands in for a user (or third-party) object that pandas subtracts an
-    :class:`Index` against. Because its reflected dunders return a scalar
-    element type, the ``_typeshed.SupportsRSub``/``SupportsSub`` overloads on
-    ``Index.__sub__``/``__rsub__`` are selected and the result is pinned to
-    ``Index[int]`` rather than falling through to the untyped/error path.
-    """
-
-    def __rsub__(self, other: int, /) -> int:
-        return other
-
-    def __sub__(self, other: int, /) -> int:
-        return other
 
 
 @pytest.fixture
@@ -112,17 +92,3 @@ def test_sub_pd_index(left: "pd.Index[int]") -> None:
     check(assert_type(i - left, "pd.Index[int]"), pd.Index, np.integer)
     check(assert_type(f - left, "pd.Index[float]"), pd.Index, np.floating)
     check(assert_type(c - left, "pd.Index[complex]"), pd.Index, np.complexfloating)
-
-
-def test_sub_external_reflected(left: "pd.Index[int]") -> None:
-    """Test pd.Index[int] - an external operand with reflected subtraction.
-
-    The ``SupportsRSub``/``SupportsSub`` overloads give element-type precision
-    for an operand whose reflected ``__sub__``/``__rsub__`` returns a scalar
-    dtype (``int`` here). These are rejected as unsupported operators without
-    those overloads; the reflected dunders do not run at runtime, so this is
-    asserted only under ``TYPE_CHECKING_INVALID_USAGE``.
-    """
-    if TYPE_CHECKING_INVALID_USAGE:
-        assert_type(left - _ReflectedSub(), "pd.Index[int]")
-        assert_type(_ReflectedSub() - left, "pd.Index[int]")

--- a/tests/indexes/periodindex/test_sub.py
+++ b/tests/indexes/periodindex/test_sub.py
@@ -1,0 +1,70 @@
+from datetime import (
+    datetime,
+    timedelta,
+)
+from typing import assert_type
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    check,
+)
+
+from pandas.tseries.offsets import Day
+
+
+@pytest.fixture
+def left() -> pd.PeriodIndex:
+    """Left operand"""
+    lo = pd.PeriodIndex(["2025-08-20"], freq="D")
+    return check(assert_type(lo, pd.PeriodIndex), pd.PeriodIndex, pd.Period)
+
+
+def test_sub_py_scalar(left: pd.PeriodIndex) -> None:
+    """Test pd.PeriodIndex - Python native scalars"""
+    d = timedelta(days=1)
+    i = 1
+    s = datetime(2025, 8, 20)
+
+    check(assert_type(left - d, pd.PeriodIndex), pd.PeriodIndex, pd.Period)
+    check(assert_type(left - i, pd.PeriodIndex), pd.PeriodIndex, pd.Period)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+
+
+def test_sub_numpy_scalar(left: pd.PeriodIndex) -> None:
+    """Test pd.PeriodIndex - numpy scalars"""
+    d = np.timedelta64(1, "D")
+    i = np.int64(1)
+    s = np.datetime64("2025-08-20")
+
+    check(assert_type(left - d, pd.PeriodIndex), pd.PeriodIndex, pd.Period)
+    check(assert_type(left - i, pd.PeriodIndex), pd.PeriodIndex, pd.Period)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        _0 = left - s  # type: ignore[operator] # pyright: ignore[reportOperatorIssue,reportUnknownVariableType] # pyrefly: ignore[unsupported-operation]
+
+
+def test_sub_pd_scalar(left: pd.PeriodIndex) -> None:
+    """Test pd.PeriodIndex - pandas scalars"""
+    d = pd.Timedelta(days=1)
+    off = Day(1)
+    p = pd.Period("2025-08-20", freq="D")
+
+    check(assert_type(left - d, pd.PeriodIndex), pd.PeriodIndex, pd.Period)
+    check(assert_type(left - off, pd.PeriodIndex), pd.PeriodIndex, pd.Period)
+    check(assert_type(left - p, pd.Index), pd.Index)
+    check(assert_type(p - left, pd.Index), pd.Index)
+
+
+def test_sub_pd_index(left: pd.PeriodIndex) -> None:
+    """Test pd.PeriodIndex - pandas Indexes"""
+    pi = pd.PeriodIndex(["2025-08-20"], freq="D")
+    ti = pd.TimedeltaIndex([pd.Timedelta(days=1)])
+
+    check(assert_type(left - pi, pd.Index), pd.Index)
+    check(assert_type(left - ti, pd.PeriodIndex), pd.PeriodIndex, pd.Period)

--- a/tests/indexes/test_indexes.py
+++ b/tests/indexes/test_indexes.py
@@ -1299,13 +1299,10 @@ def test_new() -> None:
 def test_datetime_operators_builtin() -> None:
     time = pd.date_range("2022-01-01", "2022-01-31", freq="D")
     check(assert_type(time + dt.timedelta(0), pd.DatetimeIndex), pd.DatetimeIndex)
-    check(assert_type(time - dt.timedelta(0), pd.DatetimeIndex), pd.DatetimeIndex)
-    check(assert_type(time - dt.datetime.now(), pd.TimedeltaIndex), pd.TimedeltaIndex)
 
     delta = check(assert_type(time - time, pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(delta + dt.timedelta(0), pd.TimedeltaIndex), pd.TimedeltaIndex)
     check(assert_type(dt.datetime.now() + delta, pd.DatetimeIndex), pd.DatetimeIndex)
-    check(assert_type(delta - dt.timedelta(0), pd.TimedeltaIndex), pd.TimedeltaIndex)
 
 
 def test_get_loc() -> None:

--- a/tests/indexes/timedeltaindex/test_sub.py
+++ b/tests/indexes/timedeltaindex/test_sub.py
@@ -1,0 +1,137 @@
+from datetime import (
+    datetime,
+    timedelta,
+)
+from typing import (
+    Never,
+    assert_type,
+)
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tests import (
+    TYPE_CHECKING_INVALID_USAGE,
+    check,
+)
+from tests._typing import (
+    np_ndarray_dt,
+    np_ndarray_td,
+)
+
+
+@pytest.fixture
+def left() -> pd.TimedeltaIndex:
+    """Left operand"""
+    lo = pd.Index([pd.Timedelta(1, "s")])
+    return check(assert_type(lo, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+
+def test_sub_py_scalar(left: pd.TimedeltaIndex) -> None:
+    """Test pd.TimedeltaIndex - Python native scalars"""
+    s = datetime(2025, 8, 20)
+    d = timedelta(seconds=1)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - s, Never)
+    check(assert_type(left - d, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+    check(assert_type(s - left, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+    check(assert_type(d - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+
+def test_sub_numpy_scalar(left: pd.TimedeltaIndex) -> None:
+    """Test pd.TimedeltaIndex - numpy scalars"""
+    s = np.datetime64("2025-08-20")
+    d = np.timedelta64(1, "s")
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - s, Never)
+    check(assert_type(left - d, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+    check(assert_type(s - left, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+    check(assert_type(d - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+
+def test_sub_pd_scalar(left: pd.TimedeltaIndex) -> None:
+    """Test pd.TimedeltaIndex - pandas scalars"""
+    s = pd.Timestamp("2025-08-20")
+    d = pd.Timedelta(seconds=1)
+    p = pd.Period("2025-08-20", freq="s")
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - s, Never)
+    check(assert_type(left - d, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+    check(assert_type(s - left, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+    check(assert_type(d - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+    check(assert_type(p - left, pd.PeriodIndex), pd.PeriodIndex, pd.Period)
+
+
+def test_sub_py_sequence(left: pd.TimedeltaIndex) -> None:
+    """Test pd.TimedeltaIndex - Python native sequences"""
+    s = [datetime(2025, 8, 20)]
+    d = [timedelta(seconds=1)]
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - s, Never)
+    check(assert_type(left - d, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+    check(assert_type(s - left, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+    check(assert_type(d - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+
+def test_sub_numpy_scalar_sequence(left: pd.TimedeltaIndex) -> None:
+    """Test pd.TimedeltaIndex - sequences of numpy scalars"""
+    s = [np.datetime64("2025-08-20")]
+    d = [np.timedelta64(1, "s")]
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - s, Never)
+    check(assert_type(left - d, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+    check(assert_type(s - left, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+    check(assert_type(d - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+
+def test_sub_pd_array(left: pd.TimedeltaIndex) -> None:
+    """Test pd.TimedeltaIndex - pandas extension arrays"""
+    s = pd.array([datetime(2025, 8, 20)])
+    d = pd.array([timedelta(seconds=1)])
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - s, Never)
+    check(assert_type(left - d, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+    check(s - left, pd.DatetimeIndex, pd.Timestamp)
+    check(d - left, pd.TimedeltaIndex, pd.Timedelta)
+
+
+def test_sub_numpy_array(left: pd.TimedeltaIndex) -> None:
+    """Test pd.TimedeltaIndex - numpy arrays"""
+    s = np.array([np.datetime64("2025-08-20")], np.datetime64)
+    d = np.array([np.timedelta64(1, "s")], np.timedelta64)
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - s, Never)
+    check(assert_type(left - d, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+    # `numpy` typing gives the corresponding `ndarray`s in the static type
+    # checking, where our `__rsub__` cannot override. At runtime, they return
+    # `DatetimeIndex` or `TimedeltaIndex`.
+    check(assert_type(s - left, np_ndarray_dt), pd.DatetimeIndex, pd.Timestamp)
+    check(assert_type(d - left, np_ndarray_td), pd.TimedeltaIndex, pd.Timedelta)
+
+
+def test_sub_pd_index(left: pd.TimedeltaIndex) -> None:
+    """Test pd.TimedeltaIndex - pandas Indexes"""
+    s = pd.Index([pd.Timestamp("2025-08-20")])
+    d = pd.Index([pd.Timedelta(seconds=1)])
+
+    if TYPE_CHECKING_INVALID_USAGE:
+        assert_type(left - s, Never)
+    check(assert_type(left - d, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)
+
+    check(assert_type(s - left, pd.DatetimeIndex), pd.DatetimeIndex, pd.Timestamp)
+    check(assert_type(d - left, pd.TimedeltaIndex), pd.TimedeltaIndex, pd.Timedelta)

--- a/tests/scalars/test_scalars.py
+++ b/tests/scalars/test_scalars.py
@@ -541,7 +541,6 @@ def test_timedelta_add_sub() -> None:
 
     ndarray_td64: np_ndarray_td = np.array([1, 2, 3], dtype="timedelta64[D]")
     ndarray_dt64: np_ndarray_dt = np.array([1, 2, 3], dtype="datetime64[D]")
-    as_period = pd.Period("2012-01-01", freq="D")
     as_timestamp = pd.Timestamp("2012-01-01")
     as_datetime = dt.datetime(2012, 1, 1)
     as_date = dt.date(2012, 1, 1)
@@ -1713,11 +1712,6 @@ def test_period_properties() -> None:
 def test_period_add_subtract() -> None:
     p = pd.Period("2012-1-1", freq="D")
 
-    as_pd_td = pd.Timedelta(1, "D")
-    as_dt_td = dt.timedelta(days=1)
-    as_np_td = np.timedelta64(1, "D")
-    as_np_i64 = np.int64(1)
-    as_int: int = 1
     as_period_index = pd.period_range("2012-1-1", periods=10, freq="D")
     check(assert_type(as_period_index, pd.PeriodIndex), pd.PeriodIndex)
     scale = 24 * 60 * 60 * 10**9
@@ -1726,8 +1720,6 @@ def test_period_add_subtract() -> None:
     as_period_series = pd.Series(as_period_index)
     check(assert_type(as_period_series, "pd.Series[pd.Period]"), pd.Series, pd.Period)
     as_timedelta_idx = pd.timedelta_range(scale, scale, freq="D")
-    as_nat = pd.NaT
-
     # offset_index is tested below
     offset_index = p - as_period_index
     # https://github.com/pandas-dev/pandas/issues/50162 dtype=object
@@ -1745,13 +1737,9 @@ def test_period_add_subtract() -> None:
     check(assert_type(p + offset_series, "pd.Series[pd.Period]"), pd.Series, pd.Period)
     check(assert_type(offset_index, pd.Index), pd.Index)
     check(assert_type(p - as_td_series, "pd.Series[pd.Period]"), pd.Series, pd.Period)
-    check(assert_type(p - as_timedelta_idx, pd.PeriodIndex), pd.PeriodIndex)
-
     check(assert_type(as_td_series + p, "pd.Series[pd.Period]"), pd.Series, pd.Period)
 
     check(assert_type(as_timedelta_idx + p, pd.PeriodIndex), pd.PeriodIndex)
-
-    check(assert_type(as_period_index - p, pd.Index), pd.Index)
 
 
 def test_period_cmp_scalar() -> None:


### PR DESCRIPTION
- [x] Towards pandas-dev/pandas-stubs#1474
- [x] Tests added (using `assert_type()` for return types)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Aligns `Index.__sub__`/`Index.__rsub__` with pandas runtime behavior, including the datetime-like Index subclasses (`DatetimeIndex`, `PeriodIndex`, `TimedeltaIndex`). Consolidates the repeated subtraction operand unions in `core/indexes/base.pyi` onto named aliases in `_stubs_only`, and adds focused per-type subtraction tests for those three Index subtypes.

On top of that (follow-up `bc985f07`) the change added `_typeshed.SupportsRSub`/`SupportsSub` reflected-dunder overloads to `Index.__sub__`/`__rsub__`, mirroring `__add__`/`__mul__`. That parity approach was then **reverted** by follow-up `a976e506`: the external `Supports*` overload with `self: Index[S2_contra]` greedily captured `Index[bool]` (because `bool <: int` and `Index[bool]`'s `Never`-guarded dunders structurally satisfy `SupportsRSub[bool, Never]`), resolving the invalid `Index[bool] - Index[bool]` to `Index[Never]` instead of an operator error. `-` now follows its sibling `/` (`__truediv__`), which uses only the internal self-bound `Supports_ProtoTrueDiv` + explicit `Never` guards with no external `_typeshed.Supports*` overload. This restores `Index[bool] - Index[bool]` to a genuine operator error and drops the `np_ndarray_bool` guard extension. Static typing only; no runtime API change.

<details><summary>Accountability Index</summary>

## Commits

| Commit | What | Why |
| --- | --- | --- |
| cmp0xff/pandas-stubs@ec114bec | align Index subtraction overloads | split Index subtraction out of #1474; explicit `Never` overloads fix an upstream mypy Protocol-`self` false-accept (python/mypy#20061) |
| cmp0xff/pandas-stubs@bc985f07 | bring `Index.__sub__`/`__rsub__` to SupportsSub/SupportsRSub parity | fold the parity change into this branch per plan; recorded in ADR-0023 |
| cmp0xff/pandas-stubs@a976e506 | drop external `Supports*` parity for `Index.__sub__`/`__rsub__` — follow `/` | the external `Supports*` overload greedily captures `Index[bool]` → `Index[bool] - Index[bool]` resolved to `Index[Never]` instead of an operator error; `-` follows `/` (internal `Supports_ProtoSub` + `Never` guards) |

## Review decisions

- none yet

## Verification (real poetry harness, no ad-hoc `--pythonpath`)

- `poetry run poe mypy` (tests + local stubs): Success, 355 source files
- `poetry run poe pyright`: 0 errors, 0 warnings
- `poetry run poe pyrefly`: 0 diagnostics
- `poetry run poe ty`: all checks passed
- `poetry run poe pytest`: 3391 passed / 6 skipped
- `poetry run poe type_completeness`: 100.00% (1,408/1,408)

Focused (CI-style invocation) on `tests/indexes`: `mypy --no-incremental --strict` Success; `pyright --warnings` 0 errors; `pyrefly check` 0 diagnostics.

## Caveats

- Static typing only; pandas runtime behavior and public runtime APIs are unchanged.
- Works around a live upstream mypy bug (python/mypy#20061) where a Protocol-typed `self` overload is incorrectly matched for `Index[bool]`; `tests/indexes/bool/test_truediv.py` has the same underlying issue for `__truediv__` but is untouched here (out of scope).
- Durable record of the Protocol-`self` trap and deferred `__truediv__`/`__floordiv__`/`str` follow-ups: ADR-0023 (`docs/architecture/decisions/adr-0023-protocol-self-overloads-need-never-exclusions.md`, pandas-dev/pandas-stubs#1926). The `Supports*` parity decision and its bool interaction are recorded in ADR-0023 (`docs/architecture/decisions/adr-0023-index-sub-supports-sub-parity.md`).
- A separate local branch `align-sub-family` holds a byte-identical copy of this Index subtraction work (verified by blob hash for `core/indexes/base.pyi`, `core/indexes/datetimes.pyi`, and `core/indexes/timedeltas.pyi`) plus additional `Series` subtraction changes in `series.pyi`; once this merges it reduces to its Series-only half and should be rebased onto the new `main` before submission.

</details>
