### PR TITLE
TST: nightly expect `Pandas4Warning` for `Series.drop`/`rename` `inplace` and `GroupBy.nth` indexing

### DIFF
--- a/tests/frame/test_groupby.py
+++ b/tests/frame/test_groupby.py
@@ -21,9 +21,12 @@ from pandas.core.groupby.generic import (
     NamedAgg,
 )
 
+from pandas.errors import Pandas4Warning
+
 from tests import (
     TYPE_CHECKING_INVALID_USAGE,
     check,
+    pytest_warns_bounded,
 )
 
 if TYPE_CHECKING:
@@ -428,7 +431,13 @@ def test_groupby_series_methods() -> None:
     check(assert_type(gb.nlargest(), pd.Series), pd.Series)
     check(assert_type(gb.nsmallest(), pd.Series), pd.Series)
     check(assert_type(gb.nth(0), pd.DataFrame | pd.Series), pd.Series)
-    check(assert_type(gb.nth[0, 1, 2], pd.DataFrame | pd.Series), pd.Series)
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "GroupBy.nth",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(assert_type(gb.nth[0, 1, 2], pd.DataFrame | pd.Series), pd.Series)
     check(assert_type(gb.nth((0, 1, 2)), pd.DataFrame | pd.Series), pd.Series)
 
     if TYPE_CHECKING_INVALID_USAGE:

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -258,8 +258,20 @@ def test_types_drop() -> None:
     check(assert_type(s.drop(0), "pd.Series[int]"), pd.Series, np.integer)
     check(assert_type(s.drop([0, 1]), "pd.Series[int]"), pd.Series, np.integer)
     check(assert_type(s.drop(0, axis=0), "pd.Series[int]"), pd.Series, np.integer)
-    assert assert_type(s.drop([0, 1], inplace=True, errors="raise"), None) is None
-    assert assert_type(s.drop([0, 1], inplace=True, errors="ignore"), None) is None
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in Series",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        assert assert_type(s.drop([0, 1], inplace=True, errors="raise"), None) is None
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in Series",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        assert assert_type(s.drop([0, 1], inplace=True, errors="ignore"), None) is None
     # GH 302
     s = pd.Series([0, 1, 2])
     check(
@@ -1607,26 +1619,54 @@ def test_types_rename() -> None:
     s5 = pd.Series([1, 2, 3]).rename({1: 10})
     check(assert_type(s5, "pd.Series[int]"), pd.Series, np.integer)
     # inplace
-    check(
-        assert_type(pd.Series([1, 2, 3]).rename("A", inplace=True), "pd.Series[int]"),
-        pd.Series,
-        np.integer,
-    )
-    check(
-        assert_type(pd.Series([1, 2, 3]).rename({1: 4, 2: 5}, inplace=True), None),
-        type(None),
-    )
-    check(
-        assert_type(
-            pd.Series([1, 2, 3]).rename(index=None, inplace=True), "pd.Series[int]"
-        ),
-        pd.Series,
-        np.integer,
-    )
-    check(
-        assert_type(pd.Series([1, 2, 3]).rename(lambda x: x**2, inplace=True), None),
-        type(None),
-    )
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in Series",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(
+                pd.Series([1, 2, 3]).rename("A", inplace=True), "pd.Series[int]"
+            ),
+            pd.Series,
+            np.integer,
+        )
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in Series",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(pd.Series([1, 2, 3]).rename({1: 4, 2: 5}, inplace=True), None),
+            type(None),
+        )
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in Series",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(
+                pd.Series([1, 2, 3]).rename(index=None, inplace=True), "pd.Series[int]"
+            ),
+            pd.Series,
+            np.integer,
+        )
+    with pytest_warns_bounded(
+        Pandas4Warning,
+        "The inplace keyword in Series",
+        lower="3.0.99",
+        upper="3.99",
+    ):
+        check(
+            assert_type(
+                pd.Series([1, 2, 3]).rename(lambda x: x**2, inplace=True), None
+            ),
+            type(None),
+        )
 
     if TYPE_CHECKING_INVALID_USAGE:
         _s7 = pd.Series([1, 2, 3]).rename({1: [3, 4, 5]})  # type: ignore[dict-item] # pyright: ignore[reportArgumentType] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
- [x] Propagates pandas-dev/pandas#67962 and pandas-dev/pandas#67716
- [x] Tests added (using `assert_type()` for return values)
- [x] AI-assisted development followed `AGENTS.md`

Nightly pandas (2026-09-03) now emits `Pandas4Warning` for two deprecations:
`Series.drop()`/`Series.rename()` `inplace` (PDEP-8) and `GroupBy.nth[...]` indexing.
`filterwarnings = ["error"]` turns these into failures in the nightly pytest job. This wraps the
affected calls in `pytest_warns_bounded(Pandas4Warning, ..., lower="3.0.99", upper="3.99")` so
released pandas 3.0.x still passes unchanged. Tests-only; no stub changes.

<details><summary>AI Implementation Plan</summary>

### Motivation
Nightly job `Run pytest (against pandas nightly)` failed (run 33905551325, job 101129508806),
3 failed / 3390 passed. Errors: `Pandas4Warning` for `GroupBy.nth[...]` and `Series.drop`/`rename`
`inplace`.

### Root cause
- pandas-dev/pandas#67716 (deprecate `GroupBy.nth[...]`, merged 2026-09-03)
- pandas-dev/pandas#67962 (deprecate `Series.rename()`/`drop()` `inplace`, merged 2026-09-03)
- `filterwarnings = ["error"]` in `pyproject.toml` promotes the warnings to failures.

### Fix
Wrap each affected call in `pytest_warns_bounded(Pandas4Warning, match, lower="3.0.99",
upper="3.99")`. Mirrors pandas-stubs #1922 (sort inplace) and #1927 (query/eval inplace).
`pytest_warns_bounded` (tests/__init__.py) is version-conditional, so pandas 3.0.x is unaffected.

### Validation
- `poe style`
- `poe pytest --nightly`
- `poe test_all`

### Out of scope
Removing the deprecated stub members (`GroupByNthSelector.__getitem__`, `inplace` overloads) is
deferred to the pandas 4.0 removal, as in #1922/#1927.

</details>
